### PR TITLE
Write periodic mark-to-market snapshots from SSE stream

### DIFF
--- a/src/gimmes/clubhouse/server.py
+++ b/src/gimmes/clubhouse/server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import socket
 import threading
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
@@ -29,8 +30,15 @@ from gimmes.clubhouse.models import (
     TradeItem,
 )
 from gimmes.config import GIMMES_HOME
+from gimmes.models.portfolio import PortfolioSnapshot
+from gimmes.store.database import Database
+from gimmes.store.queries import insert_snapshot
 
 logger = logging.getLogger("gimmes.clubhouse")
+
+_SNAPSHOT_INTERVAL = timedelta(minutes=5)
+_last_snapshot_time: datetime | None = None
+_snapshot_lock = asyncio.Lock()
 
 DEFAULT_PORT = 1919
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
@@ -136,6 +144,48 @@ async def api_market_detail(ticker: str) -> MarketDetailResponse:
 
 
 # ---------------------------------------------------------------------------
+# Periodic snapshot writer
+# ---------------------------------------------------------------------------
+
+
+async def _maybe_write_snapshot(
+    db_path: Path,
+    portfolio: PortfolioResponse,
+    risk: RiskResponse,
+    snap_logger: logging.Logger,
+) -> None:
+    """Write a mark-to-market snapshot if enough time has elapsed.
+
+    Uses module-level state so concurrent SSE clients don't duplicate writes.
+    """
+    global _last_snapshot_time
+
+    if portfolio.balance <= 0:
+        return
+
+    async with _snapshot_lock:
+        now = datetime.now()
+        if _last_snapshot_time is not None and now - _last_snapshot_time < _SNAPSHOT_INTERVAL:
+            return
+
+        try:
+            snap = PortfolioSnapshot(
+                timestamp=now,
+                balance=portfolio.balance,
+                portfolio_value=portfolio.portfolio_value,
+                total_equity=portfolio.total_equity,
+                open_position_count=risk.position_count,
+                daily_pnl=portfolio.daily_pnl,
+                total_pnl=portfolio.total_pnl,
+            )
+            async with Database(db_path) as db:
+                await insert_snapshot(db, snap)
+            _last_snapshot_time = now
+        except Exception:
+            snap_logger.warning("Snapshot write failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # SSE stream
 # ---------------------------------------------------------------------------
 
@@ -158,9 +208,16 @@ async def api_stream() -> StreamingResponse:
                     activity = await data.get_activity(_db_path)
                     trades = await data.get_trades(_db_path)
                     candidates = await data.get_candidates(_db_path, limit=10)
-                    metrics = await data.get_metrics(_db_path)
                     errors = await data.get_errors_data(_db_path, limit=10)
                     recs = await data.get_recommendations_data(_db_path, limit=10)
+
+                    # Write periodic mark-to-market snapshot
+                    await _maybe_write_snapshot(
+                        _db_path, portfolio, risk, sse_logger,
+                    )
+
+                    # Fetch metrics after snapshot write (includes new snapshot)
+                    metrics = await data.get_metrics(_db_path)
 
                     payload = json.dumps({
                         "status": status.model_dump(),

--- a/tests/unit/test_snapshot_writer.py
+++ b/tests/unit/test_snapshot_writer.py
@@ -1,0 +1,112 @@
+"""Unit tests for periodic snapshot writer."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+import gimmes.clubhouse.server as server_mod
+from gimmes.clubhouse.models import PortfolioResponse, RiskResponse
+from gimmes.clubhouse.server import _SNAPSHOT_INTERVAL, _maybe_write_snapshot
+from gimmes.store.database import Database
+from gimmes.store.migrations import run_migrations
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path) -> Path:
+    """Create a temporary database with schema."""
+    path = tmp_path / "test.db"
+    async with Database(path) as db:
+        await run_migrations(db)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_snapshot_state():
+    """Reset module-level snapshot state between tests."""
+    server_mod._last_snapshot_time = None
+    yield
+    server_mod._last_snapshot_time = None
+
+
+def _portfolio(balance: float = 9500.0) -> PortfolioResponse:
+    return PortfolioResponse(
+        balance=balance,
+        portfolio_value=500.0,
+        total_equity=10000.0,
+        daily_pnl=50.0,
+        total_pnl=100.0,
+    )
+
+
+def _risk(position_count: int = 3) -> RiskResponse:
+    return RiskResponse(position_count=position_count)
+
+
+class TestMaybeWriteSnapshot:
+    async def test_writes_snapshot_on_first_call(self, db_path: Path) -> None:
+        await _maybe_write_snapshot(
+            db_path, _portfolio(), _risk(), logging.getLogger("test"),
+        )
+
+        async with Database(db_path) as db:
+            cursor = await db.conn.execute("SELECT COUNT(*) FROM snapshots")
+            row = await cursor.fetchone()
+            assert row[0] == 1
+
+    async def test_skips_before_interval(self, db_path: Path) -> None:
+        server_mod._last_snapshot_time = datetime.now() - timedelta(minutes=1)
+
+        await _maybe_write_snapshot(
+            db_path, _portfolio(), _risk(), logging.getLogger("test"),
+        )
+
+        async with Database(db_path) as db:
+            cursor = await db.conn.execute("SELECT COUNT(*) FROM snapshots")
+            row = await cursor.fetchone()
+            assert row[0] == 0
+
+    async def test_writes_after_interval(self, db_path: Path) -> None:
+        server_mod._last_snapshot_time = (
+            datetime.now() - _SNAPSHOT_INTERVAL - timedelta(seconds=1)
+        )
+
+        await _maybe_write_snapshot(
+            db_path, _portfolio(), _risk(), logging.getLogger("test"),
+        )
+
+        async with Database(db_path) as db:
+            cursor = await db.conn.execute("SELECT COUNT(*) FROM snapshots")
+            row = await cursor.fetchone()
+            assert row[0] == 1
+
+    async def test_skips_zero_balance(self, db_path: Path) -> None:
+        await _maybe_write_snapshot(
+            db_path, _portfolio(balance=0), _risk(), logging.getLogger("test"),
+        )
+
+        async with Database(db_path) as db:
+            cursor = await db.conn.execute("SELECT COUNT(*) FROM snapshots")
+            row = await cursor.fetchone()
+            assert row[0] == 0
+
+    async def test_snapshot_values_match_portfolio(self, db_path: Path) -> None:
+        portfolio = _portfolio()
+        risk = _risk(position_count=5)
+
+        await _maybe_write_snapshot(
+            db_path, portfolio, risk, logging.getLogger("test"),
+        )
+
+        async with Database(db_path) as db:
+            cursor = await db.conn.execute("SELECT * FROM snapshots LIMIT 1")
+            row = await cursor.fetchone()
+            assert row["balance"] == pytest.approx(9500.0)
+            assert row["portfolio_value"] == pytest.approx(500.0)
+            assert row["total_equity"] == pytest.approx(10000.0)
+            assert row["open_position_count"] == 5
+            assert row["daily_pnl"] == pytest.approx(50.0)
+            assert row["total_pnl"] == pytest.approx(100.0)


### PR DESCRIPTION
## Summary
- Write portfolio snapshots every 5 minutes from SSE stream (was never written — table was always empty)
- Enables mark-to-market equity curves and meaningful performance metrics (Sharpe, drawdown, return)
- Uses module-level lock to prevent duplicate writes from concurrent SSE clients
- `calculate_metrics()` already prefers snapshots — no changes needed to metrics code

Closes #284

## Test plan
- [x] All 716 unit tests pass (5 new for snapshot writer)
- [x] Tests verify: first-call write, interval gating, zero-balance skip, value fidelity
- [x] Module-level state reset between tests via autouse fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)