### PR TITLE
Fix Ctrl+C in gimmes clubhouse by overriding uvicorn handle_exit

### DIFF
--- a/src/gimmes/clubhouse/server.py
+++ b/src/gimmes/clubhouse/server.py
@@ -238,7 +238,7 @@ def run_standalone(
         timer.start()
 
     def _force_exit(_sig: int, _frame: object) -> None:
-        print("\n  Clubhouse stopped.")
+        print("\n  Clubhouse stopped.", flush=True)
         os._exit(0)
 
     config = uvicorn.Config(

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -344,7 +344,8 @@ class TestRunStandalone:
         handler = stub["server"].handle_exit
         exit_codes: list[int] = []
         monkeypatch.setattr("os._exit", lambda code: exit_codes.append(code))
-        handler(2, None)  # signal.SIGINT = 2
+        import signal
+        handler(signal.SIGINT, None)
         assert exit_codes == [0]
 
 


### PR DESCRIPTION
## Summary
- `gimmes clubhouse` hung on Ctrl+C because uvicorn's `capture_signals()` unconditionally overwrites signal handlers, making the custom `signal.signal(SIGINT, ...)` approach ineffective
- Replaced with `server.handle_exit = _force_exit` which uvicorn registers as its own signal handler via `capture_signals()`
- `_force_exit` calls `os._exit(0)` to bypass graceful shutdown that hangs on SSE connections
- Removed the no-op `server.install_signal_handlers = lambda: None` (this attribute doesn't exist in uvicorn 0.41.0)

Closes #227

## Test plan
- [ ] Run `gimmes clubhouse` and press Ctrl+C — should exit immediately with "Clubhouse stopped."
- [ ] Verify the dashboard still works normally before pressing Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)