### PR TITLE
Add autonomous and manual playing guides to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ gimmes championship     # Real money (requires confirmation)
 
 The **Caddie Master** dispatches agents each cycle: Monitor reviews positions, Scout scans, Caddie researches, Closer executes, Scorecard reports. See [How it works](#how-it-works) for the full cycle breakdown.
 
-The [Clubhouse](#the-clubhouse) dashboard auto-launches at `http://127.0.0.1:1919` — open your browser to watch live.
+The [Clubhouse](#the-clubhouse) dashboard auto-launches at `http://127.0.0.1:1919` (or the next available port) — check the printed URL and open your browser to watch live.
 
 Press **Ctrl+C** to stop. Run the command again to resume — the loop reads database state, so it picks up where it left off. Use `--cycles N` to run a fixed number of cycles, `--pause N` to adjust seconds between cycles.
 


### PR DESCRIPTION
## Summary
- Adds "Playing with a Caddie" section — autonomous mode guide with Clubhouse, Ctrl+C, and --cycles/--pause
- Adds "Walking the Course Solo" section — step-by-step manual command flow (scan → score → research → validate → size → order → positions → report)
- Separates Starter agent into its own "On-demand" table (not part of autonomous cycle)
- Fixes pre-existing incorrect default pause time (30s → 60s)

Closes #165

## Test plan
- [x] `uv run pytest tests/unit/` — 539 passed
- [x] Internal link anchors verified (#how-it-works, #the-clubhouse, #cli-commands)
- [x] CLI command signatures verified against cli.py
- [x] Agent dispatch order matches caddie-master.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)