### PR TITLE
Fix probability=0.0 bypassing validation gates

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -719,7 +719,7 @@ def order(
                         side=side,
                         count=final_count,
                         price=final_price,
-                        model_probability=probability or 0.0,
+                        model_probability=0.0 if probability is None else probability,
                         edge=(
                             probability - final_price
                             if probability is not None
@@ -1119,7 +1119,7 @@ def log_trade(
             side=side,
             count=count,
             price=price_val,
-            model_probability=prob or 0.0,
+            model_probability=0.0 if prob is None else prob,
             gimme_score=score_val,
             edge=prob - price_val if prob is not None else 0.0,
             rationale=rationale,


### PR DESCRIPTION
## Summary
- Changes `--prob` option default from `0` to `None` in both `order` and `log-trade` commands
- Replaces all `probability > 0` sentinel checks with `probability is not None`
- Ensures `probability=0.0` is treated as a real value (fails validation) rather than "not provided" (skips validation)

Closes #170

## Test plan
- [x] `uv run pytest tests/unit/` — 543 passed
- [x] `uv run ruff check` — clean
- [x] Existing tests pass `--prob 0.55` explicitly — unaffected by default change

🤖 Generated with [Claude Code](https://claude.com/claude-code)