### PR TITLE
Secure .env file permissions to 0600 after every write

### DIFF
--- a/src/gimmes/init.py
+++ b/src/gimmes/init.py
@@ -29,6 +29,12 @@ KEYS_DIR = GIMMES_HOME / "keys"
 PEM_FILENAME = "kalshi_private.pem"
 
 
+def _secure_env_file() -> None:
+    """Set .env file permissions to 0600 (owner read/write only)."""
+    if ENV_FILE.exists():
+        ENV_FILE.chmod(0o600)
+
+
 def _copy_example_file(example: Path, target: Path, label: str) -> bool:
     """Copy an example file to its target. Returns True if copied."""
     if target.exists():
@@ -39,6 +45,8 @@ def _copy_example_file(example: Path, target: Path, label: str) -> bool:
 
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(example, target)
+    if target == ENV_FILE:
+        _secure_env_file()
     console.print(f"[green]Created {label}:[/green] {target}")
     return True
 
@@ -136,6 +144,7 @@ def _update_env_key_path(pem_path: Path) -> None:
         lines.append(f"KALSHI_PROD_PRIVATE_KEY_PATH={pem_path}")
 
     ENV_FILE.write_text("\n".join(lines) + "\n")
+    _secure_env_file()
     console.print(f"[green]Updated .env:[/green] KALSHI_PROD_PRIVATE_KEY_PATH={pem_path}")
 
 
@@ -175,6 +184,7 @@ def _offer_api_key_paste() -> None:
             lines.append(f"KALSHI_PROD_API_KEY={api_key.strip()}")
 
         ENV_FILE.write_text("\n".join(lines) + "\n")
+        _secure_env_file()
         console.print("[green]Updated .env:[/green] KALSHI_PROD_API_KEY set")
 
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -15,6 +15,7 @@ from gimmes.init import (
     _copy_example_file,
     _find_downloaded_key,
     _install_private_key,
+    _secure_env_file,
     _validate_pem_content,
 )
 
@@ -64,6 +65,31 @@ class TestCopyExampleFile:
 
         assert result is True
         assert target.read_text() == "new content"
+
+
+class TestSecureEnvFile:
+    def test_sets_600_permissions(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("KALSHI_PROD_API_KEY=secret")
+        env_file.chmod(0o644)  # World-readable
+
+        with patch("gimmes.init.ENV_FILE", env_file):
+            _secure_env_file()
+
+        mode = env_file.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_copy_example_secures_env_file(self, tmp_path: Path) -> None:
+        example = tmp_path / ".env.example"
+        example.write_text("KALSHI_PROD_API_KEY=placeholder")
+        example.chmod(0o644)
+        target = tmp_path / ".env"
+
+        with patch("gimmes.init.ENV_FILE", target):
+            _copy_example_file(example, target, ".env")
+
+        mode = target.stat().st_mode & 0o777
+        assert mode == 0o600
 
 
 class TestFindDownloadedKey:


### PR DESCRIPTION
## Summary

- Added `_secure_env_file()` helper that sets `.env` permissions to `0600` (owner read/write only)
- Called after every `.env` write: initial copy from `.env.example`, key path update, and API key paste
- Previously, `.env` inherited world-readable `0644` permissions from `.env.example` via `shutil.copy2`
- Locked down existing project-root `.env` to `0600`
- Deferred: password-protected PEM keys (#59), cancel command confirmation (#60)

Closes #27

## Test plan
- [x] 291 unit tests pass (289 existing + 2 new)
- [x] `test_sets_600_permissions` — verifies `_secure_env_file()` sets 0600
- [x] `test_copy_example_secures_env_file` — verifies copy + chmod end-to-end
- [x] Verified project-root `.env` is now `0600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)