### PR TITLE
Catch httpx.HTTPStatusError and TimeoutException in CLI _run()

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -29,7 +29,7 @@ def _api_error_detail(e) -> str:  # type: ignore[no-untyped-def]
         return fallback
     if not isinstance(body, dict):
         return fallback
-    return body.get("message") or body.get("error") or fallback
+    return str(body.get("message") or body.get("error") or fallback)
 
 
 def _run(coro):  # type: ignore[no-untyped-def]
@@ -51,6 +51,10 @@ def _run(coro):  # type: ignore[no-untyped-def]
     except httpx.TimeoutException as e:
         logger.debug("Timeout error", exc_info=True)
         console.print(f"[red]Request timed out: {e}[/red]")
+        raise typer.Exit(1)
+    except httpx.TransportError as e:
+        logger.debug("Transport error", exc_info=True)
+        console.print(f"[red]Connection error: {e}[/red]")
         raise typer.Exit(1)
     except (ConnectionError, ValueError, RuntimeError) as e:
         logger.debug("CLI error", exc_info=True)

--- a/tests/unit/test_run_error_handling.py
+++ b/tests/unit/test_run_error_handling.py
@@ -74,6 +74,14 @@ class TestRunTimeoutError:
         assert "timed out" in output.lower()
 
 
+class TestRunTransportError:
+    def test_connect_error(self) -> None:
+        exc = httpx.ConnectError("Connection refused")
+        output = _run_expecting_exit(exc)
+        assert "Connection error" in output
+        assert "Connection refused" in output
+
+
 class TestRunExistingErrors:
     def test_connection_error_still_caught(self) -> None:
         exc = ConnectionError("Connection refused")


### PR DESCRIPTION
## Summary
- Add `httpx.HTTPStatusError` handler to `_run()` — extracts status code and human-readable detail from JSON response body (falls back to raw text)
- Add `httpx.TimeoutException` handler for clean timeout messages
- Extract `_api_error_detail()` helper for JSON message parsing with non-dict and non-JSON fallbacks

Closes #101

## Test plan
- [x] 7 new unit tests covering: JSON `message` field, JSON `error` field, non-JSON body, non-dict JSON body, empty body, timeout, and regression test for existing `ConnectionError` handler
- [x] All 438 unit tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)