### PR TITLE
Add sqlite3.Error handler to _run; fix typer.Exit inheritance bug

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -42,6 +42,7 @@ def _api_error_detail(e) -> str:  # type: ignore[no-untyped-def]
 def _run(coro):  # type: ignore[no-untyped-def]
     """Run an async coroutine from sync CLI context with error handling."""
     import logging
+    import sqlite3
 
     import httpx
 
@@ -63,6 +64,12 @@ def _run(coro):  # type: ignore[no-untyped-def]
         logger.debug("Transport error", exc_info=True)
         console.print(f"[red]Connection error: {e}[/red]")
         raise typer.Exit(1)
+    except sqlite3.Error as e:
+        logger.debug("Database error", exc_info=True)
+        console.print(f"[red]Database error: {e}[/red]")
+        raise typer.Exit(1)
+    except typer.Exit:
+        raise
     except (ConnectionError, ValueError, RuntimeError) as e:
         logger.debug("CLI error", exc_info=True)
         console.print(f"[red]Error: {e}[/red]")
@@ -1328,16 +1335,17 @@ def log_outcome(
 
         async with Database(config.db_path) as db:
             updated = await update_trade_outcome(db, ticker, outcome)
-            if updated:
-                console.print(
-                    f"[green]Recorded outcome '{outcome}' for"
-                    f" {updated} trade(s) on {ticker}[/green]"
-                )
-            else:
-                console.print(
-                    f"[yellow]No trades found for {ticker}"
-                    " (or already recorded)[/yellow]"
-                )
+
+        if updated:
+            console.print(
+                f"[green]Recorded outcome '{outcome}' for"
+                f" {updated} trade(s) on {ticker}[/green]"
+            )
+        else:
+            console.print(
+                f"[yellow]No trades found for {ticker}"
+                " (or already recorded)[/yellow]"
+            )
 
     _run(_log())
 


### PR DESCRIPTION
## Summary

- Centralize `sqlite3.Error` handling in `_run()` so all CLI commands get clean `[red]Database error: ...[/red]` messages instead of raw tracebacks on DB failure
- Fix a pre-existing latent bug: `typer.Exit` inherits from `RuntimeError` (via `click.exceptions.Exit`), so without an `except typer.Exit: raise` guard, any `typer.Exit` raised inside an async coroutine was caught by `_run`'s `except RuntimeError` handler, producing duplicate/garbled error output
- Move `log-outcome` display logic outside the `async with` block (shorter connection hold)

Closes #230

## Test plan

- [ ] 661 tests passing, lint clean
- [ ] `gimmes log-activity --cycle 0 --agent test --phase start --message "test"` with a valid DB → clean green output
- [ ] With an invalid/locked DB path → single clean `[red]Database error: ...[/red]` message, exit code 1 (no duplicate "Error: 1")

🤖 Generated with [Claude Code](https://claude.com/claude-code)