### PR TITLE
Fix timestamp parsing for timezone-aware ISO strings

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -407,7 +407,7 @@
         function formatTimestamp(ts) {
             if (!ts) return '--';
             const iso = ts.replace(' ', 'T');
-            const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(iso);
+            const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/.test(iso);
             const d = new Date(hasTimezone ? iso : iso + 'Z');
             return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
         }


### PR DESCRIPTION
## Summary
- `formatTimestamp()` in the Clubhouse dashboard appended `Z` to timestamps that already contained timezone offsets (`+00:00` from Python's `datetime.isoformat()`), producing unparseable strings like `2026-03-18T09:27:55.105718+00:00Z`
- Replaced the naive `endsWith('Z')` check with a single regex `/Z|[+-]\d{2}:\d{2}$/` that detects both `Z` and `±HH:MM` timezone suffixes
- Affects all three `formatTimestamp()` call sites: activity log, error log, and trades table

Closes #222

## Test plan
- [ ] Open Clubhouse dashboard with trades that have timezone-aware timestamps — verify times display correctly
- [ ] Verify activity log and error log timestamps still render properly
- [ ] Confirm timestamps from SQLite `datetime('now')` (space-separated, no TZ) still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)