### PR TITLE
Fix hardcoded gimme threshold and validate scoring weights

### DIFF
--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from pathlib import Path
 
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 GIMMES_HOME = Path(os.getenv("GIMMES_HOME", str(Path.home() / ".gimmes"))).expanduser()
 
@@ -70,6 +70,18 @@ class ScoringWeights(BaseModel):
     liquidity_depth: float = 0.15
     settlement_clarity: float = 0.15
     time_to_resolution: float = 0.15
+
+    @model_validator(mode="after")
+    def _check_weights_sum(self) -> ScoringWeights:
+        total = (
+            self.edge_size + self.signal_strength + self.liquidity_depth
+            + self.settlement_clarity + self.time_to_resolution
+        )
+        if abs(total - 1.0) > 0.01:
+            raise ValueError(
+                f"Scoring weights must sum to 1.0 (got {total:.4f})"
+            )
+        return self
 
 
 class ScoringConfig(BaseModel):

--- a/src/gimmes/models/gimme.py
+++ b/src/gimmes/models/gimme.py
@@ -27,10 +27,9 @@ class GimmeScore(BaseModel):
     time_to_resolution_score: float = 0.0
     memo: str = ""
 
-    @property
-    def qualifies(self) -> bool:
-        """Check if this score meets the default threshold."""
-        return self.total >= 75
+    def qualifies(self, threshold: float = 75) -> bool:
+        """Check if this score meets the given threshold."""
+        return self.total >= threshold
 
 
 class GimmeCandidate(BaseModel):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -43,13 +43,18 @@ class TestOrderbook:
 
 
 class TestGimmeScore:
-    def test_qualifies(self) -> None:
+    def test_qualifies_default_threshold(self) -> None:
         score = GimmeScore(total=80)
-        assert score.qualifies is True
+        assert score.qualifies() is True
 
-    def test_does_not_qualify(self) -> None:
+    def test_does_not_qualify_default_threshold(self) -> None:
         score = GimmeScore(total=50)
-        assert score.qualifies is False
+        assert score.qualifies() is False
+
+    def test_qualifies_custom_threshold(self) -> None:
+        score = GimmeScore(total=80)
+        assert score.qualifies(threshold=85) is False
+        assert score.qualifies(threshold=75) is True
 
 
 class TestOrder:


### PR DESCRIPTION
## Summary
- `GimmeScore.qualifies` now accepts a threshold parameter instead of hardcoding 75
- `ScoringWeights` validates that weights sum to 1.0 (tolerance 0.01)

Closes #37

## Test plan
- [x] 344 unit tests pass
- [x] Code review agent passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)