### PR TITLE
Let --help/-h pass through to Typer instead of shell wrapper

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -31,7 +31,7 @@ case "${1:-}" in
         fi
         echo "Updated to $(git rev-parse --short HEAD)"
         ;;
-    help|--help|-h)
+    help)
         cat <<'HELP'
 gimmes -- We only play the gimmes.
 


### PR DESCRIPTION
## Summary
- Remove `--help` and `-h` from the shell wrapper's `case` pattern so they fall through to Typer's auto-generated help
- Only the bare `help` subcommand is still intercepted for the curated quick-reference
- Makes `gimmes --help` consistent with `gimmes` (no args)

Closes #119

## Test plan
- `gimmes --help` → shows Typer auto-generated help (same as `gimmes` no args)
- `gimmes -h` → shows Typer auto-generated help
- `gimmes help` → still shows curated shell wrapper help
- `gimmes` (no args) → unchanged, shows Typer help

🤖 Generated with [Claude Code](https://claude.com/claude-code)