### PR TITLE
Fix gimmes update running post-update steps from stale code

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -155,7 +155,7 @@ if [ ! -d "$REPO" ]; then
     exit 1
 fi
 
-if [ ! -f "$PYTHON" ]; then
+if [ ! -f "$PYTHON" ] && [ "${1:-}" != "_post-update" ]; then
     echo "Error: Python virtual environment not found at $REPO/.venv"
     echo "Try running: gimmes update"
     exit 1
@@ -195,6 +195,18 @@ case "${1:-}" in
             update_label=$(git rev-parse --short HEAD)
         fi
 
+        # Re-exec into the updated script for post-update steps.
+        # This ensures uv sync, config-sync, and banner use the NEW code.
+        # The || guard ensures a clear error message if exec fails under set -e.
+        exec "$REPO/bin/gimmes.sh" _post-update "$update_label" || {
+            echo "Error: failed to run post-update step."
+            echo "Try running: gimmes update"
+            exit 1
+        }
+        ;;
+    _post-update)
+        update_label="${2:-unknown}"
+        cd "$REPO"
         if command -v uv &>/dev/null; then
             uv sync --quiet
         else

--- a/tests/unit/test_gimmes_sh.py
+++ b/tests/unit/test_gimmes_sh.py
@@ -269,3 +269,39 @@ class TestCheckUpdateDev:
         result = run_function("check_update_dev", repo=repo)
         assert "Update available" in result.stdout
         assert "3 commits ahead" in result.stdout
+
+
+# -- _post-update venv bypass ------------------------------------------------
+
+
+class TestPostUpdateVenvBypass:
+    """The venv check should not block _post-update (it creates the venv)."""
+
+    def test_venv_check_blocks_normal_commands(self, tmp_path: Path) -> None:
+        """Without _post-update, a missing venv causes exit 1."""
+        home = tmp_path / "gimmes_home"
+        repo = home / "repo"
+        repo.mkdir(parents=True)
+        init_repo(repo)
+        result = run_bash(
+            f'export GIMMES_HOME="{home}"; '
+            f'bash "{GIMMES_SH}" version'
+        )
+        assert result.returncode == 1
+        combined = result.stdout + result.stderr
+        assert "virtual environment not found" in combined
+
+    def test_venv_check_bypassed_for_post_update(self, tmp_path: Path) -> None:
+        """_post-update skips the venv check so uv sync can create it."""
+        home = tmp_path / "gimmes_home"
+        repo = home / "repo"
+        repo.mkdir(parents=True)
+        init_repo(repo)
+        # The script will fail at uv sync (no real project), but it should
+        # NOT fail at the venv check
+        result = run_bash(
+            f'export GIMMES_HOME="{home}"; '
+            f'bash "{GIMMES_SH}" _post-update v1.0.0 2>&1'
+        )
+        combined = result.stdout + result.stderr
+        assert "virtual environment not found" not in combined


### PR DESCRIPTION
## Summary
- Split `update)` case into git-only phase + `exec` re-entry into `_post-update)` case
- After git pull/checkout, `exec` replaces the process with the freshly-pulled script
- Post-update steps (uv sync, config-sync, banner) now always run from NEW code
- Bypass venv existence check for `_post-update` since it creates the venv via `uv sync`

Closes #291

## Test plan
- [x] All 718 unit tests pass (2 new shell tests)
- [x] `test_venv_check_blocks_normal_commands` — guard still works for regular commands
- [x] `test_venv_check_bypassed_for_post_update` — `_post-update` skips venv check

🤖 Generated with [Claude Code](https://claude.com/claude-code)