### PR TITLE
Populate unrealized_pnl when parsing Kalshi API positions

### DIFF
--- a/src/gimmes/kalshi/portfolio.py
+++ b/src/gimmes/kalshi/portfolio.py
@@ -17,12 +17,24 @@ def _parse_position(data: dict) -> Position:  # type: ignore[type-arg]
 
     market_value = float(data.get("market_exposure_dollars", "0"))
     realized_pnl = float(data.get("realized_pnl_dollars", "0"))
+    total_traded = float(data.get("total_traded_dollars", "0"))
+    fees_paid = float(data.get("fees_paid_dollars", "0"))
+
+    # total_traded is the raw fill cost; fees are separate
+    cost_basis = total_traded + fees_paid
+    unrealized_pnl = (market_value - cost_basis) if abs_count > 0 else 0.0
+    avg_price = cost_basis / abs_count if abs_count > 0 else 0.0
+    market_price = market_value / abs_count if abs_count > 0 else 0.0
 
     return Position(
         ticker=ticker,
         side=side,
         count=abs_count,
+        avg_price=avg_price,
+        market_price=market_price,
+        cost_basis=cost_basis,
         market_value=market_value,
+        unrealized_pnl=unrealized_pnl,
         realized_pnl=realized_pnl,
     )
 

--- a/tests/unit/test_portfolio_parse.py
+++ b/tests/unit/test_portfolio_parse.py
@@ -1,0 +1,95 @@
+"""Unit tests for Kalshi API position parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from gimmes.kalshi.portfolio import _parse_position
+
+
+class TestParsePosition:
+    def test_yes_position_with_unrealized_gain(self) -> None:
+        data = {
+            "ticker": "KXTEST",
+            "position_fp": "50.00",
+            "market_exposure_dollars": "32.50",
+            "realized_pnl_dollars": "0.00",
+            "total_traded_dollars": "25.00",
+            "fees_paid_dollars": "1.50",
+        }
+        pos = _parse_position(data)
+        assert pos.ticker == "KXTEST"
+        assert pos.side == "yes"
+        assert pos.count == 50
+        assert pos.cost_basis == pytest.approx(26.50)  # 25.00 + 1.50
+        assert pos.market_value == pytest.approx(32.50)
+        assert pos.unrealized_pnl == pytest.approx(6.00)  # 32.50 - 26.50
+        assert pos.avg_price == pytest.approx(0.53)  # 26.50 / 50
+        assert pos.market_price == pytest.approx(0.65)  # 32.50 / 50
+
+    def test_no_position(self) -> None:
+        data = {
+            "ticker": "KXFED",
+            "position_fp": "-30.00",
+            "market_exposure_dollars": "21.00",
+            "realized_pnl_dollars": "1.50",
+            "total_traded_dollars": "18.00",
+            "fees_paid_dollars": "0.90",
+        }
+        pos = _parse_position(data)
+        assert pos.side == "no"
+        assert pos.count == 30
+        assert pos.cost_basis == pytest.approx(18.90)
+        assert pos.unrealized_pnl == pytest.approx(2.10)  # 21.00 - 18.90
+
+    def test_zero_count_no_division_error(self) -> None:
+        data = {
+            "ticker": "KXZERO",
+            "position_fp": "0.00",
+            "market_exposure_dollars": "0.00",
+            "total_traded_dollars": "10.00",
+            "fees_paid_dollars": "0.50",
+        }
+        pos = _parse_position(data)
+        assert pos.count == 0
+        assert pos.unrealized_pnl == 0.0
+        assert pos.avg_price == 0.0
+        assert pos.market_price == 0.0
+
+    def test_unrealized_loss(self) -> None:
+        data = {
+            "ticker": "KXLOSS",
+            "position_fp": "10.00",
+            "market_exposure_dollars": "3.00",
+            "total_traded_dollars": "5.00",
+            "fees_paid_dollars": "0.30",
+        }
+        pos = _parse_position(data)
+        # unrealized = 3.00 - (5.00 + 0.30) = -2.30
+        assert pos.unrealized_pnl == pytest.approx(-2.30)
+
+    def test_legacy_format_fallback(self) -> None:
+        """Old API format without _dollars/_fp suffixes still parses."""
+        data = {
+            "market_ticker": "KXOLD",
+            "position": 20,
+        }
+        pos = _parse_position(data)
+        assert pos.ticker == "KXOLD"
+        assert pos.count == 20
+        assert pos.side == "yes"
+        # No cost data available — cost_basis defaults to 0
+        assert pos.cost_basis == 0.0
+
+    def test_realized_pnl_preserved(self) -> None:
+        data = {
+            "ticker": "KXREAL",
+            "position_fp": "5.00",
+            "market_exposure_dollars": "2.50",
+            "realized_pnl_dollars": "3.75",
+            "total_traded_dollars": "2.00",
+            "fees_paid_dollars": "0.10",
+        }
+        pos = _parse_position(data)
+        assert pos.realized_pnl == pytest.approx(3.75)
+        assert pos.unrealized_pnl == pytest.approx(0.40)  # 2.50 - 2.10


### PR DESCRIPTION
## Summary
- Extract `total_traded_dollars` and `fees_paid_dollars` from the Kalshi API position response
- Compute `cost_basis` (total_traded + fees), `unrealized_pnl` (market_value - cost_basis), `avg_price`, and `market_price`
- Previously these fields defaulted to 0.0 in championship mode, making the daily loss calculation from #88 ignore unrealized drawdowns

Closes #109

## Test plan
- [x] All 468 unit tests pass
- [x] Lint clean (ruff)
- [x] 6 new tests for _parse_position() covering YES/NO positions, zero count, unrealized loss, legacy format, and realized P&L
- [ ] Verify with real Kalshi API response that `total_traded_dollars` represents raw fill cost (not including fees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)