### PR TITLE
Replace proc.communicate() with threaded reader to fix Ctrl+C on macOS

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1976,12 +1976,19 @@ def _communicate_interruptible(
     """
     import threading
 
+    if proc.stdout is None:
+        raise ValueError(
+            "_communicate_interruptible requires stdout=PIPE"
+        )
+
+    stdout = proc.stdout  # narrowed to IO[bytes] for the closure
+
     output: list[bytes] = []
     error: list[BaseException] = []
 
     def _reader() -> None:
         try:
-            data = proc.stdout.read()
+            data = stdout.read()
             if data:
                 output.append(data)
         except BaseException as exc:
@@ -2001,7 +2008,16 @@ def _communicate_interruptible(
 
     # Bounded wait to reap the child — stdout is already at EOF so the
     # process should have exited (or be exiting imminently).
-    proc.wait(timeout=5)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        import logging
+
+        logging.getLogger("gimmes").warning(
+            "Subprocess did not exit within 5s after stdout EOF; "
+            "killing process group",
+        )
+        _kill_process_group(proc)
     return b"".join(output)
 
 

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -563,6 +563,28 @@ class TestCommunicateInterruptible:
         with pytest.raises(OSError, match="Broken pipe"):
             _communicate_interruptible(mock_proc, timeout=10)
 
+    def test_raises_value_error_when_stdout_is_none(self) -> None:
+        """Calling with proc.stdout=None raises ValueError immediately."""
+        mock_proc = MagicMock()
+        mock_proc.stdout = None
+        mock_proc.args = ["claude"]
+
+        with pytest.raises(ValueError, match="requires stdout=PIPE"):
+            _communicate_interruptible(mock_proc, timeout=10)
+
+    def test_returns_output_when_proc_wait_hangs(self) -> None:
+        """If proc.wait() times out after stdout EOF, output is still returned."""
+        mock_proc = _mock_popen(output=b"cycle output")
+        mock_proc.wait.side_effect = [
+            _subprocess.TimeoutExpired(cmd=mock_proc.args, timeout=5),
+            None,  # _kill_process_group's proc.wait(timeout=5) succeeds
+        ]
+
+        with patch("os.killpg"):
+            result = _communicate_interruptible(mock_proc, timeout=2700)
+
+        assert result == b"cycle output"
+
 
 # ---------------------------------------------------------------------------
 # _extract_terminal_text


### PR DESCRIPTION
## Summary
- `proc.communicate()` blocks the main thread in a C-level read that cannot be interrupted by SIGINT on macOS (SA_RESTART restarts the underlying syscall), making the KeyboardInterrupt handler from #196 unreachable
- New `_communicate_interruptible()` reads stdout in a daemon thread and waits via `Thread.join()`, which is pure-Python and interruptible by KeyboardInterrupt
- Reader thread exceptions are captured and re-raised in the main thread instead of being silently swallowed

Closes #205

## Test plan
- [x] All 598 unit tests pass
- [x] Lint clean on changed files
- [x] New `TestCommunicateInterruptible` class covers: success, empty output, timeout, and reader exception paths
- [x] Existing KeyboardInterrupt and timeout tests updated to verify behavior through new function

🤖 Generated with [Claude Code](https://claude.com/claude-code)