### PR TITLE
Add --agent flag to order command for trade attribution

### DIFF
--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -18,7 +18,7 @@ For each approved candidate (GimmeScore >= 75, Caddie recommends PROCEED), execu
 
 1. **Validate**: `python -m gimmes validate TICKER --prob P` — MUST pass all checks. If ANY check fails → MUST reject (go to step 5).
 2. **Size**: `python -m gimmes size TICKER --prob P` — MUST run only after validate passes.
-3. **Order**: `python -m gimmes order TICKER --prob P --yes` — MUST run only after steps 1-2 pass.
+3. **Order**: `python -m gimmes order TICKER --prob P --yes --agent closer` — MUST run only after steps 1-2 pass.
 4. **Log success**: The order command logs the trade and syncs positions atomically — no separate log-trade needed.
 5. **Log rejection** (if steps 1-2 failed): `python -m gimmes log-trade TICKER --action skip --prob P --score S --rationale "[which check failed and why]" --agent closer`. If the command fails, note the failure in your output and continue. Do not retry.
 6. **Log completion** (see Activity Logging below)
@@ -29,7 +29,7 @@ When Caddie Master dispatches you for a SIZE UP (adding to an existing position)
 
 1. **Validate**: `python -m gimmes validate TICKER --prob P --size-up` — MUST pass all checks. The `--size-up` flag allows the duplicate position check to pass.
 2. **Size**: `python -m gimmes size TICKER --prob P`
-3. **Order**: `python -m gimmes order TICKER --prob P --size-up --yes`
+3. **Order**: `python -m gimmes order TICKER --prob P --size-up --yes --agent closer`
 4. **Log success**: The order command logs the trade atomically.
 5. **Log rejection** (if steps 1-2 failed): `python -m gimmes log-trade TICKER --action skip --prob P --score 0 --rationale "SIZE UP rejected: [which check failed]" --agent closer`
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -460,6 +460,9 @@ def order(
     size_up: bool = typer.Option(
         False, "--size-up", help="Allow adding to existing position (SIZE UP)",
     ),
+    agent: str = typer.Option(
+        "cli", "--agent", help="Agent identifier for trade/error logging",
+    ),
 ) -> None:
     """Place an order on Kalshi (runs pre-trade validation first)."""
     config = load_config()
@@ -702,7 +705,7 @@ def order(
                         severity=ErrorSeverity.ERROR,
                         category=ErrorCategory.ORDER_FAILURE,
                         error_code="http_status_error",
-                        component="cli.order", agent="cli",
+                        component="cli.order", agent=agent,
                         message=f"Order placement failed ({exc.response.status_code}): {detail}",
                         stack_trace=traceback.format_exc(),
                         context=json.dumps({"ticker": ticker, "side": side,
@@ -723,7 +726,7 @@ def order(
                         severity=ErrorSeverity.ERROR,
                         category=ErrorCategory.ORDER_FAILURE,
                         error_code="timeout",
-                        component="cli.order", agent="cli",
+                        component="cli.order", agent=agent,
                         message=f"Order placement timed out: {exc}",
                         stack_trace=traceback.format_exc(),
                         context=json.dumps({"ticker": ticker, "side": side,
@@ -754,7 +757,7 @@ def order(
                         severity=ErrorSeverity.ERROR,
                         category=ErrorCategory.ORDER_FAILURE,
                         error_code=error_code,
-                        component="cli.order", agent="cli",
+                        component="cli.order", agent=agent,
                         message=f"Order placement failed: {exc}",
                         stack_trace=traceback.format_exc(),
                         context=json.dumps({"ticker": ticker, "side": side,
@@ -821,9 +824,9 @@ def order(
                             if probability is not None
                             else 0.0
                         ),
-                        rationale="CLI order",
+                        rationale=f"{agent} order",
                         thesis=thesis,
-                        agent="cli",
+                        agent=agent,
                         order_id=result.order_id,
                     )
                     await sync_positions_with_trade(
@@ -840,7 +843,7 @@ def order(
                         severity=ErrorSeverity.WARNING,
                         category=ErrorCategory.DATA_INTEGRITY,
                         error_code="position_sync_db_error",
-                        component="cli.order", agent="cli",
+                        component="cli.order", agent=agent,
                         message=f"Position sync failed after order {result.order_id}: {exc}",
                         stack_trace=traceback.format_exc(),
                         context=json.dumps({"ticker": ticker, "side": side,
@@ -866,7 +869,7 @@ def order(
                         severity=ErrorSeverity.WARNING,
                         category=ErrorCategory.DATA_INTEGRITY,
                         error_code="position_sync_failed",
-                        component="cli.order", agent="cli",
+                        component="cli.order", agent=agent,
                         message=f"Position sync failed after order {result.order_id}: {exc}",
                         stack_trace=traceback.format_exc(),
                         context=json.dumps({"ticker": ticker, "side": side,

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -89,7 +89,7 @@ def _stub_config():
 
 def _run_order_cli(
     broker, *, sync_side_effect=None, championship_create_order=None,
-    insert_error_side_effect=None,
+    insert_error_side_effect=None, extra_args=None,
 ):
     """Invoke the order CLI command with a mocked broker."""
     mock_console = MagicMock()
@@ -161,7 +161,8 @@ def _run_order_cli(
         from gimmes.cli import app
 
         runner = CliRunner()
-        result = runner.invoke(app, _ORDER_CLI_ARGS)
+        cli_args = _ORDER_CLI_ARGS + (extra_args or [])
+        result = runner.invoke(app, cli_args)
     finally:
         for p in patches:
             p.stop()
@@ -379,6 +380,28 @@ class TestOrderErrorLogging:
         assert ctx["side"] == "yes"
         assert ctx["count"] == 10
         assert ctx["price"] == 0.40
+
+    def test_agent_flag_propagates_to_error_log(self) -> None:
+        """The --agent flag value flows through to error log entries."""
+        exc = httpx.ReadTimeout("timeout")
+        broker = _make_mock_broker(create_order_side_effect=exc)
+
+        _, _, mock_insert = _run_order_cli(
+            broker, extra_args=["--agent", "closer"],
+        )
+
+        entry = _error_entry(mock_insert)
+        assert entry.agent == "closer"
+
+    def test_agent_defaults_to_cli(self) -> None:
+        """Without --agent, error logs default to 'cli'."""
+        exc = httpx.ReadTimeout("timeout")
+        broker = _make_mock_broker(create_order_side_effect=exc)
+
+        _, _, mock_insert = _run_order_cli(broker)
+
+        entry = _error_entry(mock_insert)
+        assert entry.agent == "cli"
 
 
 class TestErrorLoggingResilience:


### PR DESCRIPTION
## Summary
- Add `--agent` parameter to `order` command (default: `"cli"`)
- Thread it through all 6 trade/error logging sites (was hardcoded `agent="cli"`)
- Update Closer agent to pass `--agent closer` for proper attribution
- Fix `rationale` to use agent name instead of hardcoded "CLI order"

Closes #264

## Test plan
- [x] All 696 unit tests pass (2 new)
- [x] New test verifies `--agent closer` propagates to error log entries
- [x] New test verifies default `agent="cli"` when flag not passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)