### PR TITLE
Capture full agent output in cycle log files via JSON format

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1962,6 +1962,12 @@ def _extract_terminal_text(json_bytes: bytes) -> bytes:
     import json as _json
     import logging
 
+    if not json_bytes or not json_bytes.strip():
+        logging.getLogger("gimmes").warning(
+            "Claude subprocess produced no output for this cycle",
+        )
+        return b""
+
     try:
         data = _json.loads(json_bytes)
     except (_json.JSONDecodeError, UnicodeDecodeError):
@@ -1971,11 +1977,12 @@ def _extract_terminal_text(json_bytes: bytes) -> bytes:
         return json_bytes
 
     if isinstance(data, dict):
+        if data.get("is_error"):
+            detail = data.get("result") or data.get("subtype", "unknown")
+            return f"[Claude error: {detail}]\n".encode()
         result = data.get("result")
         if result:
             return (result + "\n").encode("utf-8")
-        if data.get("is_error"):
-            return f"[Claude error: {data.get('subtype', 'unknown')}]\n".encode()
         return b""
 
     return json_bytes

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -538,6 +538,21 @@ class TestExtractTerminalText:
         data = json.dumps({"result": ""}).encode()
         assert _extract_terminal_text(data) == b""
 
+    def test_returns_empty_on_empty_bytes(self) -> None:
+        assert _extract_terminal_text(b"") == b""
+
+    def test_returns_empty_on_whitespace_bytes(self) -> None:
+        assert _extract_terminal_text(b"   \n  ") == b""
+
+    def test_error_with_nonempty_result(self) -> None:
+        import json
+
+        data = json.dumps({
+            "is_error": True, "result": "Rate limit exceeded",
+            "subtype": "rate_limit",
+        }).encode()
+        assert _extract_terminal_text(data) == b"[Claude error: Rate limit exceeded]\n"
+
 
 # ---------------------------------------------------------------------------
 # CLI commands


### PR DESCRIPTION
## Summary
- Switches Claude subprocess from `--output-format text` to `--output-format json` so cycle logs capture all tool calls, sub-agent dispatches, and intermediate CLI output
- Adds `_extract_terminal_text()` helper to extract human-readable summaries for terminal display, with graceful fallback and Claude error handling
- Changes log file extension from `.log` to `.json` for proper tooling support
- Wraps log file write in try-except so disk errors don't crash the trading loop

Closes #195

## Test plan
- [x] 591 tests pass (5 new tests added)
- [x] Lint clean on changed files
- [x] `_extract_terminal_text` tested: valid JSON, invalid JSON, missing result, empty result, Claude error response
- [x] Log file creation and sequential naming verified with JSON extension
- [x] `--output-format json` flag verified in CLI args test

🤖 Generated with [Claude Code](https://claude.com/claude-code)