### PR TITLE
Mark positions to market before risk checks in CLI commands

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -77,6 +77,33 @@ def _championship_warning(config) -> None:  # type: ignore[no-untyped-def]
         )
 
 
+async def _mark_positions_to_market(
+    broker,   # PaperBroker
+    client,   # KalshiClient
+    *,
+    known_prices: dict[str, float] | None = None,
+) -> list:
+    """Mark all paper positions to market and return refreshed list."""
+    from gimmes.kalshi.markets import get_market
+
+    positions = await broker.get_positions()
+    prices = dict(known_prices or {})
+
+    for pos in positions:
+        try:
+            if pos.ticker not in prices:
+                market = await get_market(client, pos.ticker)
+                prices[pos.ticker] = market.midpoint or market.last_price
+            await broker.mark_to_market(pos.ticker, prices[pos.ticker])
+        except Exception as exc:
+            console.print(
+                f"[yellow]Warning: could not mark {pos.ticker}"
+                f" to market: {exc}[/yellow]"
+            )
+
+    return await broker.get_positions()
+
+
 @asynccontextmanager
 async def trading_context(config: GimmesConfig):
     """Yields (client, broker, db). broker is None in championship mode.
@@ -299,9 +326,13 @@ def validate(
         async with trading_context(config) as (client, broker, db):
             market = await get_market(client, ticker)
 
+            price = market.midpoint or market.last_price
+
             if broker:
                 balance = await broker.get_balance()
-                positions = await broker.get_positions()
+                positions = await _mark_positions_to_market(
+                    broker, client, known_prices={ticker: price},
+                )
             else:
                 from gimmes.kalshi.portfolio import get_all_positions, get_balance
                 from gimmes.store.queries import sync_positions
@@ -309,7 +340,6 @@ def validate(
                 positions = await get_all_positions(client)
                 await sync_positions(db, positions)
 
-            price = market.midpoint or market.last_price
             fees = get_multipliers(market.series_ticker)
             if dollars <= 0:
                 contracts = position_size(
@@ -411,7 +441,9 @@ def order(
             # Get balance and positions for both sizing and validation
             if broker:
                 balance = await broker.get_balance()
-                positions = await broker.get_positions()
+                positions = await _mark_positions_to_market(
+                    broker, client, known_prices={ticker: mkt_price},
+                )
             else:
                 from gimmes.kalshi.portfolio import get_all_positions, get_balance
                 from gimmes.store.queries import sync_positions
@@ -882,7 +914,7 @@ def risk_check() -> None:
         async with trading_context(config) as (client, broker, db):
             if broker:
                 balance = await broker.get_balance()
-                pos = await broker.get_positions()
+                pos = await _mark_positions_to_market(broker, client)
             else:
                 from gimmes.kalshi.portfolio import get_all_positions, get_balance
                 from gimmes.store.queries import sync_positions

--- a/tests/unit/test_mark_to_market.py
+++ b/tests/unit/test_mark_to_market.py
@@ -1,0 +1,119 @@
+"""Tests for the _mark_positions_to_market CLI helper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from gimmes.models.portfolio import Position
+
+
+def _pos(ticker: str = "KXTEST", unrealized_pnl: float = 0.0) -> Position:
+    return Position(ticker=ticker, count=10, avg_price=0.50, unrealized_pnl=unrealized_pnl)
+
+
+def _market(midpoint: float = 0.65) -> MagicMock:
+    m = MagicMock()
+    m.midpoint = midpoint
+    m.last_price = midpoint
+    return m
+
+
+class TestMarkPositionsToMarket:
+    async def test_marks_each_position(self) -> None:
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(return_value=[_pos("A"), _pos("B")])
+        broker.mark_to_market = AsyncMock()
+        client = AsyncMock()
+
+        with patch("gimmes.kalshi.markets.get_market", AsyncMock(return_value=_market(0.70))):
+            from gimmes.cli import _mark_positions_to_market
+
+            await _mark_positions_to_market(broker, client)
+
+        assert broker.mark_to_market.call_count == 2
+        broker.mark_to_market.assert_any_call("A", 0.70)
+        broker.mark_to_market.assert_any_call("B", 0.70)
+
+    async def test_known_prices_skip_api_call(self) -> None:
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(return_value=[_pos("A"), _pos("B")])
+        broker.mark_to_market = AsyncMock()
+        client = AsyncMock()
+        mock_get_market = AsyncMock(return_value=_market(0.80))
+
+        with patch("gimmes.kalshi.markets.get_market", mock_get_market):
+            from gimmes.cli import _mark_positions_to_market
+
+            await _mark_positions_to_market(
+                broker, client, known_prices={"A": 0.65},
+            )
+
+        # A uses known price, B fetches from API
+        broker.mark_to_market.assert_any_call("A", 0.65)
+        broker.mark_to_market.assert_any_call("B", 0.80)
+        # get_market called only for B
+        assert mock_get_market.call_count == 1
+
+    async def test_error_does_not_abort_loop(self) -> None:
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(return_value=[_pos("A"), _pos("BAD"), _pos("C")])
+        broker.mark_to_market = AsyncMock()
+        client = AsyncMock()
+
+        def _market_or_fail(client, ticker):
+            if ticker == "BAD":
+                raise httpx.ConnectError("connection refused")
+            return _market(0.70)
+
+        mock_console = MagicMock()
+        with (
+            patch("gimmes.kalshi.markets.get_market", AsyncMock(side_effect=_market_or_fail)),
+            patch("gimmes.cli.console", mock_console),
+        ):
+            from gimmes.cli import _mark_positions_to_market
+
+            await _mark_positions_to_market(broker, client)
+
+        # A and C were marked, BAD was skipped
+        assert broker.mark_to_market.call_count == 2
+        broker.mark_to_market.assert_any_call("A", 0.70)
+        broker.mark_to_market.assert_any_call("C", 0.70)
+        # Warning printed for BAD
+        warning_text = str(mock_console.print.call_args_list)
+        assert "BAD" in warning_text
+
+    async def test_empty_positions(self) -> None:
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(return_value=[])
+        broker.mark_to_market = AsyncMock()
+        client = AsyncMock()
+
+        with patch("gimmes.kalshi.markets.get_market", AsyncMock()) as mock_gm:
+            from gimmes.cli import _mark_positions_to_market
+
+            result = await _mark_positions_to_market(broker, client)
+
+        assert result == []
+        mock_gm.assert_not_called()
+        broker.mark_to_market.assert_not_called()
+
+    async def test_returns_refreshed_positions(self) -> None:
+        """After marking, the function re-fetches to get updated P&L."""
+        stale = [_pos("A", unrealized_pnl=0.0)]
+        fresh = [_pos("A", unrealized_pnl=1.50)]
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(side_effect=[stale, fresh])
+        broker.mark_to_market = AsyncMock()
+        client = AsyncMock()
+
+        with patch("gimmes.kalshi.markets.get_market", AsyncMock(return_value=_market(0.65))):
+            from gimmes.cli import _mark_positions_to_market
+
+            result = await _mark_positions_to_market(broker, client)
+
+        # Returns the second (refreshed) fetch
+        assert result[0].unrealized_pnl == pytest.approx(1.50)
+        assert broker.get_positions.call_count == 2

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -100,11 +100,16 @@ def _run_order_cli(
         return_value=1, side_effect=insert_error_side_effect,
     )
 
