### PR TITLE
Remove championship mode hook, add trading gravity reinforcement

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,2 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -qE '(gimmes order|gimmes trade|create_order)' && [ \"$GIMMES_MODE\" = 'championship' ]; then echo '⚠️  CHAMPIONSHIP MODE: This will place a REAL MONEY order on Kalshi. Proceed with caution.' >&2; fi; exit 0"
-          }
-        ]
-      }
-    ]
-  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,4 @@ The following rules apply exclusively to named agents defined in `.claude/agents
 - You have a specific role. Follow your agent definition exclusively — it contains everything you need.
 - Never modify source code, agent definitions, or configuration to fix a problem. Log it and continue your work.
 - Only interact with the trading system through the `gimmes` CLI. Never directly access the database or call the Kalshi API.
+- Every trade is a capital deployment decision. Be certain before you act.


### PR DESCRIPTION
## Summary
- Remove PreToolUse hook from settings.json that warned about championship mode orders (leaked mode awareness to agents)
- Add "Every trade is a capital deployment decision. Be certain before you act." to CLAUDE.md Agent Rules

Closes #272

## Test plan
- [x] All 696 unit tests pass (config-only change, no code modified)
- [x] CLI's own `typer.confirm()` gates remain for championship mode orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)