### PR TITLE
Add config-sync command and integrate into gimmes update

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -200,6 +200,10 @@ case "${1:-}" in
         else
             "$PYTHON" -m pip install -e . --quiet
         fi
+        # Sync user config with latest example (add new keys, remove deprecated)
+        if [ -f "$GIMMES_HOME/config/gimmes.toml" ]; then
+            "$PYTHON" -m gimmes config-sync || echo "Warning: config sync failed (run 'gimmes config-sync' manually)"
+        fi
         show_banner
         echo "Updated to $update_label"
         ;;

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2120,6 +2120,53 @@ def config(
     run_config_wizard(section_filter=section)
 
 
+@app.command("config-sync")
+def config_sync() -> None:
+    """Sync gimmes.toml with the latest example config (add new keys, remove deprecated)."""
+    from gimmes.config import DEFAULT_CONFIG_PATH
+    from gimmes.config_sync import EXAMPLE_TOML_PATH, sync_config
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        console.print(
+            f"[red]Config file not found at {DEFAULT_CONFIG_PATH}[/red]\n"
+            "Run [bold]gimmes init[/bold] first."
+        )
+        raise typer.Exit(1)
+
+    if not EXAMPLE_TOML_PATH.exists():
+        console.print(
+            f"[red]Example config not found at {EXAMPLE_TOML_PATH}[/red]\n"
+            "Your gimmes installation may be corrupted."
+        )
+        raise typer.Exit(1)
+
+    try:
+        result = sync_config(DEFAULT_CONFIG_PATH, EXAMPLE_TOML_PATH)
+    except Exception as exc:
+        console.print(
+            f"[yellow]Config sync skipped: {exc}[/yellow]\n"
+            "Your config file may have a syntax error. "
+            "Run [bold]gimmes config[/bold] or edit the file manually."
+        )
+        raise typer.Exit(1)
+
+    if not result.added and not result.removed:
+        console.print("[dim]Config is up to date.[/dim]")
+        return
+
+    console.print("[bold]Config synced.[/bold]")
+    if result.added:
+        console.print(f"  [green]Added ({len(result.added)}):[/green]")
+        for key in result.added:
+            console.print(f"    {key}")
+    if result.removed:
+        console.print(f"  [yellow]Removed ({len(result.removed)}):[/yellow]")
+        for key in result.removed:
+            console.print(f"    {key}")
+    if result.added:
+        console.print("\nRun [bold]gimmes config[/bold] to review new settings.")
+
+
 @app.command()
 def init(
     headless: bool = typer.Option(

--- a/src/gimmes/config_sync.py
+++ b/src/gimmes/config_sync.py
@@ -1,0 +1,114 @@
+"""Config sync — keep user's gimmes.toml aligned with the example template."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import tomlkit
+
+from gimmes.config_wizard import _get_nested, _load_toml, _save_toml, _set_nested
+
+# Example config lives in the repo checkout
+EXAMPLE_TOML_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "gimmes.example.toml"
+
+
+@dataclass
+class SyncResult:
+    """Summary of config sync changes."""
+
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+
+
+def _flatten_keys(doc: tomlkit.TOMLDocument, prefix: str = "") -> set[str]:
+    """Recursively collect all leaf dotted keys from a TOML document."""
+    keys: set[str] = set()
+    for key, value in doc.items():
+        dotted = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+        if isinstance(value, dict):
+            keys.update(_flatten_keys(value, dotted))
+        else:
+            keys.add(dotted)
+    return keys
+
+
+def _remove_nested(doc: tomlkit.TOMLDocument, dotted_key: str) -> None:
+    """Remove a leaf key from a TOML document, pruning empty parent tables."""
+    parts = dotted_key.split(".")
+    # Navigate to the parent
+    parents: list[tuple[dict, str]] = []
+    current: dict = doc  # type: ignore[assignment]
+    for part in parts[:-1]:
+        if part not in current:
+            return
+        parents.append((current, part))
+        current = current[part]
+    # Remove the leaf
+    leaf = parts[-1]
+    if leaf in current:
+        del current[leaf]
+    # Prune empty parent tables bottom-up
+    for parent, key in reversed(parents):
+        child = parent[key]
+        if isinstance(child, dict) and len(child) == 0:
+            del parent[key]
+
+
+def sync_config(
+    user_path: Path,
+    example_path: Path | None = None,
+) -> SyncResult:
+    """Sync user config with the example template.
+
+    Adds new keys from the example, removes deprecated keys not in the
+    example. Never modifies existing user values.
+    """
+    example_path = example_path or EXAMPLE_TOML_PATH
+    if not example_path.exists():
+        raise FileNotFoundError(f"Example config not found: {example_path}")
+    if not user_path.exists():
+        raise FileNotFoundError(f"User config not found: {user_path}")
+
+    example_doc = _load_toml(example_path)
+    user_doc = _load_toml(user_path)
+
+    example_keys = _flatten_keys(example_doc)
+    if not example_keys:
+        raise ValueError("Example config has no keys — refusing to sync")
+
+    user_keys = _flatten_keys(user_doc)
+
+    to_add = sorted(example_keys - user_keys)
+    to_remove = sorted(user_keys - example_keys)
+
+    for key in to_remove:
+        _remove_nested(user_doc, key)
+
+    for key in to_add:
+        value = _get_nested(example_doc, key)
+        _set_nested(user_doc, key, value)
+
+    if to_add or to_remove:
+        _save_toml(user_doc, user_path)
+
+    return SyncResult(added=to_add, removed=to_remove)
+
+
+def new_keys(
+    user_path: Path,
+    example_path: Path | None = None,
+) -> set[str]:
+    """Return dotted keys in user config that still have their example default value."""
+    example_path = example_path or EXAMPLE_TOML_PATH
+    if not user_path.exists() or not example_path.exists():
+        return set()
+    example_doc = _load_toml(example_path)
+    user_doc = _load_toml(user_path)
+    result: set[str] = set()
+    for key in _flatten_keys(example_doc):
+        user_val = _get_nested(user_doc, key)
+        example_val = _get_nested(example_doc, key)
+        if user_val is not None and user_val == example_val:
+            result.add(key)
+    return result

--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -576,11 +576,17 @@ def _parse_input(raw: str, setting: Setting) -> int | float | str | list[str]:
     return raw
 
 
-def _prompt_setting(setting: Setting, current_value: object) -> object:
+def _prompt_setting(
+    setting: Setting, current_value: object, *, is_new: bool = False,
+) -> object:
     """Prompt the user for a single setting. Returns the new value or current if skipped."""
     display = _format_current(current_value, setting)
 
-    console.print(f"\n  [bold]{setting.name}[/bold]")
+    if is_new:
+        label = f"[bold yellow] NEW [/bold yellow] [bold]{setting.name}[/bold]"
+    else:
+        label = f"[bold]{setting.name}[/bold]"
+    console.print(f"\n  {label}")
     console.print(f"  Current value: [cyan]{display}[/cyan]")
 
     # Show description indented
@@ -632,6 +638,10 @@ def run_config_wizard(section_filter: str | None = None) -> None:
 
     doc = _load_toml(TOML_FILE)
 
+    from gimmes.config_sync import EXAMPLE_TOML_PATH, new_keys
+
+    new_key_set = new_keys(TOML_FILE, EXAMPLE_TOML_PATH)
+
     console.print("\n[bold cyan]GIMMES Configuration Wizard[/bold cyan]")
     console.print("[dim]Walk through each setting. Press Enter to keep the current value.[/dim]\n")
 
@@ -659,7 +669,7 @@ def run_config_wizard(section_filter: str | None = None) -> None:
             if current is None:
                 current = setting.default
 
-            new_value = _prompt_setting(setting, current)
+            new_value = _prompt_setting(setting, current, is_new=setting.key in new_key_set)
             if new_value != current:
                 _set_nested(doc, setting.key, new_value)
                 changed = True

--- a/tests/unit/test_config_sync.py
+++ b/tests/unit/test_config_sync.py
@@ -1,0 +1,127 @@
+"""Unit tests for config sync."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomlkit
+
+from gimmes.config_sync import (
+    _flatten_keys,
+    _remove_nested,
+    new_keys,
+    sync_config,
+)
+
+
+def _write_toml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestFlattenKeys:
+    def test_simple(self) -> None:
+        doc = tomlkit.parse("[strategy]\ngimme_threshold = 75\n")
+        assert _flatten_keys(doc) == {"strategy.gimme_threshold"}
+
+    def test_nested(self) -> None:
+        doc = tomlkit.parse("[scoring.weights]\nedge_size = 0.30\n")
+        assert _flatten_keys(doc) == {"scoring.weights.edge_size"}
+
+    def test_empty(self) -> None:
+        doc = tomlkit.document()
+        assert _flatten_keys(doc) == set()
+
+    def test_multiple_sections(self) -> None:
+        doc = tomlkit.parse("[a]\nx = 1\n[b]\ny = 2\n")
+        assert _flatten_keys(doc) == {"a.x", "b.y"}
+
+
+class TestRemoveNested:
+    def test_removes_leaf(self) -> None:
+        doc = tomlkit.parse("[strategy]\na = 1\nb = 2\n")
+        _remove_nested(doc, "strategy.b")
+        assert "b" not in doc["strategy"]
+        assert doc["strategy"]["a"] == 1
+
+    def test_prunes_empty_parent(self) -> None:
+        doc = tomlkit.parse("[old_section]\nkey = 1\n")
+        _remove_nested(doc, "old_section.key")
+        assert "old_section" not in doc
+
+    def test_no_op_for_missing_key(self) -> None:
+        doc = tomlkit.parse("[a]\nx = 1\n")
+        _remove_nested(doc, "a.nonexistent")
+        assert doc["a"]["x"] == 1
+
+
+class TestSyncConfig:
+    def test_no_changes(self, tmp_path: Path) -> None:
+        content = "[strategy]\ngimme_threshold = 75\n"
+        _write_toml(tmp_path / "user.toml", content)
+        _write_toml(tmp_path / "example.toml", content)
+
+        result = sync_config(tmp_path / "user.toml", tmp_path / "example.toml")
+        assert result.added == []
+        assert result.removed == []
+
+    def test_adds_new_key(self, tmp_path: Path) -> None:
+        _write_toml(tmp_path / "user.toml", "[strategy]\na = 1\n")
+        _write_toml(tmp_path / "example.toml", "[strategy]\na = 1\nb = 2\n")
+
+        result = sync_config(tmp_path / "user.toml", tmp_path / "example.toml")
+        assert result.added == ["strategy.b"]
+        assert result.removed == []
+
+        # Verify the file was updated
+        doc = tomlkit.parse((tmp_path / "user.toml").read_text())
+        assert doc["strategy"]["b"] == 2
+
+    def test_removes_deprecated_key(self, tmp_path: Path) -> None:
+        _write_toml(tmp_path / "user.toml", "[strategy]\na = 1\nold = 99\n")
+        _write_toml(tmp_path / "example.toml", "[strategy]\na = 1\n")
+
+        result = sync_config(tmp_path / "user.toml", tmp_path / "example.toml")
+        assert result.added == []
+        assert result.removed == ["strategy.old"]
+
+        doc = tomlkit.parse((tmp_path / "user.toml").read_text())
+        assert "old" not in doc["strategy"]
+
+    def test_preserves_existing_values(self, tmp_path: Path) -> None:
+        _write_toml(tmp_path / "user.toml", "[strategy]\na = 99\n")
+        _write_toml(tmp_path / "example.toml", "[strategy]\na = 1\nb = 2\n")
+
+        sync_config(tmp_path / "user.toml", tmp_path / "example.toml")
+
+        doc = tomlkit.parse((tmp_path / "user.toml").read_text())
+        assert doc["strategy"]["a"] == 99  # user's value preserved
+        assert doc["strategy"]["b"] == 2  # new key added
+
+    def test_both_add_and_remove(self, tmp_path: Path) -> None:
+        _write_toml(tmp_path / "user.toml", "[strategy]\na = 1\nold = 99\n")
+        _write_toml(tmp_path / "example.toml", "[strategy]\na = 1\nnew = 42\n")
+
+        result = sync_config(tmp_path / "user.toml", tmp_path / "example.toml")
+        assert result.added == ["strategy.new"]
+        assert result.removed == ["strategy.old"]
+
+
+class TestNewKeys:
+    def test_returns_keys_at_default(self, tmp_path: Path) -> None:
+        _write_toml(tmp_path / "user.toml", "[strategy]\na = 1\n")
+        _write_toml(tmp_path / "example.toml", "[strategy]\na = 1\n")
+
+        result = new_keys(tmp_path / "user.toml", tmp_path / "example.toml")
+        assert "strategy.a" in result
+
+    def test_excludes_customized_keys(self, tmp_path: Path) -> None:
+        _write_toml(tmp_path / "user.toml", "[strategy]\na = 99\n")
+        _write_toml(tmp_path / "example.toml", "[strategy]\na = 1\n")
+
+        result = new_keys(tmp_path / "user.toml", tmp_path / "example.toml")
+        assert "strategy.a" not in result
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        result = new_keys(tmp_path / "nope.toml", tmp_path / "also_nope.toml")
+        assert result == set()

--- a/tests/unit/test_config_wizard.py
+++ b/tests/unit/test_config_wizard.py
@@ -294,7 +294,7 @@ class TestRunConfigWizard:
 
         prompted_keys: list[str] = []
 
-        def fake_prompt(setting: Setting, current: object) -> object:
+        def fake_prompt(setting: Setting, current: object, **kwargs: object) -> object:
             prompted_keys.append(setting.key)
             return current
 


### PR DESCRIPTION
## Summary
- New `gimmes config-sync` command: compares user's gimmes.toml against example template, adds new keys, removes deprecated, preserves existing values
- Integrated into `gimmes update` shell script (non-fatal on failure)
- Config wizard flags parameters still at defaults with NEW label
- Safety: validates example file exists and has keys before syncing, error handling for parse failures

Closes #283

## Test plan
- [x] All 711 unit tests pass (15 new for config sync)
- [x] Tests cover: key flattening, nested removal with pruning, sync add/remove/preserve, new_keys detection
- [x] Shell script guards config-sync failure with `|| echo` so update continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)