### PR TITLE
Switch cycle logs to stream-json for full tool call history

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2065,7 +2065,7 @@ def _communicate_interruptible(
     return b"".join(output)
 
 
-def _result_dict_to_text(data: dict) -> bytes:
+def _result_dict_to_text(data: dict[str, object]) -> bytes:
     """Extract terminal text from a Claude result dict."""
     if data.get("is_error"):
         detail = data.get("result") or data.get("subtype", "unknown")
@@ -2146,7 +2146,7 @@ def _wrap_stream_json(raw: bytes) -> bytes:
             events.append(_json.loads(line))
         except (_json.JSONDecodeError, UnicodeDecodeError):
             events.append(line.decode("utf-8", errors="replace"))
-    return _json.dumps(events, indent=2).encode("utf-8")
+    return _json.dumps(events, separators=(",", ":")).encode("utf-8")
 
 
 def _autonomous_loop(

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -648,6 +648,20 @@ class TestExtractTerminalText:
         data = "\n".join(lines).encode()
         assert _extract_terminal_text(data) == b"cycle done\n"
 
+    def test_stream_json_no_result_returns_empty(self, caplog) -> None:
+        import json
+        import logging
+
+        lines = [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps({"type": "assistant", "message": {"text": "working..."}}),
+        ]
+        data = "\n".join(lines).encode()
+        with caplog.at_level(logging.WARNING, logger="gimmes"):
+            result = _extract_terminal_text(data)
+        assert result == b""
+        assert "no result event" in caplog.text
+
     def test_stream_json_error_event(self) -> None:
         import json
 


### PR DESCRIPTION
## Summary
- Switch Claude CLI from `--output-format json` to `--verbose --output-format stream-json` to capture full conversation history (tool calls, sub-agent outputs, intermediate messages)
- Log files now contain a JSON array of all stream events via `_wrap_stream_json`
- `_extract_terminal_text` updated to handle NDJSON format, scanning for the `"type": "result"` event
- Explicit warning logged when stream-json contains no result event (e.g. killed mid-session)

Closes #207

## Test plan
- [x] All 616 unit tests pass
- [x] Lint clean on changed files
- [x] New tests for stream-json extraction, stream-json error event, and `_wrap_stream_json` (single object, NDJSON array, empty lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)