### PR TITLE
Add database indexes and Pydantic validation constraints

### DIFF
--- a/src/gimmes/models/gimme.py
+++ b/src/gimmes/models/gimme.py
@@ -37,8 +37,8 @@ class GimmeCandidate(BaseModel):
 
     ticker: str
     title: str = ""
-    market_price: float  # Current YES price
-    model_probability: float = 0.0  # Our estimated true probability
+    market_price: float = Field(ge=0.0, le=1.0)
+    model_probability: float = Field(default=0.0, ge=0.0, le=1.0)
     edge: float = 0.0  # model_probability - market_price
     signals: list[ConfidenceSignal] = Field(default_factory=list)
     score: GimmeScore | None = None

--- a/src/gimmes/models/portfolio.py
+++ b/src/gimmes/models/portfolio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -12,7 +13,7 @@ class Position(BaseModel):
 
     ticker: str
     title: str = ""
-    side: str = "yes"  # yes or no
+    side: Literal["yes", "no"] = "yes"
     count: int = 0
     avg_price: float = 0.0  # Average entry price in dollars
     market_price: float = 0.0  # Current market price

--- a/src/gimmes/models/trade.py
+++ b/src/gimmes/models/trade.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -19,11 +20,11 @@ class TradeDecision(BaseModel):
 
     ticker: str
     action: Action
-    side: str = "yes"
-    count: int = 0
-    price: float = 0.0
-    model_probability: float = 0.0
-    gimme_score: float = 0.0
+    side: Literal["yes", "no"] = "yes"
+    count: int = Field(default=0, ge=0)
+    price: float = Field(default=0.0, ge=0.0, le=1.0)
+    model_probability: float = Field(default=0.0, ge=0.0, le=1.0)
+    gimme_score: float = Field(default=0.0, ge=0.0, le=100.0)
     edge: float = 0.0
     kelly_fraction: float = 0.0
     rationale: str = ""

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -63,6 +63,7 @@ MIGRATIONS: list[tuple[int, str]] = [
         CREATE INDEX IF NOT EXISTS idx_rec_parameter ON recommendations(parameter_path);
     """),
     # Version 5 uses _run_alter_columns below (ALTER TABLE is not idempotent).
+    # Versions > 5 must go after the v5 block in run_migrations().
 ]
 
 # ALTER TABLE ADD COLUMN statements for v5. Each is run individually so that
@@ -124,5 +125,20 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 5
+
+    # Version 6: indexes on high-query tables
+    if current < 6:
+        await db.conn.executescript("""
+            CREATE INDEX IF NOT EXISTS idx_trades_ticker ON trades(ticker);
+            CREATE INDEX IF NOT EXISTS idx_trades_timestamp ON trades(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_trades_action ON trades(action);
+            CREATE INDEX IF NOT EXISTS idx_snapshots_timestamp ON snapshots(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_candidates_scanned ON candidates(scanned_at);
+        """)
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (6,)
+        )
+        await db.conn.commit()
+        current = 6
 
     return current


### PR DESCRIPTION
## Summary
- Add v6 migration with indexes on trades, snapshots, candidates tables
- Add Pydantic `Literal["yes","no"]` for side fields and `Field` constraints for prices/probabilities/scores
- Fix v6 migration placement to not skip v5 ALTER TABLE statements

Closes #41

## Test plan
- [x] 345 unit tests pass
- [x] Code review agent passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)