### PR TITLE
Add error handling around order placement and position sync

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -568,7 +568,7 @@ def order(
                     f"[red bold]Order FAILED"
                     f" ({exc.response.status_code}): {detail}[/red bold]"
                 )
-                return
+                raise typer.Exit(1)
             except httpx.TimeoutException:
                 logger.debug("Order placement timed out", exc_info=True)
                 console.print(
@@ -580,11 +580,11 @@ def order(
                         " by Kalshi before the timeout.[/red]"
                     )
                 console.print(_RECONCILE_HINT)
-                return
+                raise typer.Exit(1)
             except Exception as exc:
                 logger.debug("Order placement failed", exc_info=True)
                 console.print(f"[red bold]Order FAILED: {exc}[/red bold]")
-                return
+                raise typer.Exit(1)
 
             console.print(
                 f"[green]{label}Order placed:[/green] {result.order_id}"

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -170,6 +170,7 @@ class TestOrderPlacementErrors:
 
         result, mock_console = _run_order_cli(broker)
 
+        assert result.exit_code == 1
         out = _printed(mock_console)
         assert "Order FAILED" in out
         assert "Insufficient balance" in out
@@ -178,8 +179,9 @@ class TestOrderPlacementErrors:
         exc = httpx.ReadTimeout("Connection read timed out")
         broker = _make_mock_broker(create_order_side_effect=exc)
 
-        _, mock_console = _run_order_cli(broker)
+        result, mock_console = _run_order_cli(broker)
 
+        assert result.exit_code == 1
         out = _printed(mock_console)
         assert "Order FAILED" in out
         assert "timed out" in out
@@ -189,10 +191,11 @@ class TestOrderPlacementErrors:
         exc = httpx.ReadTimeout("Connection read timed out")
         mock_create = AsyncMock(side_effect=exc)
 
-        _, mock_console = _run_order_cli(
+        result, mock_console = _run_order_cli(
             None, championship_create_order=mock_create
         )
 
+        assert result.exit_code == 1
         out = _printed(mock_console)
         assert "Order FAILED" in out
         assert "timed out" in out
@@ -203,8 +206,9 @@ class TestOrderPlacementErrors:
         exc = RuntimeError("Paper DB locked")
         broker = _make_mock_broker(create_order_side_effect=exc)
 
-        _, mock_console = _run_order_cli(broker)
+        result, mock_console = _run_order_cli(broker)
 
+        assert result.exit_code == 1
         out = _printed(mock_console)
         assert "Order FAILED" in out
         assert "Paper DB locked" in out
@@ -213,8 +217,9 @@ class TestOrderPlacementErrors:
         exc = RuntimeError("create failed")
         broker = _make_mock_broker(create_order_side_effect=exc)
 
-        _run_order_cli(broker)
+        result, _ = _run_order_cli(broker)
 
+        assert result.exit_code == 1
         # get_positions is called once for pre-order validation (line 395),
         # but should NOT be called a second time for post-order sync
         assert broker.get_positions.call_count == 1


### PR DESCRIPTION
## Summary
- Wraps order placement in a try/except that catches `HTTPStatusError` (with API detail extraction), `TimeoutException` (with championship-mode ambiguity warning), and generic exceptions
- Wraps post-order position sync in a separate try/except that warns the user and suggests running `reconcile` if sync fails after a successful order
- Adds `logger.debug(exc_info=True)` to all catch blocks for stack trace preservation
- Extracts `_RECONCILE_HINT` constant for consistent messaging
- 9 unit tests covering placement errors (API, timeout, generic, championship timeout) and sync errors (fetch failure, DB write failure, order ID in warning, no crash)

Closes #102

## Deferred
- #105: Add structured error logging (`insert_error`) to these handlers
- #106: Narrow `except Exception` to specific exception types

## Test plan
- [ ] `uv run pytest tests/unit/test_order_error_handling.py` — 9 tests for error paths
- [ ] `uv run pytest tests/unit/` — Full suite (448 tests pass)
- [ ] `uv run ruff check src/gimmes/cli.py` — Lint clean
- [ ] Manual: `python -m gimmes order NONEXISTENT --yes` should show "Order FAILED" with API detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)