### PR TITLE
Use curated series watchlist as ScannerConfig default

### DIFF
--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -25,6 +25,33 @@ load_dotenv(dotenv_path=GIMMES_HOME / ".env")
 PROD_BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
 PROD_WS_URL = "wss://api.elections.kalshi.com/trade-api/ws/v2"
 
+# Curated series watchlist — used as the Pydantic default for ScannerConfig.series
+# and seeded into the database on first init.
+DEFAULT_SERIES = [
+    # Inflation & CPI
+    "KXCPI", "KXCPICORE", "KXCPIYOY", "KXCPICOREYOY",
+    "KXECONSTATCPI", "KXECONSTATCPICORE", "KXECONSTATCPIYOY", "KXECONSTATCORECPIYOY",
+    "KXPCECORE",
+    # GDP & Growth
+    "KXGDP", "KXGDPNOM", "KXGDPUSMAX",
+    # Fed & Rates
+    "KXFED", "KXFEDDECISION", "KXFEDCOMBO", "KXRATECUTCOUNT", "KXFEDCHGCOUNT",
+    "KXFEDMEET", "KXEMERCUTS", "KXFEDDISSENT",
+    # Employment
+    "KXJOBLESSCLAIMS", "KXUE", "KXU3", "KXPAYROLLS", "KXADP",
+    # Housing & Mortgage
+    "KXMORTGAGERATE", "KXHOUSINGSTART", "KXEHSALES", "KXNHSALES",
+    # Other Econ
+    "KXISMPMI", "KXRECSSNBER", "KXEFFTARIFF", "KXTARIFFREVENUE",
+    # Financials — S&P, Nasdaq, Treasuries
+    "KXINX", "KXINXU", "KXINXMAXY", "KXINXMINY",
+    "KXNASDAQ100", "KXNASDAQ100U", "KXNASDAQ100Y",
+    "KXUSTYLD", "KXTNOTEW", "KX10Y2Y", "KX10Y3M", "KX3MTBILL",
+    "KXGOLDW", "KXSILVERW", "KXWTI", "KXWTIMAX",
+    # Politics — high-level
+    "CONTROLH", "CONTROLS",
+]
+
 
 class Mode(StrEnum):
     DRIVING_RANGE = "driving_range"
