### PR TITLE
Deduplicate candidate pipeline display by ticker

### DIFF
--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -245,13 +245,18 @@ async def get_trades(db_path: Path, limit: int = 500) -> list[TradeItem]:
 
 
 async def get_candidates(db_path: Path, limit: int = 20) -> list[CandidateItem]:
-    """Get recent scanned candidates."""
+    """Get most recent assessment per candidate ticker."""
     items: list[CandidateItem] = []
 
     try:
         async with _connect(db_path) as conn:
             cursor = await conn.execute(
-                "SELECT * FROM candidates ORDER BY scanned_at DESC LIMIT ?", (limit,)
+                "SELECT c.* FROM candidates c"
+                " INNER JOIN ("
+                "   SELECT MAX(id) AS max_id FROM candidates GROUP BY ticker"
+                " ) latest ON c.id = latest.max_id"
+                " ORDER BY c.scanned_at DESC LIMIT ?",
+                (limit,),
             )
             rows = await cursor.fetchall()
             for row in rows:

--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -953,7 +953,7 @@
         }
 
         function tradeEmptyRow() {
-            var msg = tradeEmptyMsgs[tradeFilter] || 'No entries today';
+            const msg = tradeEmptyMsgs[tradeFilter] || 'No entries today';
             return '<tr><td colspan="8" class="text-center text-slate-500 py-8">' + msg + '</td></tr>';
         }
 

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -162,6 +162,22 @@ class TestDataLayer:
         assert candidates[0].ticker == "CAND-YES"
         assert candidates[0].gimme_score == 85
 
+    async def test_get_candidates_deduplicates_by_ticker(self, db_path: Path) -> None:
+        """Only the most recent assessment per ticker is returned (#257)."""
+        async with Database(db_path) as db:
+            await db.conn.execute(
+                """INSERT INTO candidates (ticker, title, market_price,
+                   model_probability, edge, gimme_score, research_memo)
+                   VALUES ('CAND-YES', 'Updated', 0.75, 0.98, 0.23, 92, 'New memo')"""
+            )
+            await db.conn.commit()
+        candidates = await get_candidates(db_path)
+        # Two rows for CAND-YES exist, but only the latest should be returned
+        cand_yes = [c for c in candidates if c.ticker == "CAND-YES"]
+        assert len(cand_yes) == 1
+        assert cand_yes[0].gimme_score == 92
+        assert cand_yes[0].title == "Updated"
+
     async def test_get_metrics(self, db_path: Path) -> None:
         metrics = await get_metrics(db_path)
         assert isinstance(metrics, MetricsResponse)


### PR DESCRIPTION
## Summary
- `get_candidates()` now uses a `MAX(id) GROUP BY ticker` subquery to return only the most recent assessment per ticker, eliminating duplicate entries when the same ticker is researched across multiple cycles
- The limit applies to unique tickers rather than raw rows, so the panel shows more distinct candidates
- Caddie research cooldown (#275) and cap-blocked opportunity surfacing (#276) filed as separate issues

Closes #257

## Test plan
- [ ] `uv run pytest tests/unit/test_clubhouse.py` — 36 tests pass (1 new for deduplication)
- [ ] Verify inserting two candidates for the same ticker returns only the latest
- [ ] Verify existing single-candidate behavior is unchanged
- [ ] Full suite: `uv run pytest tests/unit/` — 689 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)