### PR TITLE
Fix TOML config parsing and _apply_toml_change rewrite

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1114,6 +1114,11 @@ def _apply_toml_change(
     for part in parts[:-1]:
         if part not in current:
             current[part] = tomlkit.table()
+        elif not isinstance(current[part], dict):
+            raise ValueError(
+                f"Cannot set '{parameter_path}': "
+                f"'{part}' is a scalar, not a table"
+            )
         current = current[part]
     current[parts[-1]] = typed_value
 
@@ -1123,6 +1128,9 @@ def _apply_toml_change(
         tomllib.loads(new_text)
     except tomllib.TOMLDecodeError as e:
         raise ValueError(f"Generated invalid TOML: {e}") from e
+
+    # Ensure parent directory exists
+    path.parent.mkdir(parents=True, exist_ok=True)
 
     # Backup original if it exists
     if path.exists():

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -131,8 +131,8 @@ def load_config(config_path: Path | None = None) -> GimmesConfig:
             with open(toml_path, "rb") as f:
                 toml_data = tomllib.load(f)
         except tomllib.TOMLDecodeError as e:
-            raise SystemExit(
-                f"Error: Failed to parse {toml_path}: {e}\n"
+            raise ValueError(
+                f"Failed to parse {toml_path}: {e}. "
                 "Fix or delete the TOML file to continue."
             ) from e
 

--- a/tests/unit/test_toml_config.py
+++ b/tests/unit/test_toml_config.py
@@ -1,0 +1,144 @@
+"""Tests for TOML config parsing and _apply_toml_change."""
+
+from __future__ import annotations
+
+import pytest
+
+from gimmes.cli import _apply_toml_change
+from gimmes.config import load_config
+
+
+class TestLoadConfigMalformedToml:
+    def test_raises_on_malformed_toml(self, tmp_path):
+        """load_config should raise ValueError on invalid TOML."""
+        bad_toml = tmp_path / "gimmes.toml"
+        bad_toml.write_text("[broken\nkey = !!!")
+
+        with pytest.raises(ValueError, match="Failed to parse"):
+            load_config(config_path=bad_toml)
+
+    def test_loads_valid_toml(self, tmp_path):
+        """load_config should work with valid TOML."""
+        good_toml = tmp_path / "gimmes.toml"
+        good_toml.write_text("[strategy]\nmin_edge_after_fees = 0.08\n")
+
+        config = load_config(config_path=good_toml)
+        assert config.strategy.min_edge_after_fees == 0.08
+
+    def test_loads_defaults_when_no_file(self, tmp_path):
+        """load_config should use defaults when file doesn't exist."""
+        config = load_config(config_path=tmp_path / "nonexistent.toml")
+        assert config.strategy is not None
+
+
+class TestApplyTomlChange:
+    def test_simple_key(self, tmp_path):
+        """Should update a simple section.key path."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("[strategy]\nmin_edge_after_fees = 0.05\n")
+
+        _apply_toml_change(toml, "strategy.min_edge_after_fees", "0.08")
+
+        import tomllib
+        with open(toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["strategy"]["min_edge_after_fees"] == 0.08
+
+    def test_nested_key(self, tmp_path):
+        """Should handle 3-level nested paths like scoring.weights.edge_size."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text(
+            "[scoring.weights]\nedge_size = 25\n"
+        )
+
+        _apply_toml_change(toml, "scoring.weights.edge_size", "30")
+
+        import tomllib
+        with open(toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["scoring"]["weights"]["edge_size"] == 30
+
+    def test_creates_missing_section(self, tmp_path):
+        """Should create missing sections when path doesn't exist."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("")
+
+        _apply_toml_change(toml, "new_section.new_key", "42")
+
+        import tomllib
+        with open(toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["new_section"]["new_key"] == 42
+
+    def test_creates_file_when_missing(self, tmp_path):
+        """Should create the file if it doesn't exist."""
+        toml = tmp_path / "gimmes.toml"
+
+        _apply_toml_change(toml, "strategy.threshold", "85")
+
+        assert toml.exists()
+        import tomllib
+        with open(toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["strategy"]["threshold"] == 85
+
+    def test_creates_backup(self, tmp_path):
+        """Should create a .bak backup before writing."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("[strategy]\nthreshold = 75\n")
+
+        _apply_toml_change(toml, "strategy.threshold", "85")
+
+        backup = tmp_path / "gimmes.toml.bak"
+        assert backup.exists()
+        assert "threshold = 75" in backup.read_text()
+
+    def test_preserves_comments(self, tmp_path):
+        """Should preserve TOML comments."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("# Important config\n[strategy]\nthreshold = 75\n")
+
+        _apply_toml_change(toml, "strategy.threshold", "85")
+
+        content = toml.read_text()
+        assert "# Important config" in content
+
+    def test_boolean_value(self, tmp_path):
+        """Should handle boolean values."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("[orders]\npost_only = false\n")
+
+        _apply_toml_change(toml, "orders.post_only", "true")
+
+        import tomllib
+        with open(toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["orders"]["post_only"] is True
+
+    def test_string_value(self, tmp_path):
+        """Should handle non-numeric string values."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("[strategy]\nmode = \"conservative\"\n")
+
+        _apply_toml_change(toml, "strategy.mode", "aggressive")
+
+        import tomllib
+        with open(toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["strategy"]["mode"] == "aggressive"
+
+    def test_raises_on_scalar_intermediate(self, tmp_path):
+        """Should raise ValueError if intermediate path is a scalar."""
+        toml = tmp_path / "gimmes.toml"
+        toml.write_text("scoring = 42\n")
+
+        with pytest.raises(ValueError, match="is a scalar, not a table"):
+            _apply_toml_change(toml, "scoring.weights.edge", "30")
+
+    def test_creates_parent_dir(self, tmp_path):
+        """Should create parent directories if they don't exist."""
+        toml = tmp_path / "subdir" / "gimmes.toml"
+
+        _apply_toml_change(toml, "strategy.threshold", "85")
+
+        assert toml.exists()


### PR DESCRIPTION
## Summary
- Exit with clear error message on malformed TOML instead of unreadable traceback
- Rewrite `_apply_toml_change` to use `tomlkit` instead of fragile regex: supports arbitrary nesting, preserves formatting, validates output, atomic write with backup
- Fix Python 3.11 compat for backup file naming

Closes #34

## Test plan
- [x] All 325 unit tests pass
- [x] Code review agent passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)