### PR TITLE
Enforce min_true_probability in pre-trade validation

### DIFF
--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -52,9 +52,10 @@ def validate_trade(
     3. Single position size limit
     4. Balance sufficient
     4b. Session spending cap (callers must track and pass session_spent)
-    5. Edge after fees meets minimum (skipped when true_probability is None)
-    6. Duplicate position check
-    7. Settlement risk
+    5. Minimum true probability gate (skipped when true_probability is None)
+    6. Edge after fees meets minimum (skipped when true_probability is None)
+    7. Duplicate position check
+    8. Settlement risk
     """
     checks: list[str] = []
     failures: list[str] = []
@@ -97,7 +98,19 @@ def validate_trade(
     elif cap > 0:
         checks.append(f"Session spending OK (${session_spent + trade_dollars:.2f}/${cap:.2f})")
 
-    # 5. Edge after fees (skipped when probability is unknown)
+    # 5. Minimum true probability gate (skipped when probability is unknown)
+    if true_probability is not None:
+        min_prob = config.strategy.min_true_probability
+        if true_probability >= min_prob:
+            checks.append(f"True probability OK ({true_probability:.0%} >= {min_prob:.0%})")
+        else:
+            failures.append(
+                f"True probability too low: {true_probability:.0%} < {min_prob:.0%} minimum"
+            )
+    else:
+        checks.append("True probability check skipped (no probability provided)")
+
+    # 6. Edge after fees (skipped when probability is unknown)
     if true_probability is not None:
         price = market.midpoint if market.midpoint > 0 else market.last_price
         edge = edge_after_fees(price, true_probability, is_taker=is_taker, fees=fees)
@@ -109,13 +122,13 @@ def validate_trade(
     else:
         checks.append("Edge check skipped (no probability provided)")
 
-    # 6. Duplicate check
+    # 7. Duplicate check
     if market.ticker in existing_tickers:
         failures.append(f"Already have position in {market.ticker}")
     else:
         checks.append("No duplicate position")
 
-    # 7. Settlement risk
+    # 8. Settlement risk
     settlement = scan_settlement_rules(market.rules_primary)
     if settlement.is_clear:
         checks.append("Settlement rules clear")

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -79,6 +79,38 @@ class TestValidateTrade:
         assert result.approved is False
         assert any("edge" in f.lower() for f in result.failures)
 
+    def test_true_probability_at_boundary_passes(self, config: GimmesConfig) -> None:
+        """Trade approved when true probability equals min_true_probability (>= not >)."""
+        market = _make_market()
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=0.90,  # Exactly at 0.90 default threshold
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert result.approved is True
+        assert any("true probability ok" in c.lower() for c in result.checks)
+
+    def test_true_probability_too_low(self, config: GimmesConfig) -> None:
+        """Trade rejected when true probability is below min_true_probability."""
+        market = _make_market()
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=0.85,  # Below 0.90 default min
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert result.approved is False
+        assert any("true probability" in f.lower() for f in result.failures)
+
     def test_duplicate_position(self, config: GimmesConfig) -> None:
         market = _make_market()
         result = validate_trade(
@@ -111,6 +143,22 @@ class TestValidateTrade:
         )
         assert result.approved is False
         assert any("settlement" in f.lower() for f in result.failures)
+
+    def test_none_probability_skips_true_prob_check(self, config: GimmesConfig) -> None:
+        """When true_probability is None, the min probability check is skipped."""
+        market = _make_market()
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=None,
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert result.approved is True
+        assert any("true probability check skipped" in c.lower() for c in result.checks)
 
     def test_none_probability_skips_edge_check(self, config: GimmesConfig) -> None:
         """When true_probability is None, edge check is skipped."""


### PR DESCRIPTION
## Summary
- Wires the unused `min_true_probability` config parameter (default 0.90) into `validate_trade()` as check #5
- Rejects trades where the model's assessed probability falls below the configured threshold
- Skips gracefully when `true_probability` is `None` (consistent with existing edge check behavior)
- Adds 3 tests: boundary pass, rejection, and None-skip
- Filed #170 (CLI `probability=0.0` → `None` bypass) and #171 (config bounds validation) for pre-existing concerns surfaced during review

Closes #164

## Test plan
- [x] `uv run pytest tests/unit/test_validator.py` — 11 passed (3 new)
- [x] `uv run pytest tests/unit/` — 539 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)