### PR TITLE
Replace git reset --hard with git pull --ff-only in update paths

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -22,8 +22,7 @@ case "${1:-}" in
     update)
         echo "Updating gimmes..."
         cd "$REPO"
-        git fetch origin main
-        git reset --hard origin/main
+        git pull --ff-only origin main
         if command -v uv &>/dev/null; then
             uv sync --quiet
         else

--- a/install.sh
+++ b/install.sh
@@ -94,8 +94,7 @@ mkdir -p "$GIMMES_HOME"
 if [ -d "$REPO_DIR/.git" ]; then
     info "Updating existing installation..."
     cd "$REPO_DIR"
-    git fetch origin main
-    git reset --hard origin/main
+    git pull --ff-only origin main
     ok "Updated to $(git rev-parse --short HEAD)"
 else
     info "Cloning gimmes..."


### PR DESCRIPTION
## Summary
- Replace `git fetch origin main && git reset --hard origin/main` with `git pull --ff-only origin main` in both `install.sh` and `bin/gimmes.sh`
- Fast-forwards cleanly when no local changes exist (normal case)
- Fails safely with an error if local changes would be overwritten, instead of silently discarding them

Closes #124

## Test plan
- `gimmes update` on a clean install → updates normally via fast-forward
- `gimmes update` with local changes → fails with clear git error instead of silently discarding
- Both scripts run under `set -euo pipefail`, ensuring non-zero exits halt execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)