+    # Bypass mark-to-market — these tests focus on order error handling
+    async def _passthrough_mtm(b, c, **kw):
+        return await b.get_positions()
+
     patches = [
         patch("gimmes.cli.load_config", return_value=_stub_config()),
         patch("gimmes.cli.trading_context", _fake_trading_context(broker)),
         patch("gimmes.cli.console", mock_console),
         patch("gimmes.cli._championship_warning"),
+        patch("gimmes.cli._mark_positions_to_market", _passthrough_mtm),
         patch("gimmes.kalshi.markets.get_market", AsyncMock(return_value=_stub_market())),
         patch("gimmes.kalshi.markets.get_orderbook", AsyncMock(return_value=MagicMock())),
         patch("gimmes.strategy.fee_cache.get_multipliers", MagicMock(return_value=mock_fees)),


### PR DESCRIPTION
## Summary
- Add `_mark_positions_to_market()` helper that refreshes unrealized P&L for paper positions by fetching current market prices via `get_market()` and calling `broker.mark_to_market()` for each
- `validate`, `order`, and `risk-check` commands now use the helper instead of raw `broker.get_positions()`
- Accepts `known_prices` dict to reuse already-fetched market data, avoiding redundant API calls
- Per-position error handling prints warnings without aborting the loop (matches existing `positions` command pattern)

Closes #110

## Test plan
- [x] All 473 unit tests pass
- [x] Lint clean (ruff)
- [x] 5 new tests for the helper: marks each position, known_prices optimization, error resilience, empty list, returns refreshed data
- [ ] Verify `python -m gimmes risk-check` shows fresh unrealized P&L (not stale cached values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)