### PR TITLE
Fix `gimmes version` crash when no git tags exist

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -16,7 +16,7 @@ show_version() {
     sha=$(git -C "$REPO" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
     # Try git tag first, fall back to pyproject.toml version
-    tag=$(git -C "$REPO" describe --tags --abbrev=0 2>/dev/null)
+    tag=$(git -C "$REPO" describe --tags --abbrev=0 2>/dev/null || true)
     if [ -z "$tag" ]; then
         tag=$(sed -n 's/^version = "\(.*\)"/v\1/p' "$REPO/pyproject.toml" 2>/dev/null)
     fi


### PR DESCRIPTION
## Summary
- Add `|| true` to `git describe` in `show_version()` so `set -euo pipefail` doesn't kill the script when no tags exist (exit 128)
- The pyproject.toml fallback on lines 20-22 now executes as intended

Closes #148

## Test plan
- [x] Verified `set -euo pipefail; tag=$(git describe --tags --abbrev=0 2>/dev/null || true)` succeeds with empty tag
- [x] Verified fallback chain produces `v0.1.0` from pyproject.toml
- [x] 532 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)