### PR TITLE
Fix daily P&L formula to join open/close trades by ticker

### DIFF
--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -222,20 +222,22 @@ async def insert_candidate(
 async def get_daily_pnl(db: Database) -> float:
     """Calculate today's realized P&L from close trades.
 
-    Joins each close trade (today) against the most recent open trade
-    on the same ticker to compute: (close_price - open_price) * count.
+    For each close trade today, finds the most recent open trade on the
+    same ticker that occurred before the close, then computes:
+    (close_price - open_price) * count.
     """
     cursor = await db.conn.execute(
         """SELECT COALESCE(SUM(
-            (c.price - COALESCE(o.price, 0)) * c.count
+            (c.price - COALESCE(
+                (SELECT price FROM trades o
+                 WHERE o.ticker = c.ticker
+                   AND o.action = 'open'
+                   AND o.timestamp <= c.timestamp
+                 ORDER BY o.timestamp DESC
+                 LIMIT 1),
+            0)) * c.count
         ), 0) as daily_pnl
         FROM trades c
-        LEFT JOIN (
-            SELECT ticker, price,
-                   ROW_NUMBER() OVER (PARTITION BY ticker ORDER BY timestamp DESC) AS rn
-            FROM trades
-            WHERE action = 'open'
-        ) o ON o.ticker = c.ticker AND o.rn = 1
         WHERE c.action = 'close'
           AND date(c.timestamp) = date('now')"""
     )

--- a/tests/unit/test_daily_pnl.py
+++ b/tests/unit/test_daily_pnl.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -13,7 +13,7 @@ from gimmes.store.queries import get_daily_pnl, insert_trade
 
 @pytest.fixture
 async def db(tmp_path):
-    """Create an in-memory database for testing."""
+    """Create a temporary database for testing."""
     db_path = tmp_path / "test.db"
     async with Database(db_path) as database:
         yield database
@@ -126,3 +126,30 @@ class TestGetDailyPnl:
         await insert_trade(db, _trade(action="close", price=0.70, count=10))
         pnl = await get_daily_pnl(db)
         assert pnl == pytest.approx(0.0)
+
+    async def test_multi_cycle_same_ticker(self, db: Database) -> None:
+        """Two open/close cycles on the same ticker use correct entries."""
+        now = datetime.now()
+        # Cycle 1: open at 0.50, close at 0.70
+        await insert_trade(db, _trade(
+            action="open", price=0.50, count=5,
+            timestamp=now - timedelta(hours=3),
+        ))
+        await insert_trade(db, _trade(
+            action="close", price=0.70, count=5,
+            timestamp=now - timedelta(hours=2),
+        ))
+        # Cycle 2: re-open at 0.60, close at 0.65
+        await insert_trade(db, _trade(
+            action="open", price=0.60, count=5,
+            timestamp=now - timedelta(hours=1),
+        ))
+        await insert_trade(db, _trade(
+            action="close", price=0.65, count=5,
+            timestamp=now,
+        ))
+        pnl = await get_daily_pnl(db)
+        # Cycle 1: (0.70 - 0.50) * 5 = 1.0
+        # Cycle 2: (0.65 - 0.60) * 5 = 0.25
+        # Total: 1.25
+        assert pnl == pytest.approx(1.25)


### PR DESCRIPTION
## Summary

- Rewrote `get_daily_pnl()` SQL query to join close trades against their most recent open trade by ticker, computing `(close_price - open_price) * count`
- The old formula `(price - edge) * count` was financially meaningless — `edge` is probability spread (model_prob - market_price), not entry price
- This fixes the daily loss circuit breaker which relies on this P&L value for the 15% limit

Closes #25

## Test plan
- [x] 285 unit tests pass (276 existing + 9 new)
- [x] New tests cover: no trades, opens only, winning close, losing close, multiple tickers, orphaned close, edge field ignored, skip trades, break-even
- [x] `test_edge_field_not_used_in_calculation` explicitly verifies the old bug is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)