### PR TITLE
Fix P&L: estimate fees, standardize win rate, remove TradeOutcome

### DIFF
--- a/src/gimmes/models/__init__.py
+++ b/src/gimmes/models/__init__.py
@@ -4,7 +4,7 @@ from gimmes.models.gimme import ConfidenceSignal, GimmeCandidate, GimmeScore
 from gimmes.models.market import Market, MarketStatus, Orderbook, OrderbookLevel
 from gimmes.models.order import CreateOrderParams, Fill, Order, OrderAction, OrderSide
 from gimmes.models.portfolio import PortfolioSnapshot, Position
-from gimmes.models.trade import TradeDecision, TradeOutcome
+from gimmes.models.trade import TradeDecision
 
 __all__ = [
     "ConfidenceSignal",
@@ -22,5 +22,4 @@ __all__ = [
     "PortfolioSnapshot",
     "Position",
     "TradeDecision",
-    "TradeOutcome",
 ]

--- a/src/gimmes/models/trade.py
+++ b/src/gimmes/models/trade.py
@@ -31,26 +31,3 @@ class TradeDecision(BaseModel):
     agent: str = ""  # Which agent made the decision
     timestamp: datetime = Field(default_factory=datetime.now)
     order_id: str = ""
-
-
-class TradeOutcome(BaseModel):
-    """Final outcome of a completed trade."""
-
-    class Result(StrEnum):
-        WIN = "win"
-        LOSS = "loss"
-        SCRATCH = "scratch"  # Broke even or canceled
-
-    ticker: str
-    result: Result
-    entry_price: float = 0.0
-    exit_price: float = 0.0
-    contracts: int = 0
-    gross_pnl: float = 0.0
-    fees_paid: float = 0.0
-    net_pnl: float = 0.0
-    predicted_edge: float = 0.0
-    realized_edge: float = 0.0
-    hold_duration_hours: float = 0.0
-    opened_at: datetime | None = None
-    closed_at: datetime | None = None

--- a/src/gimmes/reporting/metrics.py
+++ b/src/gimmes/reporting/metrics.py
@@ -75,9 +75,25 @@ def calculate_metrics(
     """Calculate performance metrics from trades and snapshots."""
     metrics = PerformanceMetrics()
 
-    # Win rate
-    wins = sum(1 for t in trades if t.get("action") == "close" and t.get("edge", 0) > 0)
-    losses = sum(1 for t in trades if t.get("action") == "close" and t.get("edge", 0) < 0)
+    # Win rate — based on realized P&L (matching pnl.py definition)
+    # Group opens by ticker for P&L calculation
+    open_prices: dict[str, float] = {}
+    for t in trades:
+        if t.get("action") == "open":
+            open_prices.setdefault(t.get("ticker", ""), t.get("price", 0.0))
+
+    wins = 0
+    losses = 0
+    for t in trades:
+        if t.get("action") != "close":
+            continue
+        close_price = t.get("price", 0.0)
+        open_price = open_prices.get(t.get("ticker", ""), 0.0)
+        pnl = (close_price - open_price) * t.get("count", 0)
+        if pnl > 0:
+            wins += 1
+        elif pnl < 0:
+            losses += 1
     total = wins + losses
     metrics.win_rate = wins / total if total > 0 else 0.0
 

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from gimmes.strategy.fees import fee_for_order
+
 
 @dataclass
 class PnLSummary:
@@ -56,6 +58,10 @@ def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]
             count = close.get("count", 0)
 
             pnl = (close_price - open_price) * count
+            # Estimate fees for both legs (open + close)
+            open_fee = fee_for_order(count, open_price) if open_price > 0 else 0.0
+            close_fee = fee_for_order(count, close_price) if close_price > 0 else 0.0
+            summary.total_fees += open_fee + close_fee
             summary.total_trades += 1
             summary.gross_pnl += pnl
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,7 +4,7 @@ from gimmes.models.gimme import GimmeScore
 from gimmes.models.market import Market, MarketStatus, Orderbook
 from gimmes.models.order import CreateOrderParams, Order, OrderAction, OrderSide
 from gimmes.models.portfolio import Position
-from gimmes.models.trade import TradeDecision, TradeOutcome
+from gimmes.models.trade import TradeDecision
 
 
 class TestMarket:
@@ -96,11 +96,3 @@ class TestTradeDecision:
     def test_skip(self) -> None:
         td = TradeDecision(ticker="X", action=TradeDecision.Action.SKIP, rationale="No edge")
         assert td.rationale == "No edge"
-
-
-class TestTradeOutcome:
-    def test_win(self) -> None:
-        to = TradeOutcome(ticker="X", result=TradeOutcome.Result.WIN,
-                          entry_price=0.70, exit_price=1.0, contracts=10,
-                          gross_pnl=3.0, net_pnl=2.90)
-        assert to.result == TradeOutcome.Result.WIN


### PR DESCRIPTION
## Summary
- Estimate fees in `calculate_pnl` using `fee_for_order` for both legs
- Standardize `metrics.py` win rate to P&L-based definition matching `pnl.py`
- Remove unused `TradeOutcome` model (never persisted or used in production)

Closes #44

## Test plan
- [x] 344 unit tests pass
- [x] Code review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)