### PR TITLE
Add confirmation guard to cancel command in championship mode

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -490,9 +490,19 @@ def order(
 @app.command()
 def cancel(
     order_id: str = typer.Argument(..., help="Order ID to cancel"),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip confirmation",
+    ),
 ) -> None:
     """Cancel a resting order."""
     config = load_config()
+
+    if config.is_championship and not yes:
+        confirm = typer.confirm(
+            f"Cancel order {order_id} in CHAMPIONSHIP mode?"
+        )
+        if not confirm:
+            raise typer.Abort()
 
     async def _cancel() -> None:
         async with trading_context(config) as (client, broker, _db):


### PR DESCRIPTION
## Summary
- Add championship mode confirmation to cancel command
- `--yes/-y` flag to skip for autonomous mode

Closes #60

## Test plan
- [x] 367 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)