### PR TITLE
Add accessibility semantics to detail modal

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -539,12 +539,18 @@
             if (e.key === 'Escape') { closeModal(); return; }
             if (e.key !== 'Tab') return;
 
-            var focusable = modal.querySelectorAll(
+            const focusable = modal.querySelectorAll(
                 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
             );
             if (focusable.length === 0) { e.preventDefault(); return; }
-            var first = focusable[0];
-            var last = focusable[focusable.length - 1];
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const focusableArr = Array.prototype.slice.call(focusable);
+            if (focusableArr.indexOf(document.activeElement) === -1) {
+                e.preventDefault();
+                (e.shiftKey ? last : first).focus();
+                return;
+            }
             if (e.shiftKey && document.activeElement === first) {
                 e.preventDefault();
                 last.focus();


### PR DESCRIPTION
## Summary
- Add ARIA attributes to modal container: `role="dialog"`, `aria-modal="true"`, `aria-labelledby="detail-modal-title"`
- Add `aria-label="Close"` to the icon-only close button
- Focus management: auto-focus close button on open, restore focus to triggering row on close
- Focus trapping: Tab/Shift+Tab cycle within the open modal, preventing focus escape
- Keyboard-activatable table rows: `tabindex="0"` + Enter/Space handlers on Trade Log and Open Positions rows
- Extracted `activate()` helper and `handleModalKeydown` named function for cleaner structure

Closes #267

## Test plan
- [ ] Tab to a row in Trade Log or Open Positions — verify focus ring is visible
- [ ] Press Enter or Space on a focused row — verify modal opens
- [ ] Verify focus moves to the close button when modal opens
- [ ] Press Tab repeatedly — verify focus stays within the modal (cycles back to close button)
- [ ] Press Shift+Tab — verify focus wraps backward
- [ ] Press Escape — verify modal closes and focus returns to the row that opened it
- [ ] Click backdrop — verify same focus restoration behavior
- [ ] Test with a screen reader (VoiceOver on macOS): verify modal is announced as a dialog with the correct title

🤖 Generated with [Claude Code](https://claude.com/claude-code)