### PR TITLE
Document --headless flag for gimmes init

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ gimmes update            # Pull latest code and reinstall
 gimmes version           # Show version and check for updates
 ```
 
+For CI/Docker/automation, use `gimmes init --headless`. Requires env vars: `KALSHI_PROD_API_KEY`, `KALSHI_PROD_PRIVATE_KEY_PATH` (path to an unencrypted PEM), and `KALSHI_PRIVATE_KEY_PASSWORD`.
+
 ### Mode & Status
 ```bash
 gimmes mode              # Show current mode and connection status

--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -219,6 +219,7 @@ case "${1:-}" in
         cat <<'HELP'
 Setup & Config:
   gimmes init              First-time setup (API credentials, config)
+  gimmes init --headless   Non-interactive setup (requires env vars)
   gimmes config            Interactive configuration wizard
   gimmes config set K V    Set a single config value directly
   gimmes config get [K]    Show config value(s)


### PR DESCRIPTION
## Summary
- Add `gimmes init --headless` to `gimmes help` output under Setup & Config
- Add paragraph in README documenting headless mode, required env vars, and unencrypted PEM requirement

Closes #314

## Test plan
- [x] Documentation-only change — 756 tests pass
- [x] Env var names verified against `_HEADLESS_REQUIRED_VARS` in `init.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)