### PR TITLE
Add failure handling for gh issue create and resolve-error in agents

### DIFF
--- a/.claude/agents/groundskeeper.md
+++ b/.claude/agents/groundskeeper.md
@@ -90,6 +90,8 @@ gh issue create --label "bug" --title "[SEVERITY] Error: ERROR_CODE — BRIEF_DE
 - `network_error` → Check network connectivity and API endpoint reachability
 - `paper_broker` → Inspect paper trading state for inconsistencies
 
+If `gh issue create` fails, note the failure in your output and continue to the next error. Do not retry. Do NOT run `resolve-error` for that error — it must remain unresolved for re-escalation next cycle.
+
 ### Step 4: Mark Resolved
 
 After filing an issue, mark the escalated errors as resolved using the CLI:
@@ -98,7 +100,7 @@ After filing an issue, mark the escalated errors as resolved using the CLI:
 python -m gimmes resolve-error ERROR_ID --issue-url "https://github.com/..."
 ```
 
-Report the issue URL in your output.
+Report the issue URL in your output. If the command fails, note the failure in your output and continue. Do not retry.
 
 ## Output Format
 

--- a/.claude/agents/pro.md
+++ b/.claude/agents/pro.md
@@ -114,6 +114,8 @@ Issue body format:
 Review and update `gimmes.toml` if you agree with this recommendation.
 ~~~
 
+If `gh issue create` fails, note the failure in your output and continue. Do not retry.
+
 ### Step 5: Log Completion (REQUIRED — you are not done until this runs)
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds failure-handling guidance for `gh issue create` in Groundskeeper and Pro agents
- Adds failure-handling guidance for `resolve-error` in Groundskeeper
- Groundskeeper has a conditional gate: if `gh issue create` fails, do NOT run `resolve-error` — error remains unresolved for re-escalation next cycle

Closes #202

## Test plan
- [x] 594 tests pass — agent definition changes only
- [x] Conditional gate prevents silent error swallowing
- [x] Consistent with established failure-handling patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)