### PR TITLE
Fix dashboard timestamp parsing for Safari

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -395,7 +395,8 @@
 
         function formatTimestamp(ts) {
             if (!ts) return '--';
-            const d = new Date(ts.includes('T') ? ts : ts.replace(' ', 'T') + 'Z');
+            const n = ts.replace(' ', 'T');
+            const d = new Date(n.endsWith('Z') ? n : n + 'Z');
             return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
         }
 


### PR DESCRIPTION
## Summary
- Normalize SQLite `datetime('now')` timestamps to ISO-8601 format in `formatTimestamp()` before passing to `new Date()`
- Safari requires strict ISO-8601 (`YYYY-MM-DDTHH:MM:SSZ`) — SQLite produces `YYYY-MM-DD HH:MM:SS` (space separator, no timezone)
- Fixes all dashboard panels: activity feed, trade log, candidate pipeline, and error panel

Closes #18

## Test plan
- [x] All 215 unit tests pass
- [ ] Verify timestamps render correctly in Safari
- [ ] Verify timestamps still render correctly in Chrome/Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)