### PR TITLE
Build equity curve from trade history when snapshots are empty

### DIFF
--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -297,11 +297,7 @@ async def get_metrics(db_path: Path) -> MetricsResponse:
             resp.total_return = metrics.total_return
             resp.total_return_pct = metrics.total_return_pct
 
-            # Equity curve data for charting
-            resp.equity_curve = [
-                {"timestamp": s.get("timestamp", ""), "equity": s.get("total_equity", 0)}
-                for s in snapshots
-            ]
+            resp.equity_curve = metrics.equity_curve
     except Exception:
         logger.warning("get_metrics failed", exc_info=True)
 

--- a/src/gimmes/reporting/metrics.py
+++ b/src/gimmes/reporting/metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -19,6 +19,7 @@ class PerformanceMetrics:
     sharpe_ratio: float = 0.0
     total_return: float = 0.0
     total_return_pct: float = 0.0
+    equity_curve: list[dict] = field(default_factory=list)  # type: ignore[type-arg]
 
 
 def calculate_max_drawdown(equity_curve: list[float]) -> tuple[float, float]:
@@ -67,6 +68,49 @@ def calculate_sharpe(returns: list[float], risk_free_rate: float = 0.0) -> float
     return (mean / std) * math.sqrt(252)
 
 
+def _equity_curve_from_trades(
+    trades: list[dict],  # type: ignore[type-arg]
+    initial_bankroll: float,
+) -> list[dict]:  # type: ignore[type-arg]
+    """Build a cash-balance equity curve from trade history."""
+    cash = initial_bankroll
+    curve: list[dict] = []  # type: ignore[type-arg]
+    for t in sorted(trades, key=lambda x: x.get("timestamp", "")):
+        action = t.get("action", "")
+        cost = t.get("count", 0) * t.get("price", 0.0)
+        if action in ("open", "size_up"):
+            cash -= cost
+        elif action == "close":
+            cash += cost
+        else:
+            continue
+        curve.append({"timestamp": t.get("timestamp", ""), "equity": cash})
+    return curve
+
+
+def _apply_equity_curve(
+    metrics: PerformanceMetrics,
+    curve: list[dict],  # type: ignore[type-arg]
+    initial_bankroll: float,
+) -> None:
+    """Populate drawdown, return, Sharpe, and equity_curve on *metrics*."""
+    equity_values = [pt["equity"] for pt in curve]
+    metrics.max_drawdown, metrics.max_drawdown_pct = calculate_max_drawdown(
+        equity_values
+    )
+    if initial_bankroll > 0:
+        metrics.total_return = equity_values[-1] - initial_bankroll
+        metrics.total_return_pct = metrics.total_return / initial_bankroll
+    if len(equity_values) >= 2:
+        daily_returns = [
+            (equity_values[i] - equity_values[i - 1]) / equity_values[i - 1]
+            for i in range(1, len(equity_values))
+            if equity_values[i - 1] > 0
+        ]
+        metrics.sharpe_ratio = calculate_sharpe(daily_returns)
+    metrics.equity_curve = curve
+
+
 def calculate_metrics(
     trades: list[dict],  # type: ignore[type-arg]
     snapshots: list[dict],  # type: ignore[type-arg]
@@ -102,23 +146,16 @@ def calculate_metrics(
     if predicted_edges:
         metrics.avg_edge_predicted = sum(predicted_edges) / len(predicted_edges)
 
-    # Equity curve from snapshots
+    # Equity curve — prefer snapshots, fall back to trade-derived curve
     if snapshots:
-        equity_curve = [s.get("total_equity", 0) for s in snapshots]
-        if equity_curve:
-            metrics.max_drawdown, metrics.max_drawdown_pct = calculate_max_drawdown(equity_curve)
-
-            if initial_bankroll > 0 and equity_curve:
-                metrics.total_return = equity_curve[-1] - initial_bankroll
-                metrics.total_return_pct = metrics.total_return / initial_bankroll
-
-            # Daily returns for Sharpe
-            if len(equity_curve) >= 2:
-                daily_returns = [
-                    (equity_curve[i] - equity_curve[i - 1]) / equity_curve[i - 1]
-                    for i in range(1, len(equity_curve))
-                    if equity_curve[i - 1] > 0
-                ]
-                metrics.sharpe_ratio = calculate_sharpe(daily_returns)
+        curve = [
+            {"timestamp": s.get("timestamp", ""), "equity": s.get("total_equity", 0)}
+            for s in snapshots
+        ]
+        _apply_equity_curve(metrics, curve, initial_bankroll)
+    elif trades and initial_bankroll > 0:
+        curve = _equity_curve_from_trades(trades, initial_bankroll)
+        if curve:
+            _apply_equity_curve(metrics, curve, initial_bankroll)
 
     return metrics

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -105,3 +105,58 @@ class TestCalculateMetrics:
         ]
         metrics = calculate_metrics([], snapshots)
         assert metrics.max_drawdown == 3000.0
+
+    def test_equity_curve_from_snapshots(self) -> None:
+        snapshots = [
+            {"timestamp": "2026-03-18T10:00:00", "total_equity": 10000},
+            {"timestamp": "2026-03-18T11:00:00", "total_equity": 10500},
+        ]
+        metrics = calculate_metrics([], snapshots, initial_bankroll=10000)
+        assert len(metrics.equity_curve) == 2
+        assert metrics.equity_curve[0]["equity"] == 10000
+        assert metrics.equity_curve[1]["equity"] == 10500
+
+    def test_equity_curve_fallback_from_trades(self) -> None:
+        trades = [
+            {"action": "open", "ticker": "A", "price": 0.60, "count": 10,
+             "timestamp": "2026-03-18T10:00:00"},
+            {"action": "close", "ticker": "A", "price": 0.80, "count": 10,
+             "timestamp": "2026-03-18T11:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [], initial_bankroll=100.0)
+        assert len(metrics.equity_curve) == 2
+        # After open: 100 - (10 * 0.60) = 94.0
+        assert metrics.equity_curve[0]["equity"] == 94.0
+        # After close: 94 + (10 * 0.80) = 102.0
+        assert metrics.equity_curve[1]["equity"] == 102.0
+        assert metrics.total_return == 2.0
+
+    def test_equity_curve_fallback_with_size_up(self) -> None:
+        trades = [
+            {"action": "open", "ticker": "A", "price": 0.60, "count": 10,
+             "timestamp": "2026-03-18T10:00:00"},
+            {"action": "size_up", "ticker": "A", "price": 0.65, "count": 5,
+             "timestamp": "2026-03-18T10:30:00"},
+            {"action": "close", "ticker": "A", "price": 0.80, "count": 15,
+             "timestamp": "2026-03-18T11:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [], initial_bankroll=100.0)
+        assert len(metrics.equity_curve) == 3
+        # open: 100 - 6.0 = 94.0
+        assert metrics.equity_curve[0]["equity"] == 94.0
+        # size_up: 94 - 3.25 = 90.75
+        assert metrics.equity_curve[1]["equity"] == 90.75
+        # close: 90.75 + 12.0 = 102.75
+        assert metrics.equity_curve[2]["equity"] == 102.75
+
+    def test_equity_curve_empty_when_no_data(self) -> None:
+        metrics = calculate_metrics([], [])
+        assert metrics.equity_curve == []
+
+    def test_equity_curve_fallback_skips_without_bankroll(self) -> None:
+        trades = [
+            {"action": "open", "ticker": "A", "price": 0.60, "count": 10,
+             "timestamp": "2026-03-18T10:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [], initial_bankroll=0)
+        assert metrics.equity_curve == []


### PR DESCRIPTION
## Summary
- `insert_snapshot()` is never called from production code, so the snapshots table is always empty and the equity curve chart shows nothing
- Added fallback in `calculate_metrics()` that builds a cash-balance equity curve from trade history: opens/size_ups reduce cash, closes add cash
- Extracted `_apply_equity_curve()` helper to share drawdown/Sharpe/return logic between snapshot and trade-derived paths
- Simplified `data.py` to use `metrics.equity_curve` directly instead of building from raw snapshots

Closes #225

## Test plan
- [ ] Open Clubhouse dashboard after trades — verify equity curve chart shows data points
- [ ] Verify drawdown and total return metrics are computed from trade data
- [ ] Confirm snapshot-based curve still works when snapshots exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)