### PR TITLE
Fix formatPercent() to convert fractional values to percentages

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -379,7 +379,7 @@
 
         function formatPercent(val) {
             if (val == null || isNaN(val)) return '0%';
-            return parseFloat(val).toFixed(1) + '%';
+            return (parseFloat(val) * 100).toFixed(1) + '%';
         }
 
         function colorForPnl(val) {


### PR DESCRIPTION
## Summary
- `formatPercent()` displayed backend fractional values (0.15 = 15%) as-is with a `%` suffix, showing "0.2%" instead of "15.0%"
- Added `* 100` multiplication before formatting — all 6+ call sites verified to pass fractional values
- Fixes risk gauges (daily loss, largest position), win rate, max drawdown, total return, and candidate edge displays

Closes #223

## Test plan
- [ ] Open Clubhouse dashboard — verify risk gauge labels show correct percentages (e.g., "15.0%" not "0.2%")
- [ ] Check win rate, max drawdown, and total return metrics display correctly
- [ ] Verify candidate edge column shows proper percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)