### PR TITLE
Add cycle timeout to prevent autonomous loop hangs

### DIFF
--- a/config/gimmes.example.toml
+++ b/config/gimmes.example.toml
@@ -4,6 +4,7 @@ min_market_price = 0.55       # Only scan markets above this price
 max_market_price = 0.85       # Only scan markets below this price
 min_true_probability = 0.90   # Model must see >=90% to qualify
 min_edge_after_fees = 0.05    # 5pp minimum edge after fee math
+cycle_timeout = 2700              # Max seconds per autonomous cycle (45 min)
 
 [sizing]
 kelly_fraction = 0.25         # Conservative quarter-Kelly

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1981,18 +1981,39 @@ def _autonomous_loop(
             update_session_cycle(config.db_path, session_id, cycle)
 
             env["GIMMES_CYCLE"] = str(cycle)
-            result = subprocess.run(
-                [
-                    claude_path,
-                    "--agent", "Caddie Master",
-                    "-p", "Run one trading cycle.",
-                    "--allowedTools",
-                    "Bash,Read,Glob,Grep,Agent,WebSearch,WebFetch",
-                ],
-                env=env,
-                cwd=project_root,
-                check=False,
-            )
+            try:
+                result = subprocess.run(
+                    [
+                        claude_path,
+                        "--agent", "Caddie Master",
+                        "-p", "Run one trading cycle.",
+                        "--allowedTools",
+                        "Bash,Read,Glob,Grep,Agent,WebSearch,WebFetch",
+                    ],
+                    env=env,
+                    cwd=project_root,
+                    check=False,
+                    timeout=config.strategy.cycle_timeout,
+                )
+            except subprocess.TimeoutExpired:
+                consecutive_failures += 1
+                console.print(
+                    f"[yellow]Cycle {cycle} timed out after"
+                    f" {config.strategy.cycle_timeout}s"
+                    f" (failure {consecutive_failures}"
+                    f"/{max_consecutive_failures})[/yellow]"
+                )
+                if (max_consecutive_failures > 0
+                        and consecutive_failures >= max_consecutive_failures):
+                    console.print(
+                        f"[red bold]Circuit breaker tripped:"
+                        f" {max_consecutive_failures} consecutive"
+                        f" failures. Halting autonomous loop.[/red bold]"
+                    )
+                    session_status = "crashed"
+                    break
+                continue
+
             if result.returncode != 0:
                 consecutive_failures += 1
                 console.print(

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -40,6 +40,7 @@ class StrategyConfig(BaseModel):
     max_market_price: float = 0.85
     min_true_probability: float = 0.90
     min_edge_after_fees: float = 0.05
+    cycle_timeout: int = 2700
 
 
 class SizingConfig(BaseModel):

--- a/src/gimmes/init.py
+++ b/src/gimmes/init.py
@@ -46,6 +46,7 @@ min_market_price = 0.55       # Only scan markets above this price
 max_market_price = 0.85       # Only scan markets below this price
 min_true_probability = 0.90   # Model must see >=90% to qualify
 min_edge_after_fees = 0.05    # 5pp minimum edge after fee math
+cycle_timeout = 2700              # Max seconds per autonomous cycle (45 min)
 
 [sizing]
 kelly_fraction = 0.25         # Conservative quarter-Kelly

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -135,6 +135,7 @@ class TestAutonomousLoop:
         allowed = cmd[idx + 1]
         assert "WebSearch" in allowed
         assert "WebFetch" in allowed
+        assert mock_run.call_args.kwargs["timeout"] == 2700
 
     def test_warns_on_nonzero_exit(self, capsys) -> None:  # type: ignore[no-untyped-def]
         mock_result = MagicMock()
@@ -240,6 +241,52 @@ class TestAutonomousLoop:
 
         # Default max_consecutive_failures=5
         assert mock_run.call_count == 5
+
+    def test_timeout_increments_failures_and_continues(self, capsys) -> None:
+        """A TimeoutExpired cycle counts as a failure but the loop continues."""
+        import subprocess as _subprocess
+
+        call_count = 0
+        ok = MagicMock(returncode=0)
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _subprocess.TimeoutExpired(cmd=args[0], timeout=2700)
+            return ok
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", side_effect=side_effect),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=2, pause_seconds=0)
+
+        assert call_count == 2
+        output = capsys.readouterr().out
+        assert "timed out" in output
+
+    def test_timeout_feeds_circuit_breaker(self, capsys) -> None:
+        """Consecutive timeouts trip the circuit breaker."""
+        import subprocess as _subprocess
+
+        def side_effect(*args, **kwargs):
+            raise _subprocess.TimeoutExpired(cmd=args[0], timeout=2700)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", side_effect=side_effect) as mock_run,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", pause_seconds=0,
+                max_consecutive_failures=3,
+            )
+
+        assert mock_run.call_count == 3
+        output = capsys.readouterr().out
+        assert "Circuit breaker tripped" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `cycle_timeout` config parameter (default 2700s / 45 min) to `[strategy]` section
- Wraps `subprocess.run()` in `_autonomous_loop()` with `timeout=config.strategy.cycle_timeout`
- On `TimeoutExpired`: increments failure counter, prints warning, feeds circuit breaker, continues to next cycle
- Adds 3 tests: timeout-continues, timeout-trips-breaker, and timeout kwarg verification
- Filed #177 for follow-up: graceful shutdown with process groups instead of SIGKILL

Closes #167

## Test plan
- [x] `uv run pytest tests/unit/` — 541 passed
- [x] `uv run ruff check` — clean
- [x] Config default matches across config.py, init.py, and gimmes.example.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)