### PR TITLE
Clubhouse UX: error/skip toggles, scroll fixes, config overflow

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -272,7 +272,7 @@
                         </thead>
                         <tbody id="trades-body" class="font-mono">
                             <tr>
-                                <td colspan="8" class="text-center text-slate-500 py-8">No recent trades</td>
+                                <td colspan="8" class="text-center text-slate-500 py-8">No trades</td>
                             </tr>
                         </tbody>
                     </table>
@@ -444,14 +444,14 @@
         // ------------------------------------------------------------------
         // Action badge color
         // ------------------------------------------------------------------
+        const actionColors = {
+            open:    'bg-emerald-500/20 text-emerald-400',
+            buy:     'bg-emerald-500/20 text-emerald-400',
+            close:   'bg-cyan-500/20 text-cyan-400',
+            sell:    'bg-cyan-500/20 text-cyan-400',
+            size_up: 'bg-amber-500/20 text-amber-400',
+        };
         function actionBadge(action) {
-            const actionColors = {
-                open:    'bg-emerald-500/20 text-emerald-400',
-                buy:     'bg-emerald-500/20 text-emerald-400',
-                close:   'bg-cyan-500/20 text-cyan-400',
-                sell:    'bg-cyan-500/20 text-cyan-400',
-                size_up: 'bg-amber-500/20 text-amber-400',
-            };
             const key = (action || '').toLowerCase();
             const cls = actionColors[key] || 'bg-slate-500/20 text-slate-400';
             return '<span class="px-1.5 py-0.5 rounded text-xs font-medium ' + cls + '">' + escapeHtml(action || '--') + '</span>';
@@ -813,7 +813,7 @@
                 Object.keys(data).forEach(function(key) {
                     const val = data[key];
                     const displayVal = Array.isArray(val)
-                        ? '<span title="' + escapeHtml(val.join(', ')) + '">' + val.length + ' items</span>'
+                        ? '<span title="' + escapeHtml(val.join(', ')).replace(/"/g, '&quot;') + '">' + val.length + ' items</span>'
                         : escapeHtml(String(val));
                     html += '<div class="flex justify-between gap-2">'
                         + '<dt class="text-slate-500 truncate">' + escapeHtml(key) + '</dt>'


### PR DESCRIPTION
## Summary
- **Error Log**: Resolved errors hidden by default; "Show resolved" toggle reveals them. Shows "All errors resolved" when all cleared
- **Trade Log**: Renamed from "Recent Trades". Skip actions hidden by default with "Show skips" toggle. Added `max-h-[300px]` vertical scroll
- **Candidate Pipeline**: Increased max-h from 300px to 400px to fit more cards before scrolling
- **Configuration**: Array values (e.g., scanner series list) display as "N items" with hover tooltip instead of raw overflow
- **Action badges**: Added amber badge for `size_up` action; refactored to lookup map
- **Deferred**: Ticker title display filed as #246

Closes #228

## Test plan
- [ ] Open dashboard with errors — verify only unresolved show by default, toggle reveals resolved
- [ ] Check Trade Log filters out "skip" actions, toggle shows them
- [ ] Verify Trade Log and Candidate Pipeline scroll properly when content exceeds panel height
- [ ] Check Configuration > Scanner shows "N items" with tooltip instead of long overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)