@@ -434,7 +461,7 @@ class ScannerConfig(BaseModel):
         },
     )
     series: list[str] = Field(
-        default_factory=list,
+        default_factory=lambda: list(DEFAULT_SERIES),
         json_schema_extra={
             "display_name": "Series Watchlist",
             "description": (

--- a/src/gimmes/init.py
+++ b/src/gimmes/init.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from rich.console import Console
 
-from gimmes.config import GIMMES_HOME, config_keys_in_db, save_config_value
+from gimmes.config import DEFAULT_SERIES, GIMMES_HOME, config_keys_in_db, save_config_value
 
 console = Console()
 
@@ -37,32 +37,6 @@ KALSHI_PROD_PRIVATE_KEY_PATH=~/.gimmes/keys/kalshi_private.pem
 # Password for encrypted private key (set automatically by gimmes init)
 # KALSHI_PRIVATE_KEY_PASSWORD=
 """
-
-# Curated series watchlist seeded into the database on first init.
-DEFAULT_SERIES = [
-    # Inflation & CPI
-    "KXCPI", "KXCPICORE", "KXCPIYOY", "KXCPICOREYOY",
-    "KXECONSTATCPI", "KXECONSTATCPICORE", "KXECONSTATCPIYOY", "KXECONSTATCORECPIYOY",
-    "KXPCECORE",
-    # GDP & Growth
-    "KXGDP", "KXGDPNOM", "KXGDPUSMAX",
-    # Fed & Rates
-    "KXFED", "KXFEDDECISION", "KXFEDCOMBO", "KXRATECUTCOUNT", "KXFEDCHGCOUNT",
-    "KXFEDMEET", "KXEMERCUTS", "KXFEDDISSENT",
-    # Employment
-    "KXJOBLESSCLAIMS", "KXUE", "KXU3", "KXPAYROLLS", "KXADP",
-    # Housing & Mortgage
-    "KXMORTGAGERATE", "KXHOUSINGSTART", "KXEHSALES", "KXNHSALES",
-    # Other Econ
-    "KXISMPMI", "KXRECSSNBER", "KXEFFTARIFF", "KXTARIFFREVENUE",
-    # Financials — S&P, Nasdaq, Treasuries
-    "KXINX", "KXINXU", "KXINXMAXY", "KXINXMINY",
-    "KXNASDAQ100", "KXNASDAQ100U", "KXNASDAQ100Y",
-    "KXUSTYLD", "KXTNOTEW", "KX10Y2Y", "KX10Y3M", "KX3MTBILL",
-    "KXGOLDW", "KXSILVERW", "KXWTI", "KXWTIMAX",
-    # Politics — high-level
-    "CONTROLH", "CONTROLS",
-]
 
 KEYS_DIR = GIMMES_HOME / "keys"
 PEM_FILENAME = "kalshi_private.pem"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 
 from gimmes.config import (
+    DEFAULT_SERIES,
     _load_config_from_db,
     config_keys_in_db,
     load_config,
@@ -190,6 +191,32 @@ class TestLoadConfig:
         config = load_config(db_path=db)
         assert config.strategy.gimme_threshold == 80
         assert config.strategy.min_market_price == 0.55  # default
+
+
+class TestDefaultSeries:
+    def test_series_defaults_to_curated_list_when_no_db(self, tmp_path):
+        config = load_config(db_path=tmp_path / "nonexistent.db")
+        assert config.scanner.series == DEFAULT_SERIES
+
+    def test_series_defaults_to_curated_list_with_empty_db(self, tmp_path):
+        db = tmp_path / "test.db"
+        _create_config_db(db)
+        config = load_config(db_path=db)
+        assert config.scanner.series == DEFAULT_SERIES
+
+    def test_explicit_series_overrides_default(self, tmp_path):
+        db = tmp_path / "test.db"
+        _create_config_db(db)
+        save_config_value("scanner.series", ["KXGDP"], db_path=db)
+        config = load_config(db_path=db)
+        assert config.scanner.series == ["KXGDP"]
+
+    def test_explicit_empty_series_overrides_default(self, tmp_path):
+        db = tmp_path / "test.db"
+        _create_config_db(db)
+        save_config_value("scanner.series", [], db_path=db)
+        config = load_config(db_path=db)
+        assert config.scanner.series == []
 
 
 class TestMonitorPriceTrigger:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -12,8 +12,8 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from gimmes.config import DEFAULT_SERIES
 from gimmes.init import (
-    DEFAULT_SERIES,
     _clear_shell_history,
     _encrypt_private_key,
     _find_downloaded_key,


### PR DESCRIPTION
## Summary
- After the TOML→SQLite migration (#294), `ScannerConfig.series` defaulted to `[]` when no `scanner.series` key existed in the database, causing the dashboard to show "series: 0 items"
- Moved `DEFAULT_SERIES` from `init.py` to `config.py` and wired it as the Pydantic `default_factory` so the curated watchlist is always available without requiring `gimmes init`
- Explicit user overrides (including empty `[]`) are still honored when stored in the database

Closes #296

## Test plan
- [x] `test_series_defaults_to_curated_list_when_no_db` — no DB → uses DEFAULT_SERIES
- [x] `test_series_defaults_to_curated_list_with_empty_db` — empty config table → uses DEFAULT_SERIES
- [x] `test_explicit_series_overrides_default` — DB has custom list → uses custom list
- [x] `test_explicit_empty_series_overrides_default` — DB has `[]` → uses `[]`
- [x] All 102 config-related tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)