### PR TITLE
Kill subprocess process group on Ctrl+C in autonomous loop

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -1888,6 +1889,30 @@ def start(
                      no_dashboard=no_dashboard)
 
 
+def _kill_process_group(proc: subprocess.Popen[bytes]) -> None:
+    """Send SIGTERM to the process group, escalating to SIGKILL if needed.
+
+    Handles ProcessLookupError at each step in case the process exits
+    between our check and the signal delivery.
+    """
+    import os
+    import signal
+
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return  # Already exited
+
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass  # Exited between SIGTERM and SIGKILL
+        proc.wait()
+
+
 def _autonomous_loop(
     mode: str,
     *,
@@ -1908,7 +1933,6 @@ def _autonomous_loop(
     """
     import os
     import shutil
-    import signal
     import subprocess
     import sys
     import time
@@ -1984,6 +2008,7 @@ def _autonomous_loop(
     cycle = 0
     consecutive_failures = 0
     session_status = "stopped"
+    proc = None
     try:
         while max_cycles == 0 or cycle < max_cycles:
             cycle += 1
@@ -2017,12 +2042,7 @@ def _autonomous_loop(
                     log_file.write(stdout_bytes)
                 returncode = proc.returncode
             except subprocess.TimeoutExpired:
-                os.killpg(proc.pid, signal.SIGTERM)
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                    proc.wait()
+                _kill_process_group(proc)
                 consecutive_failures += 1
                 console.print(
                     f"[yellow]Cycle {cycle} timed out after"
@@ -2067,7 +2087,8 @@ def _autonomous_loop(
             console.print(f"[dim]Next cycle in {pause_seconds}s...[/dim]")
             time.sleep(pause_seconds)
     except KeyboardInterrupt:
-        pass
+        if proc is not None and proc.poll() is None:
+            _kill_process_group(proc)
     except Exception:
         session_status = "crashed"
         raise

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -388,6 +388,90 @@ class TestAutonomousLoop:
         assert mock_killpg.call_count == 1
         mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
 
+    def test_keyboard_interrupt_kills_subprocess_group(self) -> None:
+        """Ctrl+C during communicate() kills the subprocess process group."""
+        import signal
+
+        mock_proc = _mock_popen()
+        mock_proc.communicate.side_effect = KeyboardInterrupt
+        mock_proc.poll.return_value = None  # subprocess still running
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch("os.killpg") as mock_killpg,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1)
+
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_keyboard_interrupt_escalates_to_sigkill(self) -> None:
+        """Ctrl+C escalates to SIGKILL if subprocess doesn't exit after SIGTERM."""
+        import signal
+
+        mock_proc = _mock_popen()
+        mock_proc.communicate.side_effect = KeyboardInterrupt
+        mock_proc.poll.return_value = None
+        mock_proc.wait.side_effect = [
+            _subprocess.TimeoutExpired(cmd="claude", timeout=5),
+            None,
+        ]
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch("os.killpg") as mock_killpg,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1)
+
+        calls = mock_killpg.call_args_list
+        assert calls[0] == ((12345, signal.SIGTERM),)
+        assert calls[1] == ((12345, signal.SIGKILL),)
+
+    def test_keyboard_interrupt_during_sleep_no_kill(self) -> None:
+        """Ctrl+C during sleep between cycles doesn't try to kill exited process."""
+        mock_proc = _mock_popen()
+        mock_proc.poll.return_value = 0  # subprocess already exited
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch("os.killpg") as mock_killpg,
+            patch("time.sleep", side_effect=KeyboardInterrupt),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", pause_seconds=60)
+
+        mock_killpg.assert_not_called()
+
+    def test_keyboard_interrupt_before_first_popen_no_kill(self) -> None:
+        """Ctrl+C before first Popen call doesn't crash (proc is None)."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=KeyboardInterrupt),
+            patch("os.killpg") as mock_killpg,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range")
+
+        mock_killpg.assert_not_called()
+
+    def test_keyboard_interrupt_handles_process_lookup_error(self) -> None:
+        """Ctrl+C doesn't crash if process exits between poll() and killpg()."""
+        mock_proc = _mock_popen()
+        mock_proc.communicate.side_effect = KeyboardInterrupt
+        mock_proc.poll.return_value = None  # subprocess appears running
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch("os.killpg", side_effect=ProcessLookupError),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1)
+
     def test_creates_cycle_log_file(self, tmp_path) -> None:
         """Each cycle writes a log file under GIMMES_HOME/logs/."""
         mock_proc = _mock_popen(output=b"hello from claude\n")


### PR DESCRIPTION
## Summary
- Replace bare `except KeyboardInterrupt: pass` with proper subprocess cleanup — sends SIGTERM to the process group, waits 5s, escalates to SIGKILL
- Extract `_kill_process_group()` helper shared by both the timeout and KeyboardInterrupt handlers, with `ProcessLookupError` guards at each step
- Add 5 new tests covering SIGTERM, SIGKILL escalation, interrupt during sleep, interrupt before Popen, and the ProcessLookupError race condition

Closes #191

## Test plan
- [x] All 583 unit tests pass (`uv run pytest tests/unit/`)
- [x] Lint clean (`uv run ruff check` on changed files)
- [ ] Manual Ctrl+C test during `gimmes driving_range` — verify subprocess is killed and session ends cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)