### PR TITLE
Replace ticker tooltips with clickable detail modal

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -350,7 +350,7 @@
         <div class="relative bg-slate-800 border border-slate-700/50 rounded-xl shadow-2xl w-full max-w-lg mx-4 max-h-[80vh] overflow-y-auto scrollbar-thin">
             <div class="flex items-center justify-between px-5 py-4 border-b border-slate-700/50">
                 <h3 id="detail-modal-title" class="text-lg font-bold text-white"></h3>
-                <button id="detail-modal-close" class="text-slate-400 hover:text-white transition-colors">
+                <button type="button" id="detail-modal-close" class="text-slate-400 hover:text-white transition-colors">
                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                     </svg>
@@ -373,7 +373,6 @@
         let lastErrors = null;
         let showSkipTrades = false;
         let lastTrades = null;
-        let lastPositions = null;
         let evtSource = null;
         const tickerTitles = {};
 
@@ -642,7 +641,6 @@
         }
 
         function updatePositions(positions) {
-            lastPositions = positions;
             const tbody = document.getElementById('positions-body');
             if (!positions || positions.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="7" class="text-center text-slate-500 py-8">No open positions</td></tr>';


### PR DESCRIPTION
## Summary
- Add a detail modal to the Clubhouse dashboard that opens when clicking any row in the Trade Log or Open Positions tables
- Modal shows all available fields: rationale/thesis, edge, model probability, market value, realized P&L — data not visible in the compact table view
- Remove now-redundant title-attribute tooltips on ticker cells
- Deferred market details (resolution date, volume, open interest) to #265 — requires backend API changes

Closes #254

## Test plan
- [ ] Open Clubhouse dashboard with open positions and trades
- [ ] Click a row in the Open Positions table — verify modal opens with position details
- [ ] Click a row in the Trade Log — verify modal opens with trade details including rationale
- [ ] Verify modal closes via X button, backdrop click, and Escape key
- [ ] Enable "Show skips" and click a skip row — verify modal shows skip details
- [ ] Verify ticker cells no longer show browser-native tooltips on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)