### PR TITLE
Fix Trade Log panel height to fill available space

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -256,7 +256,7 @@
                         Show skips
                     </button>
                 </h2>
-                <div class="max-h-[300px] overflow-x-auto overflow-y-auto scrollbar-thin">
+                <div class="max-h-[400px] overflow-x-auto overflow-y-auto scrollbar-thin">
                     <table class="w-full text-sm">
                         <thead>
                             <tr class="text-xs uppercase tracking-wider text-slate-500 border-b border-slate-700/50">


### PR DESCRIPTION
## Summary
- Increased the Trade Log scroll container's `max-height` from 300px to 400px to match the adjacent Candidate Pipeline panel, eliminating the dead space below the Trade Log

Closes #253

## Test plan
- [ ] Open the Clubhouse dashboard with "Show skips" enabled and many trade entries
- [ ] Verify the Trade Log panel now fills vertical space to match the Candidate Pipeline height
- [ ] Verify scroll behavior still works correctly within the Trade Log

🤖 Generated with [Claude Code](https://claude.com/claude-code)