### PR TITLE
Fix unawaited coroutine warnings in test_autonomous_loop.py

### DIFF
--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -99,7 +99,7 @@ class TestAutonomousLoop:
             patch("gimmes.store.session.end_session"),
             patch("gimmes.store.session.mark_stale_sessions", return_value=0),
             patch("gimmes.store.session.update_session_cycle"),
-            patch("asyncio.run"),
+            patch("asyncio.run", side_effect=lambda coro: coro.close()),
         ):
             yield
 


### PR DESCRIPTION
## Summary
- Changed `patch("asyncio.run")` to `patch("asyncio.run", side_effect=lambda coro: coro.close())` in the test fixture
- Properly disposes of the `_ensure_db` coroutine passed to the mocked `asyncio.run`, eliminating ~10 `RuntimeWarning: coroutine was never awaited` warnings per test run
- Test output goes from 8+ warnings to 0 warnings

Closes #237

## Test plan
- [x] 681 tests pass with 0 warnings (was 8+ warnings before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)