### PR TITLE
Suggest gimmes init when database errors occur pre-setup

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -65,8 +65,21 @@ def _run(coro):  # type: ignore[no-untyped-def]
         console.print(f"[red]Connection error: {e}[/red]")
         raise typer.Exit(1)
     except sqlite3.Error as e:
-        logger.debug("Database error", exc_info=True)
-        console.print(f"[red]Database error: {e}[/red]")
+        logger.warning("Database error: %s: %s", type(e).__name__, e, exc_info=True)
+        from gimmes.config import GIMMES_HOME
+
+        db_path = GIMMES_HOME / "gimmes.db"
+        if not db_path.exists():
+            console.print(
+                "[red]Database not found.[/red] "
+                "Run [bold]gimmes init[/bold] to set up GIMMES."
+            )
+        else:
+            console.print(
+                f"[red]Database error: {e}.[/red] "
+                "Try [bold]gimmes reconcile[/bold] or reinstall with "
+                "[bold]gimmes update[/bold]."
+            )
         raise typer.Exit(1)
     except typer.Exit:
         raise

--- a/tests/unit/test_run_error_handling.py
+++ b/tests/unit/test_run_error_handling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
 from unittest.mock import patch
 
 import httpx
@@ -25,9 +27,8 @@ async def _raise(exc: Exception):
 
 def _run_expecting_exit(exc: Exception) -> str:
     """Run _run() with an exception-raising coroutine, return the console output."""
-    with patch("gimmes.cli.console") as mock_console:
-        with pytest.raises(ClickExit) as exc_info:
-            _run(_raise(exc))
+    with patch("gimmes.cli.console") as mock_console, pytest.raises(ClickExit) as exc_info:
+        _run(_raise(exc))
     assert exc_info.value.exit_code == 1
     return mock_console.print.call_args[0][0]
 
@@ -88,3 +89,23 @@ class TestRunExistingErrors:
         output = _run_expecting_exit(exc)
         assert "Connection refused" in output
         assert "API error" not in output
+
+
+class TestRunSqliteError:
+    def test_db_missing_suggests_init(self, tmp_path: Path) -> None:
+        """When the DB file doesn't exist, suggest 'gimmes init'."""
+        exc = sqlite3.OperationalError("unable to open database file")
+        with patch("gimmes.config.GIMMES_HOME", tmp_path):
+            output = _run_expecting_exit(exc)
+        assert "Database not found" in output
+        assert "gimmes init" in output
+
+    def test_db_exists_shows_error_and_suggests_reconcile(self, tmp_path: Path) -> None:
+        """When the DB file exists, show the error and suggest reconcile."""
+        (tmp_path / "gimmes.db").touch()
+        exc = sqlite3.OperationalError("database disk image is malformed")
+        with patch("gimmes.config.GIMMES_HOME", tmp_path):
+            output = _run_expecting_exit(exc)
+        assert "database disk image is malformed" in output
+        assert "gimmes reconcile" in output
+        assert "gimmes update" in output


### PR DESCRIPTION
## Summary
- Enhanced `sqlite3.Error` handler in `_run()` to check if the DB file exists and provide actionable guidance
- When DB is missing: "Database not found. Run gimmes init to set up GIMMES."
- When DB exists but corrupt: "Database error: {e}. Try gimmes reconcile or reinstall with gimmes update."
- Upgraded log level from `debug` to `warning` so the original error survives in logs
- Filed #327 for three inner `sqlite3.Error` handlers that bypass `_run()`

Closes #308

## Test plan
- [x] `uv run pytest tests/unit/` — 753 tests pass
- [x] `uv run ruff check` on changed files — clean
- [x] Two new tests cover both branches (DB missing → init, DB exists → reconcile)
- [x] Code review, silent failure hunt, test coverage analysis — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)