### PR TITLE
Show contextual next steps in install.sh based on init state

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -203,6 +203,10 @@ if [ -n "$RC_FILE" ]; then
 else
     echo "  1. Restart your terminal"
 fi
-echo "  2. Run: gimmes init"
+if [ -f "$GIMMES_HOME/.env" ] && [ -f "$GIMMES_HOME/config/gimmes.toml" ]; then
+    echo "  2. Run: gimmes mode   (verify your connection)"
+else
+    echo "  2. Run: gimmes init"
+fi
 echo "  3. Run: gimmes help"
 echo ""


### PR DESCRIPTION
## Summary
- Check for `$GIMMES_HOME/.env` and `$GIMMES_HOME/config/gimmes.toml` before suggesting next steps
- If init was already completed, suggest `gimmes mode` (verify connection) instead of `gimmes init`
- Fresh installs still see `gimmes init` as before

Closes #121

## Test plan
- Run `install.sh` on a fresh system → should show "Run: gimmes init"
- Run `install.sh` after `gimmes init` has been completed → should show "Run: gimmes mode (verify your connection)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)