### PR TITLE
Add TradeRecord TypedDict for type-safe trade queries

### DIFF
--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -29,7 +29,7 @@ class PnLSummary:
         return self.winning_trades / completed
 
 
-def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]
+def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  # accepts TradeRecord dicts
     """Calculate P&L from a list of trade records.
 
     Args:

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -2,11 +2,33 @@
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 from gimmes.models.error import ErrorLogEntry
 from gimmes.models.portfolio import PortfolioSnapshot, Position
 from gimmes.models.recommendation import Recommendation
 from gimmes.models.trade import TradeDecision
 from gimmes.store.database import Database
+
+
+class TradeRecord(TypedDict, total=False):
+    """Typed dict for trade records from the database."""
+
+    id: int
+    ticker: str
+    action: str
+    side: str
+    count: int
+    price: float
+    model_probability: float
+    gimme_score: float
+    edge: float
+    kelly_fraction: float
+    rationale: str
+    agent: str
+    order_id: str
+    timestamp: str
+    resolved_outcome: str | None
 
 # ---------------------------------------------------------------------------
 # Trade decisions
@@ -46,7 +68,7 @@ async def get_trades(
     ticker: str | None = None,
     action: str | None = None,
     limit: int = 50,
-) -> list[dict]:  # type: ignore[type-arg]
+) -> list[TradeRecord]:
     """Query trade decisions with optional filters."""
     query = "SELECT * FROM trades WHERE 1=1"
     params: list[object] = []


### PR DESCRIPTION
## Summary
- Add `TradeRecord` TypedDict to `queries.py` matching the trades table schema
- Update `get_trades` return type from `list[dict]` to `list[TradeRecord]`

Closes #47

## Test plan
- [x] 367 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)