### PR TITLE
Add config add/remove for list-type fields

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2229,8 +2229,17 @@ def _resolve_list_field(key: str) -> tuple[Path, list]:
 
     overrides = _load_config_from_db(db_path)
     current = _get_current_value(overrides, key, setting.default)
-    current_list: list = list(current) if isinstance(current, list) else []
-    return db_path, current_list
+    if not isinstance(current, list):
+        console.print(
+            f"[red]Error: Stored value for {key!r} is not a list."
+            " The configuration may be corrupted.[/red]"
+        )
+        console.print(
+            f"[yellow]Reset it with 'gimmes config set {key} ...' "
+            "before using add/remove.[/yellow]"
+        )
+        raise typer.Exit(1)
+    return db_path, list(current)
 
 
 @config_app.command(name="add")

--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -144,7 +144,7 @@ def _format_current(value: object, setting: Setting, *, full: bool = False) -> s
     """Format a value for display."""
     if setting.type == "list" and isinstance(value, list):
         if full:
-            return "\n  ".join(str(v) for v in value)
+            return "\n  " + "\n  ".join(str(v) for v in value)
         if len(value) > 6:
             return f"[{len(value)} items] {', '.join(str(v) for v in value[:6])}..."
         return ", ".join(str(v) for v in value)

--- a/tests/unit/test_config_set.py
+++ b/tests/unit/test_config_set.py
@@ -295,6 +295,22 @@ class TestConfigAdd:
         assert result.exit_code == 1
         assert "Database not found" in result.output
 
+    def test_add_corrupted_value_errors(self, db_file: Path) -> None:
+        """If the stored value is not a list, error instead of silently overwriting."""
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            "INSERT INTO config (key, value) VALUES (?, ?)",
+            ("scanner.series", json.dumps("not-a-list")),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(app, ["config", "add", "scanner.series", "KXFED"])
+
+        assert result.exit_code == 1
+        assert "corrupted" in result.output
+
     def test_add_to_default_list(self, db_file: Path) -> None:
         """Adding to an unset field should copy the default list and append."""
         with patch("gimmes.config.GIMMES_HOME", db_file.parent):
@@ -369,6 +385,22 @@ class TestConfigRemove:
 
         assert result.exit_code == 1
         assert "Unknown config key" in result.output
+
+    def test_remove_corrupted_value_errors(self, db_file: Path) -> None:
+        """If the stored value is not a list, error instead of silently proceeding."""
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            "INSERT INTO config (key, value) VALUES (?, ?)",
+            ("scanner.series", json.dumps("not-a-list")),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(app, ["config", "remove", "scanner.series", "KXFED"])
+
+        assert result.exit_code == 1
+        assert "corrupted" in result.output
 
     def test_remove_last_item_leaves_empty_list(self, db_file: Path) -> None:
         conn = sqlite3.connect(str(db_file))

--- a/tests/unit/test_config_wizard.py
+++ b/tests/unit/test_config_wizard.py
@@ -203,7 +203,8 @@ class TestFormatCurrent:
     def test_format_list_full_one_per_line(self) -> None:
         s = Setting(key="a.b", name="", description="", type="list", default=[])
         result = _format_current(["A", "B", "C"], s, full=True)
-        assert "\n" in result
+        # Every item should be on its own indented line (leading newline)
+        assert result.startswith("\n")
         assert "A" in result
         assert "B" in result
         assert "C" in result


### PR DESCRIPTION
## Summary
- Add `config add KEY VALUE` and `config remove KEY VALUE` subcommands for ergonomic list field manipulation (e.g., `gimmes config add scanner.series KXNEW` instead of replacing the entire 53-item list)
- Fix `config get` to show the full list (one item per line) when a specific list key is requested, instead of truncating to 6 items
- Deferred series category groupings to #336

Closes #317

## Test plan
- [x] 771 unit tests pass (`uv run pytest tests/unit/`)
- [x] Lint clean (`uv run ruff check`)
- [x] 15 new tests covering: add/remove happy paths, duplicate add (noop), nonexistent remove (error), non-list field guard, invalid key, missing DB, add to default list, remove last item (empty list), full list display in `config get`, `_format_current(full=True)` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)