### PR TITLE
Surface cap-blocked opportunities in candidate pipeline

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -181,11 +181,13 @@ Evaluate the output using these rules:
    ```
 3. **Prior score 60-74** (borderline) → re-research ONLY if the current market price (from the Scout's shortlist) differs from the prior `Price` by more than 5 cents. Otherwise skip with rationale noting price unchanged.
 4. **Prior score >= 75 with open position** (check `python -m gimmes positions` for the ticker) → skip, already traded
-5. **Prior score >= 75, no open position** → likely cap-blocked or rejected by validation. Send to Caddie with context that prior research exists.
+5. **Prior score >= 75, no open position** → check the Status column for "CAP BLOCKED". If cap-blocked, prioritize: send to Caddie first with context that this is a cap-blocked re-evaluation. If not cap-blocked (rejected for other reasons), send to Caddie with context that prior research exists.
 
 #### 4b. Dispatch Caddie
 
 Dispatch the **Caddie** agent to research ALL candidates that passed the cooldown check.
+
+**Priority rule:** Process cap-blocked candidates before new candidates when dispatching to Caddie.
 
 **Completeness rule (MUST follow — no exceptions):** Every candidate from the Scout's shortlist MUST be accounted for — either sent to Caddie (passed cooldown) or logged as a skip with cooldown rationale. The Caddie Master MUST NOT silently drop candidates.
 

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -58,9 +58,14 @@ If the order command fails (non-zero exit code or error output), MUST:
 
 When ANY safety check fails, MUST:
 1. Log the skip with the specific failure reason
-2. If the log-trade command fails, note the failure in your output and continue. Do not retry failed log commands.
-3. Report the rejection in the Execution Report with the specific failed check(s)
-4. NEVER override or retry — a failed check is final for this cycle
+2. **If the rejection was due to session spending cap** (validate output contains "Session spending cap exceeded"): mark the candidate as cap-blocked:
+   ```bash
+   python -m gimmes mark-cap-blocked TICKER
+   ```
+   If the command fails, note the failure in your output and continue.
+3. If the log-trade command fails, note the failure in your output and continue. Do not retry failed log commands.
+4. Report the rejection in the Execution Report with the specific failed check(s)
+5. NEVER override or retry — a failed check is final for this cycle
 
 ## Output Format
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1015,21 +1015,45 @@ def candidates(
         table.add_column("Price", justify="right")
         table.add_column("Prob", justify="right")
         table.add_column("Edge", justify="right")
+        table.add_column("Status")
         table.add_column("Scanned")
 
         for c in records:
+            status = "[yellow]CAP BLOCKED[/yellow]" if c.get("cap_blocked") else ""
             table.add_row(
                 str(c.get("ticker", "")),
                 f"{c.get('gimme_score', 0):.0f}",
                 f"${c.get('market_price', 0):.2f}",
                 f"{c.get('model_probability', 0):.0%}",
                 f"{c.get('edge', 0):+.1%}",
+                status,
                 str(c.get("scanned_at", ""))[:19],
             )
 
         console.print(table)
 
     _run(_candidates())
+
+
+@app.command(name="mark-cap-blocked")
+def mark_cap_blocked_cmd(
+    ticker: str = typer.Argument(..., help="Market ticker"),
+) -> None:
+    """Mark the most recent candidate for a ticker as cap-blocked."""
+
+    async def _mark() -> None:
+        from gimmes.store.database import Database
+        from gimmes.store.queries import mark_cap_blocked
+
+        async with Database() as db:
+            updated = await mark_cap_blocked(db, ticker)
+        if updated:
+            console.print(f"[yellow]Marked {ticker} as cap-blocked[/yellow]")
+        else:
+            console.print(f"[red]No candidate found for {ticker}[/red]")
+            raise typer.Exit(1)
+
+    _run(_mark())
 
 
 @app.command()

--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -269,6 +269,7 @@ async def get_candidates(db_path: Path, limit: int = 20) -> list[CandidateItem]:
                     gimme_score=row["gimme_score"],
                     research_memo=row["research_memo"],
                     scanned_at=row["scanned_at"],
+                    cap_blocked=bool(_row_get(row, "cap_blocked", 0)),
                 ))
     except Exception:
         logger.warning("get_candidates failed", exc_info=True)

--- a/src/gimmes/clubhouse/models.py
+++ b/src/gimmes/clubhouse/models.py
@@ -60,6 +60,7 @@ class CandidateItem(BaseModel):
     gimme_score: float = 0.0
     research_memo: str = ""
     scanned_at: str = ""
+    cap_blocked: bool = False
 
 
 class MetricsResponse(BaseModel):

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -90,6 +90,11 @@ _V10_COLUMNS: list[str] = [
     "ALTER TABLE activity_log ADD COLUMN session_id INTEGER DEFAULT NULL",
 ]
 
+# ALTER TABLE ADD COLUMN statements for v12: cap_blocked flag on candidates.
+_V12_COLUMNS: list[str] = [
+    "ALTER TABLE candidates ADD COLUMN cap_blocked INTEGER NOT NULL DEFAULT 0",
+]
+
 
 async def get_schema_version(db: Database) -> int:
     """Get the current schema version."""
@@ -231,5 +236,14 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 11
+
+    # Version 12: cap_blocked flag on candidates (#276)
+    if current < 12:
+        await _run_alter_columns(db, _V12_COLUMNS)
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (12,)
+        )
+        await db.conn.commit()
+        current = 12
 
     return current

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -286,6 +286,7 @@ async def insert_candidate(
     score: float,
     memo: str,
     *,
+    cap_blocked: bool = False,
     edge_size_score: float = 0,
     signal_strength_score: float = 0,
     liquidity_depth_score: float = 0,
@@ -299,15 +300,30 @@ async def insert_candidate(
     cursor = await db.conn.execute(
         """INSERT INTO candidates
            (ticker, title, market_price, model_probability, edge, gimme_score,
-            research_memo, edge_size_score, signal_strength_score,
+            research_memo, cap_blocked, edge_size_score, signal_strength_score,
             liquidity_depth_score, settlement_clarity_score, time_to_resolution_score)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (ticker, title, market_price, model_prob, edge, score, memo,
-         edge_size_score, signal_strength_score, liquidity_depth_score,
-         settlement_clarity_score, time_to_resolution_score),
+         int(cap_blocked), edge_size_score, signal_strength_score,
+         liquidity_depth_score, settlement_clarity_score,
+         time_to_resolution_score),
     )
     await db.conn.commit()
     return cursor.lastrowid or 0
+
+
+async def mark_cap_blocked(db: Database, ticker: str) -> bool:
+    """Mark the most recent candidate for a ticker as cap-blocked.
+
+    Returns True if a row was updated, False otherwise.
+    """
+    cursor = await db.conn.execute(
+        "UPDATE candidates SET cap_blocked = 1"
+        " WHERE id = (SELECT MAX(id) FROM candidates WHERE ticker = ?)",
+        (ticker,),
+    )
+    await db.conn.commit()
+    return cursor.rowcount > 0
 
 
 # ---------------------------------------------------------------------------

--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -1013,6 +1013,7 @@
                 html += '<div class="bg-slate-700/30 border border-slate-600/30 rounded-lg p-3">'
                     + '<div class="flex items-center justify-between mb-1">'
                     + '<span class="text-cyan-400 font-mono font-semibold text-sm">' + escapeHtml(c.ticker || '--') + '</span>'
+                    + (c.cap_blocked ? '<span class="ml-2 px-1.5 py-0.5 rounded text-xs font-medium bg-amber-500/20 text-amber-400 border border-amber-500/30">Cap blocked</span>' : '')
                     + '<div class="flex items-center gap-3 text-xs font-mono">'
                     + '<span class="text-slate-400">Mkt: ' + formatPrice(c.market_price) + '</span>'
                     + '<span class="text-slate-300">Score: ' + (c.gimme_score != null ? parseFloat(c.gimme_score).toFixed(1) : '--') + '</span>'

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -178,6 +178,21 @@ class TestDataLayer:
         assert cand_yes[0].gimme_score == 92
         assert cand_yes[0].title == "Updated"
 
+    async def test_get_candidates_includes_cap_blocked(self, db_path: Path) -> None:
+        """Cap-blocked flag is surfaced in CandidateItem (#276)."""
+        async with Database(db_path) as db:
+            await db.conn.execute(
+                """INSERT INTO candidates (ticker, title, market_price,
+                   model_probability, edge, gimme_score, research_memo,
+                   cap_blocked)
+                   VALUES ('CAP-MKT', 'Blocked', 0.70, 0.90, 0.20, 82, 'memo', 1)"""
+            )
+            await db.conn.commit()
+        candidates = await get_candidates(db_path)
+        cap_mkt = [c for c in candidates if c.ticker == "CAP-MKT"]
+        assert len(cap_mkt) == 1
+        assert cap_mkt[0].cap_blocked is True
+
     async def test_get_metrics(self, db_path: Path) -> None:
         metrics = await get_metrics(db_path)
         assert isinstance(metrics, MetricsResponse)

--- a/tests/unit/test_thesis_journal.py
+++ b/tests/unit/test_thesis_journal.py
@@ -23,6 +23,7 @@ from gimmes.store.queries import (
     insert_candidate,
     insert_position_note,
     insert_trade,
+    mark_cap_blocked,
 )
 
 
@@ -305,3 +306,38 @@ class TestGetCandidateForTicker:
         assert row["edge"] == 0.25
         assert row["gimme_score"] == 85
         assert "scanned_at" in row
+
+
+# ---------------------------------------------------------------------------
+# mark_cap_blocked (#276)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkCapBlocked:
+    async def test_marks_most_recent_candidate(self, db: Database) -> None:
+        await insert_candidate(db, "CAP-TICKER", "T", 0.70, 0.90, 0.20, 80, "memo")
+        updated = await mark_cap_blocked(db, "CAP-TICKER")
+        assert updated is True
+        rows = await get_candidate_for_ticker(db, "CAP-TICKER")
+        assert rows[0]["cap_blocked"] == 1
+
+    async def test_returns_false_when_no_match(self, db: Database) -> None:
+        updated = await mark_cap_blocked(db, "NONEXISTENT")
+        assert updated is False
+
+    async def test_only_marks_latest_row(self, db: Database) -> None:
+        await insert_candidate(db, "MULTI-CAP", "T", 0.70, 0.90, 0.20, 70, "old")
+        await insert_candidate(db, "MULTI-CAP", "T", 0.73, 0.92, 0.19, 85, "new")
+        await mark_cap_blocked(db, "MULTI-CAP")
+        rows = await get_candidate_for_ticker(db, "MULTI-CAP", limit=2)
+        # Latest (higher id) is marked, older is not
+        assert rows[0]["cap_blocked"] == 1
+        assert rows[1]["cap_blocked"] == 0
+
+    async def test_insert_with_cap_blocked_flag(self, db: Database) -> None:
+        await insert_candidate(
+            db, "FLAG-TICKER", "T", 0.70, 0.90, 0.20, 80, "memo",
+            cap_blocked=True,
+        )
+        rows = await get_candidate_for_ticker(db, "FLAG-TICKER")
+        assert rows[0]["cap_blocked"] == 1


### PR DESCRIPTION
## Summary
- Migration v12: adds `cap_blocked INTEGER NOT NULL DEFAULT 0` column to candidates table
- New `mark_cap_blocked()` query function: updates the most recent candidate row for a ticker
- New `gimmes mark-cap-blocked TICKER` CLI command (exits 1 if no candidate found)
- `CandidateItem` model includes `cap_blocked: bool` field
- Dashboard renders amber "Cap blocked" badge on candidate cards
- `candidates` CLI command shows "CAP BLOCKED" status column
- Closer agent: calls `mark-cap-blocked` when rejecting due to session spending cap
- Caddie Master: prioritizes cap-blocked candidates during cooldown check

Closes #276

## Test plan
- [ ] `uv run pytest tests/unit/` — 698 tests pass (5 new)
- [ ] Verify `mark_cap_blocked()` marks only the most recent candidate row
- [ ] Verify `mark-cap-blocked` exits 1 when no candidate found
- [ ] Verify `get_candidates()` surfaces `cap_blocked=True` in CandidateItem
- [ ] Verify dashboard renders amber badge for cap-blocked candidates
- [ ] Verify `gimmes candidates` shows Status column with "CAP BLOCKED"

🤖 Generated with [Claude Code](https://claude.com/claude-code)