### PR TITLE
Show required -p flag on validate and order in README CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ gimmes caddie_shop       # Launch The Caddie Shop — conversational config advi
 gimmes scan              # Scan markets for gimme candidates
 gimmes score TICKER      # Score a specific market
 gimmes size TICKER -p P  # Calculate position size
-gimmes validate TICKER   # Pre-trade validation
-gimmes order TICKER      # Place an order (paper or real)
+gimmes validate TICKER -p P  # Pre-trade validation
+gimmes order TICKER -p P     # Place an order (paper or real)
 gimmes cancel ORDER_ID   # Cancel a resting order
 ```
 


### PR DESCRIPTION
## Summary
The CLI commands section showed `gimmes validate TICKER` and `gimmes order TICKER` without the `-p` flag. `validate` requires `--prob` (it's `typer.Option(...)`) and `order` without it produces a useless 0-contract order. The "Walking the Course Solo" section already showed the correct syntax with `--prob 0.92`.

Closes #310

## Test plan
- [x] Documentation-only change — no code affected
- [x] `uv run pytest tests/unit/` — 756 tests pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)