### PR TITLE
Fix NO-side unrealized P&L to use NO-price space

### DIFF
--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -537,12 +537,8 @@ class PaperBroker:
                 avg_price = float(row["avg_price"])
                 side = row["side"]
 
-                if side == "yes":
-                    unrealized = (current_price - avg_price) * count
-                else:
-                    unrealized = (avg_price - current_price) * count
-
                 stored_price = current_price if side == "yes" else 1 - current_price
+                unrealized = (stored_price - avg_price) * count
                 await self._conn.execute(
                     """UPDATE paper_positions
                        SET market_price = ?, unrealized_pnl = ?,

--- a/tests/unit/test_paper_broker.py
+++ b/tests/unit/test_paper_broker.py
@@ -283,6 +283,48 @@ class TestMarkToMarket:
         no_pos = [p for p in positions if p.side == "no"][0]
         assert no_pos.market_price == pytest.approx(0.40)  # 1 - 0.60
 
+    @pytest.mark.asyncio
+    async def test_mark_to_market_no_side_unrealized_pnl(
+        self, broker: PaperBroker, orderbook: Orderbook
+    ) -> None:
+        """NO-side unrealized P&L uses NO-price space, not YES-price."""
+        params = CreateOrderParams(
+            ticker="TEST-MKT",
+            action=OrderAction.BUY,
+            side=OrderSide.NO,
+            count=10,
+            no_price=0.32,
+            post_only=True,
+        )
+        await broker.create_order(params, orderbook)
+
+        # YES midpoint = 0.60 → NO price = 0.40 > entry ~0.32 → profit
+        await broker.mark_to_market("TEST-MKT", 0.60)
+        positions = await broker.get_positions()
+        no_pos = [p for p in positions if p.side == "no"][0]
+        assert no_pos.unrealized_pnl > 0
+
+    @pytest.mark.asyncio
+    async def test_mark_to_market_no_side_price_drop(
+        self, broker: PaperBroker, orderbook: Orderbook
+    ) -> None:
+        """NO-side shows negative unrealized P&L when NO price drops."""
+        params = CreateOrderParams(
+            ticker="TEST-MKT",
+            action=OrderAction.BUY,
+            side=OrderSide.NO,
+            count=10,
+            no_price=0.32,
+            post_only=True,
+        )
+        await broker.create_order(params, orderbook)
+
+        # YES midpoint = 0.90 → NO price = 0.10 < entry ~0.32 → loss
+        await broker.mark_to_market("TEST-MKT", 0.90)
+        positions = await broker.get_positions()
+        no_pos = [p for p in positions if p.side == "no"][0]
+        assert no_pos.unrealized_pnl < 0
+
 
 # ---------------------------------------------------------------------------
 # Settlement


### PR DESCRIPTION
## Summary
- The NO-side unrealized P&L formula `(avg_price - current_price) * count` mixed NO-price `avg_price` with YES-price `current_price`, producing wrong-sign results
- Unified both sides into `(stored_price - avg_price) * count` where `stored_price` is already in the position's native price space
- This simplifies the code from a branching if/else to two straight-line statements

Closes #249

## Test plan
- [x] New test: NO position is profitable when NO price rises above entry (YES drops)
- [x] New test: NO position shows loss when NO price falls below entry (YES rises)
- [x] Existing YES-side tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)