### PR TITLE
Fix case-sensitive --agent flags in CLI invocations

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1734,7 +1734,7 @@ def tour_guide() -> None:
         result = subprocess.run(
             [
                 claude_path,
-                "--agent", "starter",
+                "--agent", "Starter",
                 "--name", "GIMMES Tour",
             ],
             cwd=project_root,
@@ -1984,7 +1984,7 @@ def _autonomous_loop(
             result = subprocess.run(
                 [
                     claude_path,
-                    "--agent", "caddie-master",
+                    "--agent", "Caddie Master",
                     "-p", "Run one trading cycle.",
                     "--allowedTools",
                     "Bash,Read,Glob,Grep,Agent,WebSearch,WebFetch",

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -130,7 +130,7 @@ class TestAutonomousLoop:
         cmd = mock_run.call_args.args[0]
         assert cmd[0] == "/opt/bin/claude"
         agent_idx = cmd.index("--agent")
-        assert cmd[agent_idx + 1] == "caddie-master"
+        assert cmd[agent_idx + 1] == "Caddie Master"
         idx = cmd.index("--allowedTools")
         allowed = cmd[idx + 1]
         assert "WebSearch" in allowed

--- a/tests/unit/test_tour_guide.py
+++ b/tests/unit/test_tour_guide.py
@@ -38,7 +38,7 @@ class TestTourGuideCommand:
         cmd = mock_run.call_args.args[0]
         assert cmd[0] == "/usr/bin/claude"
         assert "--agent" in cmd
-        assert "starter" in cmd
+        assert "Starter" in cmd
         assert "--name" in cmd
         assert "GIMMES Tour" in cmd
         assert mock_run.call_args.kwargs["cwd"] is not None


### PR DESCRIPTION
## Summary

- Fix `tour_guide()` passing `"starter"` → `"Starter"` to match agent frontmatter
- Fix `_autonomous_loop()` passing `"caddie-master"` → `"Caddie Master"` to match agent frontmatter
- Update test assertions to match corrected values

Claude CLI's `--agent` flag is case-sensitive. Mismatched casing caused agents to load their markdown as context but not adopt their persona — the model behaved as generic Claude. This was the root cause of the Starter agent failing 17/20 user journey tests.

Closes #159

## Test plan
- [x] `uv run pytest tests/unit/test_tour_guide.py -v` — all pass
- [x] `uv run pytest tests/unit/test_autonomous_loop.py -v` — all pass
- [x] `uv run pytest tests/unit/` — 538 passed
- [x] `uv run ruff check` — clean
- [x] Verified via `claude -p --agent Starter "What is your name?"` — persona adopted
- [x] Verified via `claude -p --agent "Caddie Master" "What is your name?"` — persona adopted

🤖 Generated with [Claude Code](https://claude.com/claude-code)