### PR TITLE
Store side-appropriate market_price for NO positions

### DIFF
--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -542,12 +542,13 @@ class PaperBroker:
                 else:
                     unrealized = (avg_price - current_price) * count
 
+                stored_price = current_price if side == "yes" else 1 - current_price
                 await self._conn.execute(
                     """UPDATE paper_positions
                        SET market_price = ?, unrealized_pnl = ?,
                            updated_at = datetime('now')
                        WHERE ticker = ? AND side = ?""",
-                    (current_price, unrealized, ticker, side),
+                    (stored_price, unrealized, ticker, side),
                 )
 
     async def settle(self, ticker: str, result: str) -> None:

--- a/tests/unit/test_paper_broker.py
+++ b/tests/unit/test_paper_broker.py
@@ -263,6 +263,26 @@ class TestMarkToMarket:
         """Mark-to-market on nonexistent ticker is a no-op."""
         await broker.mark_to_market("NONEXISTENT", 0.50)  # Should not raise
 
+    @pytest.mark.asyncio
+    async def test_mark_to_market_no_side_stores_no_price(
+        self, broker: PaperBroker, orderbook: Orderbook
+    ) -> None:
+        """NO-side positions store 1 - yes_price as market_price."""
+        params = CreateOrderParams(
+            ticker="TEST-MKT",
+            action=OrderAction.BUY,
+            side=OrderSide.NO,
+            count=10,
+            no_price=0.32,
+            post_only=True,
+        )
+        await broker.create_order(params, orderbook)
+
+        await broker.mark_to_market("TEST-MKT", 0.60)
+        positions = await broker.get_positions()
+        no_pos = [p for p in positions if p.side == "no"][0]
+        assert no_pos.market_price == pytest.approx(0.40)  # 1 - 0.60
+
 
 # ---------------------------------------------------------------------------
 # Settlement


### PR DESCRIPTION
## Summary
- `mark_to_market()` stored the YES midpoint as `market_price` for both YES and NO positions
- Now computes `stored_price = current_price if side == "yes" else 1 - current_price` before the UPDATE
- Fixes incorrect `market_value` for NO positions in the Clubhouse dashboard
- Filed #249 for the related unrealized P&L formula bug (pre-existing, separate scope)

Closes #242

## Test plan
- [x] New test verifies NO position stores `0.40` as market_price when YES midpoint is `0.60`
- [ ] Verify portfolio value correctly reflects NO position values in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)