### PR TITLE
Default shell history clearing to no during init

### DIFF
--- a/src/gimmes/init.py
+++ b/src/gimmes/init.py
@@ -307,7 +307,7 @@ def _clear_shell_history(*, headless: bool = False) -> None:
         "\nAs a security precaution, shell history can be cleared "
         "to ensure no credentials remain on disk."
     )
-    if not typer.confirm("Clear shell history?", default=True):
+    if not typer.confirm("Clear shell history?", default=False):
         console.print("[dim]Skipped. You can clear history manually later.[/dim]")
         return
 


### PR DESCRIPTION
## Summary
- Change the "Clear shell history?" prompt default from `True` (opt-out) to `False` (opt-in)
- Pressing Enter without reading now safely skips history clearing instead of truncating all shell history
- Credentials are already protected by `hide_input=True` on the prompt, so the security rationale for defaulting to yes is weak

Closes #322

## Test plan
- [ ] Run `uv run pytest tests/unit/test_init.py` — 45 tests pass
- [ ] Run `gimmes init` — "Clear shell history?" prompt shows `[y/N]` instead of `[Y/n]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)