### PR TITLE
Add busy_timeout and transaction grouping for SQLite writes

### DIFF
--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -114,7 +114,11 @@ class PaperBroker:
     # ------------------------------------------------------------------
 
     async def create_order(self, params: CreateOrderParams, orderbook: Orderbook) -> Order:
-        """Simulate placing an order. Fills immediately if marketable."""
+        """Simulate placing an order. Fills immediately if marketable.
+
+        All balance, order, fill, and position writes are wrapped in a single
+        transaction so a crash can never leave partial state.
+        """
         order_id = f"paper-{uuid.uuid4().hex[:12]}"
         now = datetime.datetime.now(datetime.UTC)
 
@@ -142,29 +146,23 @@ class PaperBroker:
         else:
             status = "canceled"  # Taker found nothing
 
-        # Balance delta for filled portion
-        if result.total_filled > 0:
-            if params.action == OrderAction.BUY:
-                cost = result.total_notional + result.total_fees
-                resting_cost = 0.0
-                if result.remaining_count > 0 and params.post_only:
-                    resting_cost = result.remaining_count * (
-                        params.price_cents / 100.0
-                    )
-                balance = await self.get_balance()
-                if balance < cost + resting_cost:
-                    return await self._reject_order(order_id, params, now)
-                await self._update_balance(-cost)
-            else:  # SELL — credit proceeds minus fees
-                await self._update_balance(
-                    result.total_notional - result.total_fees
+        # Pre-transaction balance validation
+        if result.total_filled > 0 and params.action == OrderAction.BUY:
+            cost = result.total_notional + result.total_fees
+            resting_cost = 0.0
+            if result.remaining_count > 0 and params.post_only:
+                resting_cost = result.remaining_count * (
+                    params.price_cents / 100.0
                 )
+            balance = await self.get_balance()
+            if balance < cost + resting_cost:
+                return await self._reject_order(order_id, params, now)
         elif (
             params.action == OrderAction.BUY
             and result.remaining_count > 0
             and params.post_only
+            and result.total_filled == 0
         ):
-            # No fills but resting — check balance for reservation
             resting_cost = result.remaining_count * (
                 params.price_cents / 100.0
             )
@@ -172,67 +170,77 @@ class PaperBroker:
             if balance < resting_cost:
                 return await self._reject_order(order_id, params, now)
 
-        # Reserve balance only for resting BUY maker orders
-        if (
-            result.remaining_count > 0
-            and params.post_only
-            and params.action == OrderAction.BUY
-        ):
-            resting_price = params.price_cents / 100.0
-            await self._update_balance(
-                -(result.remaining_count * resting_price)
-            )
+        # All writes in one atomic transaction
+        async with self._db.transaction():
+            # Balance delta for filled portion
+            if result.total_filled > 0:
+                if params.action == OrderAction.BUY:
+                    cost = result.total_notional + result.total_fees
+                    await self._update_balance(-cost)
+                else:  # SELL — credit proceeds minus fees
+                    await self._update_balance(
+                        result.total_notional - result.total_fees
+                    )
 
-        # Insert order record
-        await self._conn.execute(
-            """INSERT INTO paper_orders
-               (order_id, ticker, action, side, count, remaining_count,
-                yes_price, no_price, status, post_only, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                order_id,
-                params.ticker,
-                params.action.value,
-                params.side.value,
-                params.count,
-                result.remaining_count,
-                params.yes_price or 0,
-                params.no_price or 0,
-                status,
-                1 if params.post_only else 0,
-                now.isoformat(),
-                now.isoformat(),
-            ),
-        )
+            # Reserve balance only for resting BUY maker orders
+            if (
+                result.remaining_count > 0
+                and params.post_only
+                and params.action == OrderAction.BUY
+            ):
+                resting_price = params.price_cents / 100.0
+                await self._update_balance(
+                    -(result.remaining_count * resting_price)
+                )
 
-        # Insert fills and update positions
-        for fill in result.fills:
-            trade_id = f"paper-fill-{uuid.uuid4().hex[:12]}"
+            # Insert order record
             await self._conn.execute(
-                """INSERT INTO paper_fills
-                   (trade_id, order_id, ticker, action, side, count,
-                    yes_price, no_price, fee, is_taker, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT INTO paper_orders
+                   (order_id, ticker, action, side, count, remaining_count,
+                    yes_price, no_price, status, post_only, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
-                    trade_id,
                     order_id,
                     params.ticker,
                     params.action.value,
                     params.side.value,
-                    fill.count,
-                    fill.price_cents if params.side == OrderSide.YES else 0,
-                    fill.price_cents if params.side == OrderSide.NO else 0,
-                    fill.fee,
-                    1 if fill.is_taker else 0,
+                    params.count,
+                    result.remaining_count,
+                    params.yes_price or 0,
+                    params.no_price or 0,
+                    status,
+                    1 if params.post_only else 0,
+                    now.isoformat(),
                     now.isoformat(),
                 ),
             )
 
-        # Update position if any fills occurred
-        if result.total_filled > 0:
-            await self._update_position_from_fills(params, result)
+            # Insert fills and update positions
+            for fill in result.fills:
+                trade_id = f"paper-fill-{uuid.uuid4().hex[:12]}"
+                await self._conn.execute(
+                    """INSERT INTO paper_fills
+                       (trade_id, order_id, ticker, action, side, count,
+                        yes_price, no_price, fee, is_taker, created_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        trade_id,
+                        order_id,
+                        params.ticker,
+                        params.action.value,
+                        params.side.value,
+                        fill.count,
+                        fill.price_cents if params.side == OrderSide.YES else 0,
+                        fill.price_cents if params.side == OrderSide.NO else 0,
+                        fill.fee,
+                        1 if fill.is_taker else 0,
+                        now.isoformat(),
+                    ),
+                )
 
-        await self._conn.commit()
+            # Update position if any fills occurred
+            if result.total_filled > 0:
+                await self._update_position_from_fills(params, result)
 
         return Order(
             order_id=order_id,
@@ -257,18 +265,18 @@ class PaperBroker:
         if row is None:
             return
 
-        # Refund reserved balance for unfilled contracts
-        remaining = int(row["remaining_count"])
-        price_cents = max(int(row["yes_price"]), int(row["no_price"]))
-        refund = remaining * (price_cents / 100.0)
-        await self._update_balance(refund)
+        async with self._db.transaction():
+            # Refund reserved balance for unfilled contracts
+            remaining = int(row["remaining_count"])
+            price_cents = max(int(row["yes_price"]), int(row["no_price"]))
+            refund = remaining * (price_cents / 100.0)
+            await self._update_balance(refund)
 
-        await self._conn.execute(
-            "UPDATE paper_orders SET status = 'canceled',"
-            " updated_at = datetime('now') WHERE order_id = ?",
-            (order_id,),
-        )
-        await self._conn.commit()
+            await self._conn.execute(
+                "UPDATE paper_orders SET status = 'canceled',"
+                " updated_at = datetime('now') WHERE order_id = ?",
+                (order_id,),
+            )
 
     async def list_orders(
         self,
@@ -362,24 +370,24 @@ class PaperBroker:
         if not rows:
             return
 
-        for row in rows:
-            count = int(row["count"])
-            avg_price = float(row["avg_price"])
-            side = row["side"]
+        async with self._db.transaction():
+            for row in rows:
+                count = int(row["count"])
+                avg_price = float(row["avg_price"])
+                side = row["side"]
 
-            if side == "yes":
-                unrealized = (current_price - avg_price) * count
-            else:
-                unrealized = (avg_price - current_price) * count
+                if side == "yes":
+                    unrealized = (current_price - avg_price) * count
+                else:
+                    unrealized = (avg_price - current_price) * count
 
-            await self._conn.execute(
-                """UPDATE paper_positions
-                   SET market_price = ?, unrealized_pnl = ?,
-                       updated_at = datetime('now')
-                   WHERE ticker = ? AND side = ?""",
-                (current_price, unrealized, ticker, side),
-            )
-        await self._conn.commit()
+                await self._conn.execute(
+                    """UPDATE paper_positions
+                       SET market_price = ?, unrealized_pnl = ?,
+                           updated_at = datetime('now')
+                       WHERE ticker = ? AND side = ?""",
+                    (current_price, unrealized, ticker, side),
+                )
 
     async def settle(self, ticker: str, result: str) -> None:
         """Settle a resolved market. result is 'yes' or 'no'.
@@ -397,25 +405,25 @@ class PaperBroker:
         if not rows:
             return
 
-        for row in rows:
-            count = int(row["count"])
-            side = row["side"]
-            cost_basis = float(row["cost_basis"])
+        async with self._db.transaction():
+            for row in rows:
+                count = int(row["count"])
+                side = row["side"]
+                cost_basis = float(row["cost_basis"])
 
-            won = (side == result)
-            payout = count * 1.0 if won else 0.0
-            realized_pnl = payout - cost_basis + float(row["realized_pnl"])
+                won = (side == result)
+                payout = count * 1.0 if won else 0.0
+                realized_pnl = payout - cost_basis + float(row["realized_pnl"])
 
-            await self._update_balance(payout)
+                await self._update_balance(payout)
 
-            await self._conn.execute(
-                """UPDATE paper_positions
-                   SET count = 0, market_price = ?, unrealized_pnl = 0,
-                       realized_pnl = ?, updated_at = datetime('now')
-                   WHERE ticker = ? AND side = ?""",
-                (1.0 if won else 0.0, realized_pnl, ticker, side),
-            )
-        await self._conn.commit()
+                await self._conn.execute(
+                    """UPDATE paper_positions
+                       SET count = 0, market_price = ?, unrealized_pnl = 0,
+                           realized_pnl = ?, updated_at = datetime('now')
+                       WHERE ticker = ? AND side = ?""",
+                    (1.0 if won else 0.0, realized_pnl, ticker, side),
+                )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/gimmes/store/database.py
+++ b/src/gimmes/store/database.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import aiosqlite
@@ -85,6 +87,7 @@ class Database:
         try:
             self._conn.row_factory = aiosqlite.Row
             await self._conn.execute("PRAGMA journal_mode=WAL")
+            await self._conn.execute("PRAGMA busy_timeout=5000")
             await self._conn.executescript(SCHEMA_SQL)
             await self._conn.commit()
             # Run any pending migrations
@@ -105,6 +108,25 @@ class Database:
         if self._conn is None:
             raise RuntimeError("Database not connected. Call connect() first.")
         return self._conn
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator[None]:
+        """Explicit transaction with automatic COMMIT/ROLLBACK.
+
+        Usage:
+            async with db.transaction():
+                await db.conn.execute("INSERT ...")
+                await db.conn.execute("UPDATE ...")
+            # COMMIT happens here on success, ROLLBACK on exception
+        """
+        conn = self.conn
+        await conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield
+            await conn.commit()
+        except BaseException:
+            await conn.rollback()
+            raise
 
     async def __aenter__(self) -> Database:
         await self.connect()


### PR DESCRIPTION
## Summary
- Add `PRAGMA busy_timeout=5000` to prevent `SQLITE_BUSY` errors on concurrent access
- Add `Database.transaction()` context manager with `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`
- Wrap paper broker multi-step writes (`create_order`, `cancel_order`, `mark_to_market`, `settle`) in explicit transactions

Closes #33

## Test plan
- [x] All 325 unit tests pass
- [x] Ruff lint clean
- [x] Code review agent passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)