### PR TITLE
Add Pydantic validators to 9 config fields and improve validation messages

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2537,6 +2537,9 @@ def _championship_gate(config: GimmesConfig) -> None:
             if value <= 0:
                 console.print("  [red]Bankroll must be greater than $0.[/red]")
                 continue
+            if value > 1_000_000:
+                console.print("  [red]Bankroll cannot exceed $1,000,000.[/red]")
+                continue
             break
     else:
         console.print(
@@ -2552,6 +2555,9 @@ def _championship_gate(config: GimmesConfig) -> None:
             raise typer.Abort()
         if value <= 0:
             console.print("[red]Bankroll must be greater than $0.[/red]")
+            raise typer.Abort()
+        if value > 1_000_000:
+            console.print("[red]Bankroll cannot exceed $1,000,000.[/red]")
             raise typer.Abort()
 
     if value != current_bankroll:

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -333,7 +333,7 @@ class RiskConfig(BaseModel):
         },
     )
     bankroll_real: float = Field(
-        default=0.0, ge=0.0,
+        default=0.0, ge=0.0, le=1_000_000.0,
         json_schema_extra={
             "display_name": "Championship Bankroll",
             "description": (
@@ -409,7 +409,7 @@ class ScannerConfig(BaseModel):
     })
 
     min_volume: int = Field(
-        default=100,
+        default=100, ge=0, le=100_000,
         json_schema_extra={
             "display_name": "Min Volume (24h)",
             "description": (
@@ -426,7 +426,7 @@ class ScannerConfig(BaseModel):
         },
     )
     min_open_interest: int = Field(
-        default=50,
+        default=50, ge=0, le=100_000,
         json_schema_extra={
             "display_name": "Min Open Interest",
             "description": (
@@ -443,7 +443,7 @@ class ScannerConfig(BaseModel):
         },
     )
     max_days_to_resolution: float = Field(
-        default=90.0,
+        default=90.0, ge=1.0, le=365.0,
         json_schema_extra={
             "display_name": "Max Days to Resolution",
             "description": (
@@ -459,7 +459,7 @@ class ScannerConfig(BaseModel):
         },
     )
     min_days_to_resolution: float = Field(
-        default=0.5,
+        default=0.5, ge=0.0, le=30.0,
         json_schema_extra={
             "display_name": "Min Days to Resolution",
             "description": (
@@ -498,7 +498,7 @@ class ScannerConfig(BaseModel):
 
 class ScoringWeights(BaseModel):
     edge_size: float = Field(
-        default=0.30,
+        default=0.30, ge=0.0, le=1.0,
         json_schema_extra={
             "display_name": "Weight: Edge Size",
             "description": (
@@ -513,7 +513,7 @@ class ScoringWeights(BaseModel):
         },
     )
     signal_strength: float = Field(
-        default=0.25,
+        default=0.25, ge=0.0, le=1.0,
         json_schema_extra={
             "display_name": "Weight: Signal Strength",
             "description": (
@@ -527,7 +527,7 @@ class ScoringWeights(BaseModel):
         },
     )
     liquidity_depth: float = Field(
-        default=0.15,
+        default=0.15, ge=0.0, le=1.0,
         json_schema_extra={
             "display_name": "Weight: Liquidity Depth",
             "description": (
@@ -542,7 +542,7 @@ class ScoringWeights(BaseModel):
         },
     )
     settlement_clarity: float = Field(
-        default=0.15,
+        default=0.15, ge=0.0, le=1.0,
         json_schema_extra={
             "display_name": "Weight: Settlement Clarity",
             "description": (
@@ -558,7 +558,7 @@ class ScoringWeights(BaseModel):
         },
     )
     time_to_resolution: float = Field(
-        default=0.15,
+        default=0.15, ge=0.0, le=1.0,
         json_schema_extra={
             "display_name": "Weight: Time to Resolution",
             "description": (

--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -155,24 +155,36 @@ def _format_current(value: object, setting: Setting, *, full: bool = False) -> s
     return str(value)
 
 
+def _check_range(
+    val: int | float,
+    lo: float | None,
+    hi: float | None,
+    fmt: type = float,
+) -> None:
+    """Raise ValueError if *val* is outside [lo, hi]. Uses *fmt* for display."""
+    below = lo is not None and val < lo
+    above = hi is not None and val > hi
+    if not below and not above:
+        return
+    if lo is not None and hi is not None:
+        raise ValueError(f"Must be between {fmt(lo)} and {fmt(hi)}")
+    if below:
+        raise ValueError(f"Must be at least {fmt(lo)}")
+    raise ValueError(f"Must be at most {fmt(hi)}")
+
+
 def _parse_input(raw: str, setting: Setting) -> int | float | str | list[str]:
     """Parse and validate user input for a setting. Raises ValueError on bad input."""
     raw = raw.strip()
 
     if setting.type == "int":
         val = int(raw)
-        if setting.min_val is not None and val < setting.min_val:
-            raise ValueError(f"Must be at least {int(setting.min_val)}")
-        if setting.max_val is not None and val > setting.max_val:
-            raise ValueError(f"Must be at most {int(setting.max_val)}")
+        _check_range(val, setting.min_val, setting.max_val, fmt=int)
         return val
 
     if setting.type == "float":
         val = float(raw)
-        if setting.min_val is not None and val < setting.min_val:
-            raise ValueError(f"Must be at least {setting.min_val}")
-        if setting.max_val is not None and val > setting.max_val:
-            raise ValueError(f"Must be at most {setting.max_val}")
+        _check_range(val, setting.min_val, setting.max_val)
         return val
 
     if setting.type == "str":

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -1009,6 +1009,26 @@ class TestChampionshipGate:
         assert "must set a bankroll" in result.output.lower()
 
 
+    def test_bankroll_rejects_over_million(self) -> None:
+        """When bankroll_real is 0, values over $1M are rejected."""
+        with (
+            patch("gimmes.cli._set_mode"),
+            patch("gimmes.cli._autonomous_loop"),
+            patch("gimmes.config.save_config_value") as mock_save,
+        ):
+            # "y" confirms, 2M rejected, then "500" accepted
+            result = runner.invoke(
+                app, ["championship", "--cycles", "1"],
+                input="y\n2000000\n500\n",
+            )
+
+        mock_save.assert_called_once()
+        args, kwargs = mock_save.call_args
+        assert args == ("risk.bankroll_real", 500.0)
+        assert "db_path" in kwargs
+        assert "exceed" in result.output.lower()
+
+
 class TestOrderYesFlag:
     def test_order_command_has_yes_option(self) -> None:
         result = runner.invoke(app, ["order", "--help"])

--- a/tests/unit/test_config_set.py
+++ b/tests/unit/test_config_set.py
@@ -64,7 +64,7 @@ class TestConfigSet:
             result = runner.invoke(app, ["config", "set", "strategy.gimme_threshold", "200"])
 
         assert result.exit_code == 1
-        assert "at most" in result.output
+        assert "between" in result.output
 
     def test_set_no_change(self, db_file: Path) -> None:
         # Pre-seed the default value

--- a/tests/unit/test_config_wizard.py
+++ b/tests/unit/test_config_wizard.py
@@ -117,13 +117,29 @@ class TestParseInput:
             key="a.b", name="", description="", type="int",
             default=0, min_val=10, max_val=100,
         )
-        with pytest.raises(ValueError, match="at least"):
+        with pytest.raises(ValueError, match="between"):
             _parse_input("5", s)
 
     def test_parse_int_above_max(self) -> None:
         s = Setting(
             key="a.b", name="", description="", type="int",
             default=0, min_val=0, max_val=100,
+        )
+        with pytest.raises(ValueError, match="between"):
+            _parse_input("200", s)
+
+    def test_parse_int_below_min_only(self) -> None:
+        s = Setting(
+            key="a.b", name="", description="", type="int",
+            default=0, min_val=10,
+        )
+        with pytest.raises(ValueError, match="at least"):
+            _parse_input("5", s)
+
+    def test_parse_int_above_max_only(self) -> None:
+        s = Setting(
+            key="a.b", name="", description="", type="int",
+            default=0, max_val=100,
         )
         with pytest.raises(ValueError, match="at most"):
             _parse_input("200", s)
@@ -140,8 +156,32 @@ class TestParseInput:
             key="a.b", name="", description="", type="float",
             default=0.0, min_val=0.01, max_val=1.0,
         )
+        with pytest.raises(ValueError, match="between"):
+            _parse_input("0.001", s)
+
+    def test_parse_float_above_max(self) -> None:
+        s = Setting(
+            key="a.b", name="", description="", type="float",
+            default=0.0, min_val=0.0, max_val=1.0,
+        )
+        with pytest.raises(ValueError, match="between"):
+            _parse_input("1.5", s)
+
+    def test_parse_float_below_min_only(self) -> None:
+        s = Setting(
+            key="a.b", name="", description="", type="float",
+            default=0.0, min_val=0.01,
+        )
         with pytest.raises(ValueError, match="at least"):
             _parse_input("0.001", s)
+
+    def test_parse_float_above_max_only(self) -> None:
+        s = Setting(
+            key="a.b", name="", description="", type="float",
+            default=0.0, max_val=1.0,
+        )
+        with pytest.raises(ValueError, match="at most"):
+            _parse_input("1.5", s)
 
     def test_parse_str_valid_choice(self) -> None:
         s = Setting(key="a.b", name="", description="", type="str", default="a", choices=["a", "b"])
@@ -377,7 +417,7 @@ class TestValidateConfigValue:
         assert parsed == ["KXCPI", "KXGDP"]
 
     def test_rejects_out_of_range(self) -> None:
-        with pytest.raises(ValueError, match="at most"):
+        with pytest.raises(ValueError, match="between"):
             validate_config_value("strategy.gimme_threshold", "200")
 
     def test_rejects_invalid_choice(self) -> None:


### PR DESCRIPTION
## Summary
- Add `ge`/`le` Pydantic Field constraints to 9 config fields that previously only had wizard-level validation via `json_schema_extra` metadata: 4 scanner fields and all 5 scoring weight fields
- Add `le=1_000_000.0` to `bankroll_real` for Pydantic-level enforcement
- Improve validation messages to show both bounds ("Must be between 0 and 100000") instead of only one ("Must be at most 100000") via new `_check_range` helper
- Enforce $1M bankroll cap in `_championship_gate` prompt (both new-bankroll and update-bankroll paths)

Closes #320

## Test plan
- [ ] Run `uv run pytest tests/unit/` — 782 tests pass (6 new)
- [ ] `gimmes config set scanner.min_volume -1` — rejects with "between" message
- [ ] `gimmes config set scoring.weights.edge_size 1.5` — rejects with "between" message
- [ ] `gimmes config set strategy.gimme_threshold 200` — shows "Must be between 0 and 100"
- [ ] Championship gate rejects bankroll > $1M

🤖 Generated with [Claude Code](https://claude.com/claude-code)