### PR TITLE
Log Monitor SIZE UP recommendations for audit trail

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -59,6 +59,13 @@ python -m gimmes cancel ORDER_ID  # For resting orders to close
 
 Log all close decisions to the database.
 
+**If Monitor recommends SIZE UP on any position:**
+Full SIZE UP execution is not yet supported (the duplicate position check blocks adding to existing positions). Instead, MUST log the recommendation for audit:
+```bash
+python -m gimmes log-trade TICKER --action size_up --price CURRENT_PRICE --prob 0 --score 0 --rationale "Monitor: [reason from Monitor report]" --agent monitor
+```
+Use the position's current market price from the Monitor report as `CURRENT_PRICE`. This creates an audit trail for Pro analysis — do NOT attempt to place additional orders.
+
 Log Monitor completion:
 ```bash
 python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent monitor --phase complete --message "Monitor reviewed N positions, M recommended for action"


### PR DESCRIPTION
## Summary
- Adds SIZE UP handling to Caddie Master Step 2 — logs recommendations via `log-trade --action size_up`
- Creates audit trail for Pro analysis without attempting execution (duplicate position check blocks adding to existing positions)
- Explicitly prohibits placing additional orders until full SIZE UP execution is implemented

Closes #175

## Test plan
- [x] `uv run pytest tests/unit/` — 543 passed
- [x] `size_up` action confirmed in TradeDecision.Action enum
- [x] `log-trade` CLI accepts `--action size_up` via enum resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)