### PR TITLE
Exit with code 1 when validate command fails

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -399,6 +399,9 @@ def validate(
             for fail in result.failures:
                 console.print(f"  [red]✗[/red] {fail}")
 
+            if not result.approved:
+                raise typer.Exit(1)
+
     _run(_validate())
 
 


### PR DESCRIPTION
## Summary
- Adds `raise typer.Exit(1)` when validation result is not approved
- Gives agents a reliable exit code signal instead of relying on text parsing

Closes #174

## Test plan
- [x] `uv run pytest tests/unit/` — 543 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)