### PR TITLE
Switch Agent Activity panel to daily scope with filters

### DIFF
--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -375,8 +375,8 @@ async def get_risk(db_path: Path) -> RiskResponse:
     return resp
 
 
-async def get_activity(db_path: Path, limit: int = 50) -> list[ActivityItem]:
-    """Get recent activity log entries."""
+async def get_activity(db_path: Path) -> list[ActivityItem]:
+    """Get today's activity log entries."""
     items: list[ActivityItem] = []
 
     try:
@@ -386,7 +386,9 @@ async def get_activity(db_path: Path, limit: int = 50) -> list[ActivityItem]:
                 return items
 
             cursor = await conn.execute(
-                "SELECT * FROM activity_log ORDER BY id DESC LIMIT ?", (limit,)
+                "SELECT * FROM activity_log"
+                " WHERE date(timestamp) = date('now')"
+                " ORDER BY id DESC"
             )
             rows = await cursor.fetchall()
             for row in rows:

--- a/src/gimmes/clubhouse/server.py
+++ b/src/gimmes/clubhouse/server.py
@@ -155,7 +155,7 @@ async def api_stream() -> StreamingResponse:
                     portfolio = await data.get_portfolio(_db_path)
                     positions = await data.get_positions(_db_path)
                     risk = await data.get_risk(_db_path)
-                    activity = await data.get_activity(_db_path, limit=20)
+                    activity = await data.get_activity(_db_path)
                     trades = await data.get_trades(_db_path)
                     candidates = await data.get_candidates(_db_path, limit=10)
                     metrics = await data.get_metrics(_db_path)

--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -235,7 +235,29 @@
         <!-- ROW 5: AGENT ACTIVITY FEED                                      -->
         <!-- ================================================================ -->
         <div class="bg-slate-800/60 border border-slate-700/50 rounded-xl p-5">
-            <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400 mb-3">Agent Activity</h2>
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400 mb-3 flex items-center gap-2">
+                Agent Activity
+                <select id="activity-agent-filter" onchange="changeActivityFilter()"
+                    aria-label="Filter by agent"
+                    class="ml-auto text-xs text-slate-400 bg-slate-700 border border-slate-600 rounded px-1.5 py-0.5 font-normal normal-case tracking-normal focus:outline-none focus:border-slate-500">
+                    <option value="all" selected>All agents</option>
+                    <option value="caddie-master">caddie-master</option>
+                    <option value="scout">scout</option>
+                    <option value="caddie">caddie</option>
+                    <option value="closer">closer</option>
+                    <option value="monitor">monitor</option>
+                    <option value="scorecard">scorecard</option>
+                    <option value="groundskeeper">groundskeeper</option>
+                    <option value="pro">pro</option>
+                </select>
+                <select id="activity-phase-filter" onchange="changeActivityFilter()"
+                    aria-label="Filter by phase"
+                    class="text-xs text-slate-400 bg-slate-700 border border-slate-600 rounded px-1.5 py-0.5 font-normal normal-case tracking-normal focus:outline-none focus:border-slate-500">
+                    <option value="all" selected>All phases</option>
+                    <option value="start">start</option>
+                    <option value="complete">complete</option>
+                </select>
+            </h2>
             <div id="activity-feed" class="max-h-[200px] overflow-y-auto scrollbar-thin space-y-1.5">
                 <div id="activity-empty" class="flex items-center justify-center py-10 text-slate-500 text-sm">
                     No active loop -- start one with <code class="ml-1.5 px-2 py-0.5 bg-slate-700/50 rounded text-slate-400 font-mono text-xs">gimmes driving_range</code>
@@ -392,6 +414,9 @@
         let showResolvedErrors = false;
         let lastErrors = null;
         let tradeFilter = 'trades';
+        let activityAgentFilter = 'all';
+        let activityPhaseFilter = 'all';
+        let lastActivity = null;
         const tradeEmptyMsgs = { all: 'No entries today', trades: 'No trades today', skips: 'No skips today' };
         let lastTrades = null;
         let positionSideFilter = 'all';
@@ -905,7 +930,22 @@
             }
         }
 
+        function filterActivity(activity) {
+            return activity.filter(function(entry) {
+                if (activityAgentFilter !== 'all' && (entry.agent || '').toLowerCase() !== activityAgentFilter) return false;
+                if (activityPhaseFilter !== 'all' && (entry.phase || '').toLowerCase() !== activityPhaseFilter) return false;
+                return true;
+            });
+        }
+
+        function changeActivityFilter() {
+            activityAgentFilter = document.getElementById('activity-agent-filter').value;
+            activityPhaseFilter = document.getElementById('activity-phase-filter').value;
+            if (lastActivity) updateActivity(lastActivity);
+        }
+
         function updateActivity(activity) {
+            lastActivity = activity;
             const feed = document.getElementById('activity-feed');
             const emptyEl = document.getElementById('activity-empty');
 
@@ -914,8 +954,14 @@
                 return;
             }
 
+            const visible = filterActivity(activity);
+            if (visible.length === 0) {
+                feed.innerHTML = '<div class="flex items-center justify-center py-10 text-slate-500 text-sm">No matching activity</div>';
+                return;
+            }
+
             let html = '';
-            activity.forEach(function(entry) {
+            visible.forEach(function(entry) {
                 html += '<div class="flex items-start gap-2 py-1.5 px-2 rounded hover:bg-slate-700/20 transition-colors text-sm">'
                     + '<span class="text-xs font-mono text-slate-500 shrink-0 mt-0.5 min-w-[65px]">' + formatTimestamp(entry.timestamp) + '</span>'
                     + agentBadge(entry.agent)

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -208,6 +208,18 @@ class TestDataLayer:
         assert activity[0].agent == "scout"
         assert activity[0].cycle == 1
 
+    async def test_get_activity_excludes_yesterday(self, db_path: Path) -> None:
+        """Daily-scoped query excludes activity from previous days."""
+        async with Database(db_path) as db:
+            await db.conn.execute(
+                """INSERT INTO activity_log (cycle, agent, phase, message, timestamp)
+                   VALUES (0, 'monitor', 'start', 'old entry', datetime('now', '-1 day'))"""
+            )
+            await db.conn.commit()
+        activity = await get_activity(db_path)
+        assert len(activity) == 1
+        assert activity[0].message == "Found 3 candidates"
+
     async def test_get_errors_data(self, db_path: Path) -> None:
         errors = await get_errors_data(db_path)
         assert len(errors) == 1


### PR DESCRIPTION
## Summary
- Switch activity query from fixed `LIMIT 20` to daily scope (`date(timestamp) = date('now')`)
- Add client-side agent filter (caddie-master, scout, caddie, closer, monitor, scorecard, groundskeeper, pro)
- Add client-side phase filter (start, complete)
- Follows the same pattern as the existing Daily Log filters

Closes #259

## Test plan
- [x] All 693 unit tests pass
- [x] New test verifies yesterday's activity is excluded from daily scope
- [x] Lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)