### PR TITLE
Clear dirty working tree before gimmes update and remove dead exec guard

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -174,6 +174,10 @@ case "${1:-}" in
             exit 1
         fi
 
+        if ! git checkout . --quiet 2>/dev/null; then
+            echo "Warning: could not clean local changes; update may fail."
+        fi
+
         latest_tag=$(latest_remote_tag)
         update_label=""
 
@@ -197,12 +201,7 @@ case "${1:-}" in
 
         # Re-exec into the updated script for post-update steps.
         # This ensures uv sync and banner use the NEW code.
-        # The || guard ensures a clear error message if exec fails under set -e.
-        exec "$REPO/bin/gimmes.sh" _post-update "$update_label" || {
-            echo "Error: failed to run post-update step."
-            echo "Try running: gimmes update"
-            exit 1
-        }
+        exec "$REPO/bin/gimmes.sh" _post-update "$update_label"
         ;;
     _post-update)
         update_label="${2:-unknown}"


### PR DESCRIPTION
## Summary
- Add `git checkout .` before tag/branch check in `gimmes update` to discard local modifications that would cause checkout or pull to fail. Wrapped in `if` block so failure is non-fatal with a warning message.
- Remove dead `|| { ... }` block after `exec` — under `set -e`, a failed exec exits before the `||` branch runs. The old comment was incorrect.

Closes #312

## Test plan
- [x] Shell script change — `uv run pytest tests/unit/` confirms 756 tests still pass
- [x] Manual verification: dirty tree cleanup runs before both tag checkout and ff-only pull paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)