### PR TITLE
Fix Total Equity double-counting position cost basis

### DIFF
--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -161,7 +161,7 @@ async def get_portfolio(db_path: Path) -> PortfolioResponse:
 
             # Recalculate total equity if we have live balance
             if resp.balance > 0:
-                resp.total_equity = resp.balance + resp.unrealized_pnl
+                resp.total_equity = resp.balance + resp.portfolio_value
     except Exception:
         logger.warning("get_portfolio failed", exc_info=True)
 

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -127,6 +127,7 @@ class TestDataLayer:
         portfolio = await get_portfolio(db_path)
         assert portfolio.balance == 9500.0
         assert portfolio.portfolio_value == pytest.approx(7.0)  # 10 * 0.70
+        assert portfolio.total_equity == pytest.approx(9507.0)  # 9500 + 7.0
 
     async def test_get_positions(self, db_path: Path) -> None:
         positions = await get_positions(db_path)


### PR DESCRIPTION
## Summary
- Fix `total_equity = balance + unrealized_pnl` → `balance + portfolio_value`
- Balance already has cost_basis deducted; adding unrealized_pnl (market_value - cost_basis) double-subtracted it
- Add regression test assertion for total_equity

Closes #260

## Test plan
- [x] All 693 unit tests pass
- [x] New assertion verifies total_equity = 9500 + 7.0 = 9507.0 (would have been 9500.50 with old formula)

🤖 Generated with [Claude Code](https://claude.com/claude-code)