### PR TITLE
Narrow exception types in order command error handlers

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -387,6 +387,7 @@ def order(
     async def _order() -> None:
         import json
         import logging
+        import sqlite3
         import traceback
 
         import httpx
@@ -617,13 +618,19 @@ def order(
                     )
                 console.print(_RECONCILE_HINT)
                 raise typer.Exit(1)
-            except Exception as exc:
+            except (sqlite3.Error, ValueError, RuntimeError) as exc:
                 logger.debug("Order placement failed", exc_info=True)
+                if isinstance(exc, sqlite3.Error):
+                    error_code = "db_error"
+                elif isinstance(exc, ValueError):
+                    error_code = "value_error"
+                else:
+                    error_code = "runtime_error"
                 try:
                     await insert_error(db, ErrorLogEntry(
                         severity=ErrorSeverity.ERROR,
                         category=ErrorCategory.ORDER_FAILURE,
-                        error_code="unexpected",
+                        error_code=error_code,
                         component="cli.order", agent="cli",
                         message=f"Order placement failed: {exc}",
                         stack_trace=traceback.format_exc(),
@@ -684,7 +691,33 @@ def order(
                     from gimmes.store.queries import sync_positions
 
                     await sync_positions(db, positions_for_sync)
-            except Exception as exc:
+            except sqlite3.Error as exc:
+                logger.debug("Position sync failed (database)", exc_info=True)
+                try:
+                    await insert_error(db, ErrorLogEntry(
+                        severity=ErrorSeverity.WARNING,
+                        category=ErrorCategory.DATA_INTEGRITY,
+                        error_code="position_sync_db_error",
+                        component="cli.order", agent="cli",
+                        message=f"Position sync failed after order {result.order_id}: {exc}",
+                        stack_trace=traceback.format_exc(),
+                        context=json.dumps({"ticker": ticker, "side": side,
+                                            "count": final_count, "price": final_price,
+                                            "order_id": result.order_id}),
+                    ))
+                except Exception:
+                    logger.warning("Failed to log error to DB", exc_info=True)
+                console.print(
+                    f"[red bold]Warning: Order was placed successfully"
+                    f" ({result.order_id}) but position sync"
+                    f" failed: {exc}[/red bold]"
+                )
+                console.print(
+                    "[yellow]Database error — check database health"
+                    " (disk space, permissions, corruption).[/yellow]"
+                )
+                console.print(_RECONCILE_HINT)
+            except (httpx.HTTPError, ValueError, RuntimeError) as exc:
                 logger.debug("Position sync failed", exc_info=True)
                 try:
                     await insert_error(db, ErrorLogEntry(

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -249,7 +250,7 @@ def _broker_with_post_order_fetch_failure(error: Exception):
 class TestPositionSyncErrors:
     def test_position_fetch_failure_warns_and_suggests_reconcile(self) -> None:
         broker = _broker_with_post_order_fetch_failure(
-            RuntimeError("DB connection lost")
+            sqlite3.OperationalError("DB connection lost")
         )
 
         _, mock_console, _ = _run_order_cli(broker)
@@ -264,7 +265,7 @@ class TestPositionSyncErrors:
 
         _, mock_console, _ = _run_order_cli(
             broker,
-            sync_side_effect=RuntimeError("disk full"),
+            sync_side_effect=sqlite3.OperationalError("disk full"),
         )
 
         out = _printed(mock_console)
@@ -274,7 +275,7 @@ class TestPositionSyncErrors:
 
     def test_sync_failure_shows_order_id(self) -> None:
         broker = _broker_with_post_order_fetch_failure(
-            RuntimeError("fetch failed")
+            sqlite3.OperationalError("fetch failed")
         )
 
         _, mock_console, _ = _run_order_cli(broker)
@@ -284,7 +285,7 @@ class TestPositionSyncErrors:
 
     def test_sync_failure_does_not_crash(self) -> None:
         broker = _broker_with_post_order_fetch_failure(
-            RuntimeError("fetch failed")
+            sqlite3.OperationalError("fetch failed")
         )
 
         _, mock_console, _ = _run_order_cli(broker)
@@ -343,12 +344,12 @@ class TestOrderErrorLogging:
         entry = _error_entry(mock_insert)
         assert entry.severity == ErrorSeverity.ERROR
         assert entry.category == ErrorCategory.ORDER_FAILURE
-        assert entry.error_code == "unexpected"
+        assert entry.error_code == "runtime_error"
         assert "Paper DB locked" in entry.message
 
     def test_position_sync_failure_logs_data_integrity(self) -> None:
         broker = _broker_with_post_order_fetch_failure(
-            RuntimeError("DB connection lost")
+            sqlite3.OperationalError("DB connection lost")
         )
 
         _, _, mock_insert = _run_order_cli(broker)
@@ -356,7 +357,7 @@ class TestOrderErrorLogging:
         entry = _error_entry(mock_insert)
         assert entry.severity == ErrorSeverity.WARNING
         assert entry.category == ErrorCategory.DATA_INTEGRITY
-        assert entry.error_code == "position_sync_failed"
+        assert entry.error_code == "position_sync_db_error"
         ctx = json.loads(entry.context)
         assert ctx["order_id"] == "order-123"
 
@@ -393,7 +394,7 @@ class TestErrorLoggingResilience:
 
     def test_db_failure_does_not_mask_sync_error(self) -> None:
         broker = _broker_with_post_order_fetch_failure(
-            RuntimeError("fetch failed")
+            sqlite3.OperationalError("fetch failed")
         )
 
         _, mock_console, _ = _run_order_cli(
@@ -403,3 +404,93 @@ class TestErrorLoggingResilience:
         out = _printed(mock_console)
         assert "Order was placed successfully" in out
         assert "position sync failed" in out
+
+
+# ---------------------------------------------------------------------------
+# Narrowed exception type tests
+# ---------------------------------------------------------------------------
+
+
+class TestNarrowedExceptionTypes:
+    def test_sqlite_error_caught_in_placement(self) -> None:
+        exc = sqlite3.OperationalError("database is locked")
+        broker = _make_mock_broker(create_order_side_effect=exc)
+
+        result, mock_console, mock_insert = _run_order_cli(broker)
+
+        assert result.exit_code == 1
+        out = _printed(mock_console)
+        assert "Order FAILED" in out
+        entry = _error_entry(mock_insert)
+        assert entry.error_code == "db_error"
+
+    def test_value_error_caught_in_placement(self) -> None:
+        exc = ValueError("invalid price format")
+        broker = _make_mock_broker(create_order_side_effect=exc)
+
+        result, mock_console, mock_insert = _run_order_cli(broker)
+
+        assert result.exit_code == 1
+        out = _printed(mock_console)
+        assert "Order FAILED" in out
+        entry = _error_entry(mock_insert)
+        assert entry.error_code == "value_error"
+
+    def test_programming_bug_propagates_from_placement(self) -> None:
+        """TypeError should NOT be caught — it propagates as an unhandled exception."""
+        exc = TypeError("unsupported operand")
+        broker = _make_mock_broker(create_order_side_effect=exc)
+
+        result, _, _ = _run_order_cli(broker)
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, TypeError)
+
+    def test_sqlite_sync_failure_suggests_db_health(self) -> None:
+        broker = _broker_with_post_order_fetch_failure(
+            sqlite3.OperationalError("database is locked")
+        )
+
+        _, mock_console, _ = _run_order_cli(broker)
+
+        out = _printed(mock_console)
+        assert "Order was placed successfully" in out
+        assert "database" in out.lower()
+        assert "health" in out.lower()
+
+    def test_httpx_sync_failure_warns_reconcile(self) -> None:
+        broker = _broker_with_post_order_fetch_failure(
+            httpx.ConnectError("connection refused")
+        )
+
+        _, mock_console, mock_insert = _run_order_cli(broker)
+
+        out = _printed(mock_console)
+        assert "Order was placed successfully" in out
+        assert "reconcile" in out
+        entry = _error_entry(mock_insert)
+        assert entry.error_code == "position_sync_failed"
+
+    def test_value_error_sync_failure_warns_reconcile(self) -> None:
+        broker = _broker_with_post_order_fetch_failure(
+            ValueError("bad position data")
+        )
+
+        _, mock_console, mock_insert = _run_order_cli(broker)
+
+        out = _printed(mock_console)
+        assert "Order was placed successfully" in out
+        assert "reconcile" in out
+        entry = _error_entry(mock_insert)
+        assert entry.error_code == "position_sync_failed"
+
+    def test_programming_bug_propagates_from_sync(self) -> None:
+        """TypeError in sync should NOT be caught — it propagates."""
+        broker = _broker_with_post_order_fetch_failure(
+            TypeError("unexpected type")
+        )
+
+        result, _, _ = _run_order_cli(broker)
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, TypeError)


### PR DESCRIPTION
## Summary
- Order placement: narrowed `except Exception` to `except (sqlite3.Error, ValueError, RuntimeError)` with error_code differentiation (`db_error`, `value_error`, `runtime_error`)
- Position sync: split into `except sqlite3.Error` (with "check database health" hint) and `except (httpx.HTTPError, ValueError, RuntimeError)` (with reconcile hint)
- Programming bugs (`TypeError`, `AttributeError`) now propagate as unhandled exceptions instead of being silently caught and printed as "Order FAILED"

Closes #106

## Test plan
- [x] All 462 unit tests pass
- [x] Lint clean (ruff)
- [x] 7 new tests: sqlite/ValueError/TypeError propagation for placement; sqlite DB health hint, httpx, ValueError, TypeError propagation for sync
- [ ] Verify `TypeError` in broker.create_order() produces a full traceback (not "Order FAILED")

🤖 Generated with [Claude Code](https://claude.com/claude-code)