### PR TITLE
Add position side filter toggle with lastPositions cache

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -1095,8 +1095,8 @@
         }
 
         function cyclePositionFilter() {
-            var cycle = ['all', 'yes', 'no'];
-            var labels = { all: 'All sides', yes: 'YES only', no: 'NO only' };
+            const cycle = ['all', 'yes', 'no'];
+            const labels = { all: 'All sides', yes: 'YES only', no: 'NO only' };
             positionSideFilter = cycle[(cycle.indexOf(positionSideFilter) + 1) % cycle.length];
             document.getElementById('filter-positions-btn').textContent = labels[positionSideFilter];
             if (lastPositions) updatePositions(lastPositions);


### PR DESCRIPTION
## Summary
- Add a cycling filter button ("All sides" / "YES only" / "NO only") to the Open Positions panel header
- Mirror the existing Trade Log "Show skips" toggle pattern: cache positions in `lastPositions`, filter to `visible`, re-render from cache on toggle
- Empty-state messages reflect the active filter ("No YES positions" / "No NO positions")
- Populate `tickerTitles` from the full unfiltered set before filtering to preserve modal title lookups

Closes #268

## Test plan
- [ ] Open Clubhouse with open positions on both YES and NO sides
- [ ] Click "All sides" button — verify it cycles to "YES only" and table shows only YES positions
- [ ] Click again — verify "NO only" filter shows only NO positions
- [ ] Click again — verify "All sides" shows all positions
- [ ] When filtered to a side with no positions, verify message says "No YES positions" or "No NO positions"
- [ ] Click a row while filtered — verify detail modal opens with correct position data
- [ ] Verify filter persists across SSE data updates (new data arrives, filter stays applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)