### PR TITLE
Use full Kalshi API strings for time_in_force

### DIFF
--- a/src/gimmes/kalshi/orders.py
+++ b/src/gimmes/kalshi/orders.py
@@ -65,7 +65,7 @@ async def create_order(client: KalshiClient, params: CreateOrderParams) -> Order
         body["client_order_id"] = params.client_order_id
     else:
         body["client_order_id"] = str(uuid.uuid4())
-    if params.time_in_force != "gtc":
+    if params.time_in_force != "good_till_canceled":
         body["time_in_force"] = params.time_in_force
     if params.post_only:
         body["post_only"] = True

--- a/src/gimmes/models/order.py
+++ b/src/gimmes/models/order.py
@@ -32,7 +32,7 @@ class CreateOrderParams(BaseModel):
     yes_price: float | None = Field(default=None, ge=0.0, le=1.0)
     no_price: float | None = Field(default=None, ge=0.0, le=1.0)
     client_order_id: str = ""
-    time_in_force: str = "gtc"  # gtc, fok, ioc
+    time_in_force: str = "good_till_canceled"
     post_only: bool = True  # Maker guarantee
 
     @property


### PR DESCRIPTION
## Summary
- Change `time_in_force` default from `"gtc"` to `"good_till_canceled"` to match Kalshi API
- Update guard check in `orders.py` to match

Closes #38

## Test plan
- [x] 344 unit tests pass
- [x] Code review agent passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)