### PR TITLE
Improve error messages for invalid tickers and network failures

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -39,6 +39,17 @@ def _api_error_detail(e) -> str:  # type: ignore[no-untyped-def]
     return str(body.get("message") or body.get("error") or fallback)
 
 
+def _extract_ticker_from_url(exc) -> str | None:  # type: ignore[no-untyped-def]
+    """Try to extract a market ticker from the request URL in a 404 error."""
+    try:
+        parts = str(exc.request.url.path).split("/")
+        idx = parts.index("markets")
+        ticker = parts[idx + 1]
+    except (AttributeError, ValueError, IndexError):
+        return None
+    return ticker or None
+
+
 def _run(coro):  # type: ignore[no-untyped-def]
     """Run an async coroutine from sync CLI context with error handling."""
     import logging
@@ -53,16 +64,32 @@ def _run(coro):  # type: ignore[no-untyped-def]
         raise typer.Exit(130)
     except httpx.HTTPStatusError as e:
         logger.debug("API error", exc_info=True)
+        if e.response.status_code == 404:
+            ticker = _extract_ticker_from_url(e)
+            if ticker:
+                console.print(
+                    f"[red]Market ticker '{ticker}' not found."
+                    " Check the ticker and try again.[/red]"
+                )
+                raise typer.Exit(1)
         detail = _api_error_detail(e)
         console.print(f"[red]API error ({e.response.status_code}): {detail}[/red]")
         raise typer.Exit(1)
-    except httpx.TimeoutException as e:
+    except httpx.TimeoutException:
         logger.debug("Timeout error", exc_info=True)
-        console.print(f"[red]Request timed out: {e}[/red]")
+        console.print(
+            "[red]Request timed out.[/red] "
+            "Kalshi may be slow or unreachable. "
+            "Check your connection and try again."
+        )
         raise typer.Exit(1)
-    except httpx.TransportError as e:
+    except httpx.TransportError:
         logger.debug("Transport error", exc_info=True)
-        console.print(f"[red]Connection error: {e}[/red]")
+        console.print(
+            "[red]Connection error.[/red] "
+            "Could not reach Kalshi. "
+            "Check your internet connection and try again."
+        )
         raise typer.Exit(1)
     except sqlite3.Error as e:
         logger.warning("Database error: %s: %s", type(e).__name__, e, exc_info=True)

--- a/tests/unit/test_run_error_handling.py
+++ b/tests/unit/test_run_error_handling.py
@@ -13,9 +13,11 @@ from click.exceptions import Exit as ClickExit
 from gimmes.cli import _run
 
 
-def _make_response(status: int, *, json_data=None, text="") -> httpx.Response:
+def _make_response(
+    status: int, *, json_data=None, text="", url="https://api.example.com/test"
+) -> httpx.Response:
     """Build a fake httpx.Response for testing."""
-    request = httpx.Request("GET", "https://api.example.com/test")
+    request = httpx.Request("GET", url)
     if json_data is not None:
         return httpx.Response(status, json=json_data, request=request)
     return httpx.Response(status, text=text, request=request)
@@ -67,12 +69,35 @@ class TestRunHTTPStatusError:
         output = _run_expecting_exit(exc)
         assert "500" in output
 
+    def test_404_market_ticker_not_found(self) -> None:
+        resp = _make_response(
+            404,
+            json_data={"message": "market not found"},
+            url="https://api.elections.kalshi.com/trade-api/v2/markets/NONEXISTENT",
+        )
+        exc = httpx.HTTPStatusError("error", request=resp.request, response=resp)
+        output = _run_expecting_exit(exc)
+        assert "NONEXISTENT" in output
+        assert "not found" in output
+        assert "Check the ticker" in output
+
+    def test_404_non_market_url_shows_generic(self) -> None:
+        resp = _make_response(
+            404,
+            json_data={"message": "not found"},
+            url="https://api.elections.kalshi.com/trade-api/v2/portfolio/positions",
+        )
+        exc = httpx.HTTPStatusError("error", request=resp.request, response=resp)
+        output = _run_expecting_exit(exc)
+        assert "API error (404)" in output
+
 
 class TestRunTimeoutError:
     def test_timeout_exception(self) -> None:
         exc = httpx.ReadTimeout("Connection read timed out")
         output = _run_expecting_exit(exc)
         assert "timed out" in output.lower()
+        assert "try again" in output.lower()
 
 
 class TestRunTransportError:
@@ -80,7 +105,7 @@ class TestRunTransportError:
         exc = httpx.ConnectError("Connection refused")
         output = _run_expecting_exit(exc)
         assert "Connection error" in output
-        assert "Connection refused" in output
+        assert "try again" in output.lower()
 
 
 class TestRunExistingErrors:


### PR DESCRIPTION
## Summary
- Add 404-specific handling: when a market ticker URL returns 404, show "Market ticker 'XYZ' not found. Check the ticker and try again." instead of raw API error
- Non-market 404s (e.g., portfolio endpoints) fall through to the existing generic message
- Replace raw exception text in timeout/transport error messages with actionable user guidance
- Add `_extract_ticker_from_url` helper with narrowed exception handling (`AttributeError`, `ValueError`, `IndexError`)

Closes #321

## Test plan
- [ ] Run `uv run pytest tests/unit/` — 784 tests pass (2 new)
- [ ] `gimmes score NONEXISTENT` — shows "Market ticker 'NONEXISTENT' not found"
- [ ] Disconnect network, run `gimmes scan` — shows "Connection error. Could not reach Kalshi."

🤖 Generated with [Claude Code](https://claude.com/claude-code)