### PR TITLE
Add start activity log to all dispatched agents

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -118,6 +118,14 @@ If `market-info` fails for a candidate, log the candidate with `--price 0 --prob
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 
+MUST log start at the beginning of execution, before any other work:
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent caddie --phase start --message "Caddie starting research on candidates"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 MUST log completion after finishing research on all candidates:
 
 ```bash

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -77,6 +77,14 @@ For rejected candidates:
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 
+MUST log start at the beginning of execution, before any other work:
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent closer --phase start --message "Closer processing approved candidates"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 MUST log completion after processing all candidates:
 
 ```bash

--- a/.claude/agents/groundskeeper.md
+++ b/.claude/agents/groundskeeper.md
@@ -122,6 +122,14 @@ Issues filed: K
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 
+MUST log start at the beginning of execution, before any other work:
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent groundskeeper --phase start --message "Groundskeeper reviewing error log"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 MUST log completion after finishing the error review:
 
 ```bash

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -86,6 +86,14 @@ NEVER skip this step — missing outcome data degrades all Pro analyses. If the 
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 
+MUST log start at the beginning of execution, before any other work:
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent monitor --phase start --message "Monitor checking open positions"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 MUST log completion after producing the monitoring report:
 
 ```bash

--- a/.claude/agents/pro.md
+++ b/.claude/agents/pro.md
@@ -51,6 +51,14 @@ If total closed trades < 20, MUST:
 
 ## Workflow
 
+### Step 0: Log Start
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent pro --phase start --message "Pro starting strategy analysis"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 ### Step 1: Assess Data Availability
 
 ```bash

--- a/.claude/agents/scorecard.md
+++ b/.claude/agents/scorecard.md
@@ -77,6 +77,14 @@ MUST produce this exact format:
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 
+MUST log start at the beginning of execution, before any other work:
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent scorecard --phase start --message "Scorecard generating performance report"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 MUST log completion after producing the scorecard:
 
 ```bash

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -68,6 +68,14 @@ MUST produce a structured shortlist in this exact format:
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 
+MUST log start at the beginning of execution, before any other work:
+
+```bash
+python -m gimmes log-activity --cycle $GIMMES_CYCLE --agent scout --phase start --message "Scout scanning for gimme candidates"
+```
+
+If the command fails, note the failure in your output and continue. Do not retry.
+
 MUST log completion after producing the shortlist:
 
 ```bash


### PR DESCRIPTION
## Summary
- All 7 dispatched agents (Scout, Caddie, Closer, Monitor, Scorecard, Groundskeeper, Pro) now log a `start` activity entry before beginning work
- Follows the same pattern already used by the Caddie Master (the only agent that previously had start logging)
- Enables crash diagnosis: a `start` without a matching `complete` identifies which agent failed
- Enables real-time pipeline progress via the Clubhouse dashboard

Closes #216

## Test plan
- [x] 635 unit tests pass (no source code changes — these are agent definition files)
- [x] All 7 agents use consistent command format matching the Caddie Master pattern
- [x] Failure handling boilerplate present on all additions
- [x] Pro agent uses Step 0 pattern (consistent with its inline workflow structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)