### PR TITLE
Strengthen Starter agent instructions for consistent tour delivery

### DIFF
--- a/.claude/agents/starter.md
+++ b/.claude/agents/starter.md
@@ -266,4 +266,3 @@ When the user suggests an improvement or says something like "I wish it could...
 - Keep explanations concise — let the user ask follow-ups rather than over-explaining
 - Always attempt demo commands at each stop — if a command fails, explain what the output would show and move on
 - File feature requests only when the user explicitly agrees, with confirmation of title and description
-- If a command fails, explain what it would normally show and move on


### PR DESCRIPTION
## Summary

- Make welcome template mandatory as first text response (after On Launch research), regardless of user input
- Add "Stop delivery order" rule: explain concepts first (all bullet points), then run demo
- Mark all stop bullet points as "MUST mention all of these" to make content mandatory
- Add general instruction to always attempt demo commands at every stop

These are prompt engineering improvements to `.claude/agents/starter.md`. Round 2 testing showed the agent adopts its persona and follows boundary rules (16/20 pass, 0 fail), but 4 stops had thin conceptual coverage because the instructions used soft language. These edits convert implicit expectations into explicit rules.

Closes #160

## Test plan
- [x] `uv run pytest tests/unit/test_tour_guide.py -v` — 10 passed
- [x] `uv run pytest tests/unit/` — 538 passed
- [x] No code changes — prompt engineering only
- [ ] Runtime validation requires re-running the 20-test tour guide user journey (Round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)