### PR TITLE
Guide users to gimmes init when mode shows disconnected

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -175,7 +175,11 @@ def mode() -> None:
 
         connected = False
         balance = None
-        has_credentials = config.api_key and config.private_key_path.exists()
+        has_credentials = (
+            bool(config.api_key)
+            and str(config.private_key_path) != "."
+            and config.private_key_path.exists()
+        )
 
         if has_credentials:
             try:

--- a/tests/unit/test_mode.py
+++ b/tests/unit/test_mode.py
@@ -59,3 +59,19 @@ class TestModeInitHint:
 
         assert result.exit_code == 0
         assert "gimmes init" not in result.output
+
+    def test_shows_hint_when_api_key_set_but_no_key_file(self, tmp_path: Path) -> None:
+        """Partial config: api_key set but private_key_path is default Path()."""
+        partial = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            api_key="test-key",
+            db_path=tmp_path / "gimmes.db",
+        )
+        with (
+            patch("gimmes.cli.load_config", return_value=partial),
+            patch("gimmes.store.session.get_active_session", return_value=None),
+        ):
+            result = runner.invoke(app, ["mode"])
+
+        assert result.exit_code == 0
+        assert "gimmes init" in result.output


### PR DESCRIPTION
## Summary
- When `gimmes mode` is run before `gimmes init`, add a yellow hint: "Not configured yet. Run gimmes init to set up your API credentials."
- Extract `has_credentials` local variable to share the check between the connection guard and the hint condition
- New test file `tests/unit/test_mode.py` with tests for both branches (unconfigured → hint shown, configured → no hint)

Closes #309

## Test plan
- [x] `uv run pytest tests/unit/` — 755 tests pass
- [x] `uv run ruff check` on changed files — clean
- [x] `test_shows_init_hint_when_unconfigured` — verifies hint appears with empty credentials
- [x] `test_no_hint_when_configured` — verifies hint absent with valid credentials (properly mocked async context manager)
- [x] Code review, silent failure hunt, test coverage analysis — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)