### PR TITLE
Fix Typer help to show 'gimmes' instead of 'python -m gimmes'

### DIFF
--- a/src/gimmes/__main__.py
+++ b/src/gimmes/__main__.py
@@ -2,4 +2,4 @@
 
 from gimmes.cli import app
 
-app()
+app(prog_name="gimmes")

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -21,7 +21,7 @@ console = Console()
 
 
 _RECONCILE_HINT = (
-    "[yellow]Run 'python -m gimmes reconcile'"
+    "[yellow]Run 'gimmes reconcile'"
     " to sync positions with the broker.[/yellow]"
 )
 


### PR DESCRIPTION
## Summary
- Pass `prog_name="gimmes"` to `app()` in `__main__.py` so Click displays the user-facing command name in help/usage text instead of auto-detecting `python -m gimmes`
- Update `_RECONCILE_HINT` in `cli.py` to reference `gimmes reconcile` instead of `python -m gimmes reconcile`

Closes #117

## Test plan
- Run `python -m gimmes --help` and verify usage line shows `Usage: gimmes [OPTIONS] COMMAND [ARGS]...`
- Run `python -m gimmes` (no args) and verify same
- All 483 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)