### PR TITLE
Rename scan --top to --limit for flag consistency

### DIFF
--- a/.claude/agents/starter.md
+++ b/.claude/agents/starter.md
@@ -90,7 +90,7 @@ Explain paper trading mode — MUST mention all of these:
 - Nothing real is at stake — it's practice with live conditions
 - Run `gimmes driving_range` to start the autonomous trading loop in paper mode
 
-Demo: `python -m gimmes scan --top 5`
+Demo: `python -m gimmes scan --limit 5`
 
 This shows what the Scout sees when scanning for candidates. Walk through what the output means.
 
@@ -139,7 +139,7 @@ These are the ONLY `gimmes` commands you are allowed to run. NEVER run any `gimm
 ```
 python -m gimmes mode
 python -m gimmes --help
-python -m gimmes scan [--top N]
+python -m gimmes scan [--limit N]
 python -m gimmes score TICKER
 python -m gimmes market-info TICKER
 python -m gimmes positions

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -215,7 +215,7 @@ def mode() -> None:
 
 @app.command(rich_help_panel="Market Research")
 def scan(
-    top_n: int = typer.Option(20, "--top", "-n", help="Number of top candidates to show"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Number of top candidates to show"),
     series: list[str] = typer.Option(
         None, "--series", "-s",
         help="Override series tickers to scan (e.g. -s KXCPI -s KXGDP)",
@@ -266,7 +266,7 @@ def scan(
                 })
 
             scored.sort(key=lambda r: r["score"], reverse=True)
-            format_scan_results(scored[:top_n])
+            format_scan_results(scored[:limit])
 
     _run(_scan())
 


### PR DESCRIPTION
## Summary
- Rename `scan --top` to `scan --limit` so `-n` consistently means `--limit` across all CLI commands
- The `-p` and `-s` short flag conflicts are across unrelated command panels with no practical user confusion, so they are left as-is per the issue description
- Update Starter agent definition to use `--limit` in demo commands

Closes #319

## Test plan
- [ ] Run `uv run pytest tests/unit/` — 776 tests pass
- [ ] Run `gimmes scan --limit 5` — shows 5 results
- [ ] Run `gimmes scan -n 3` — short flag still works
- [ ] Run `gimmes scan --help` — shows `--limit` instead of `--top`

🤖 Generated with [Claude Code](https://claude.com/claude-code)