### PR TITLE
Expose series watchlist category groupings via CLI

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2187,7 +2187,7 @@ def config_get(
     """Show current configuration value(s)."""
     from rich.table import Table
 
-    from gimmes.config import _load_config_from_db
+    from gimmes.config import SERIES_CATEGORIES, _load_config_from_db
     from gimmes.config_wizard import (
         _format_current,
         _get_current_value,
@@ -2206,7 +2206,8 @@ def config_get(
             raise typer.Exit(1) from None
 
         current = _get_current_value(overrides, key, setting.default)
-        formatted = _format_current(current, setting, full=True)
+        categories = SERIES_CATEGORIES if key == "scanner.series" else None
+        formatted = _format_current(current, setting, full=True, categories=categories)
         console.print(f"[cyan]{key}[/cyan]: [bold]{formatted}[/bold]")
         console.print(f"[dim]Default: {_format_current(setting.default, setting)}[/dim]")
         console.print(f"[dim]{setting.description}[/dim]")

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -25,31 +25,44 @@ load_dotenv(dotenv_path=GIMMES_HOME / ".env")
 PROD_BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
 PROD_WS_URL = "wss://api.elections.kalshi.com/trade-api/ws/v2"
 
-# Curated series watchlist — used as the Pydantic default for ScannerConfig.series
-# and seeded into the database on first init.
-DEFAULT_SERIES = [
-    # Inflation & CPI
-    "KXCPI", "KXCPICORE", "KXCPIYOY", "KXCPICOREYOY",
-    "KXECONSTATCPI", "KXECONSTATCPICORE", "KXECONSTATCPIYOY", "KXECONSTATCORECPIYOY",
-    "KXPCECORE",
-    # GDP & Growth
-    "KXGDP", "KXGDPNOM", "KXGDPUSMAX",
-    # Fed & Rates
-    "KXFED", "KXFEDDECISION", "KXFEDCOMBO", "KXRATECUTCOUNT", "KXFEDCHGCOUNT",
-    "KXFEDMEET", "KXEMERCUTS", "KXFEDDISSENT",
-    # Employment
-    "KXJOBLESSCLAIMS", "KXUE", "KXU3", "KXPAYROLLS", "KXADP",
-    # Housing & Mortgage
-    "KXMORTGAGERATE", "KXHOUSINGSTART", "KXEHSALES", "KXNHSALES",
-    # Other Econ
-    "KXISMPMI", "KXRECSSNBER", "KXEFFTARIFF", "KXTARIFFREVENUE",
-    # Financials — S&P, Nasdaq, Treasuries
-    "KXINX", "KXINXU", "KXINXMAXY", "KXINXMINY",
-    "KXNASDAQ100", "KXNASDAQ100U", "KXNASDAQ100Y",
-    "KXUSTYLD", "KXTNOTEW", "KX10Y2Y", "KX10Y3M", "KX3MTBILL",
-    "KXGOLDW", "KXSILVERW", "KXWTI", "KXWTIMAX",
-    # Politics — high-level
-    "CONTROLH", "CONTROLS",
+# Curated series watchlist organised by category.  Used as the Pydantic
+# default for ScannerConfig.series and seeded into the database on first init.
+SERIES_CATEGORIES: dict[str, list[str]] = {
+    "Inflation & CPI": [
+        "KXCPI", "KXCPICORE", "KXCPIYOY", "KXCPICOREYOY",
+        "KXECONSTATCPI", "KXECONSTATCPICORE", "KXECONSTATCPIYOY",
+        "KXECONSTATCORECPIYOY", "KXPCECORE",
+    ],
+    "GDP & Growth": [
+        "KXGDP", "KXGDPNOM", "KXGDPUSMAX",
+    ],
+    "Fed & Rates": [
+        "KXFED", "KXFEDDECISION", "KXFEDCOMBO", "KXRATECUTCOUNT",
+        "KXFEDCHGCOUNT", "KXFEDMEET", "KXEMERCUTS", "KXFEDDISSENT",
+    ],
+    "Employment": [
+        "KXJOBLESSCLAIMS", "KXUE", "KXU3", "KXPAYROLLS", "KXADP",
+    ],
+    "Housing & Mortgage": [
+        "KXMORTGAGERATE", "KXHOUSINGSTART", "KXEHSALES", "KXNHSALES",
+    ],
+    "Other Econ": [
+        "KXISMPMI", "KXRECSSNBER", "KXEFFTARIFF", "KXTARIFFREVENUE",
+    ],
+    "Financials": [
+        "KXINX", "KXINXU", "KXINXMAXY", "KXINXMINY",
+        "KXNASDAQ100", "KXNASDAQ100U", "KXNASDAQ100Y",
+        "KXUSTYLD", "KXTNOTEW", "KX10Y2Y", "KX10Y3M", "KX3MTBILL",
+        "KXGOLDW", "KXSILVERW", "KXWTI", "KXWTIMAX",
+    ],
+    "Politics": [
+        "CONTROLH", "CONTROLS",
+    ],
+}
+
+# Flat list derived from the structured categories above.
+DEFAULT_SERIES: list[str] = [
+    t for tickers in SERIES_CATEGORIES.values() for t in tickers
 ]
 
 

--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -140,9 +140,34 @@ SECTION_KEYS = [key for key, _ in CONFIG_SECTIONS]
 # ---------------------------------------------------------------------------
 
 
-def _format_current(value: object, setting: Setting, *, full: bool = False) -> str:
+def _format_list_grouped(values: list[object], categories: dict[str, list[str]]) -> str:
+    """Format a list with items grouped under category headings."""
+    value_set = {str(v) for v in values}
+    parts: list[str] = []
+    categorised: set[str] = set()
+    for cat_name, cat_tickers in categories.items():
+        present = [t for t in cat_tickers if t in value_set]
+        if not present:
+            continue
+        categorised.update(present)
+        parts.append(f"\n  {cat_name} ({len(present)})\n    {', '.join(present)}")
+    other = [str(v) for v in values if str(v) not in categorised]
+    if other:
+        parts.append(f"\n  Other ({len(other)})\n    {', '.join(other)}")
+    return "".join(parts)
+
+
+def _format_current(
+    value: object,
+    setting: Setting,
+    *,
+    full: bool = False,
+    categories: dict[str, list[str]] | None = None,
+) -> str:
     """Format a value for display."""
     if setting.type == "list" and isinstance(value, list):
+        if full and categories:
+            return _format_list_grouped(value, categories)
         if full:
             return "\n  " + "\n  ".join(str(v) for v in value)
         if len(value) > 6:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,7 @@ import pytest
 
 from gimmes.config import (
     DEFAULT_SERIES,
+    SERIES_CATEGORIES,
     GimmesConfig,
     Mode,
     RiskConfig,
@@ -222,6 +223,14 @@ class TestDefaultSeries:
         save_config_value("scanner.series", [], db_path=db)
         config = load_config(db_path=db)
         assert config.scanner.series == []
+
+    def test_default_series_matches_categories(self):
+        flat = [t for tickers in SERIES_CATEGORIES.values() for t in tickers]
+        assert flat == DEFAULT_SERIES
+
+    def test_series_categories_no_duplicates(self):
+        all_tickers = [t for tickers in SERIES_CATEGORIES.values() for t in tickers]
+        assert len(all_tickers) == len(set(all_tickers)), "Duplicate ticker in SERIES_CATEGORIES"
 
 
 class TestMonitorPriceTrigger:

--- a/tests/unit/test_config_wizard.py
+++ b/tests/unit/test_config_wizard.py
@@ -253,6 +253,29 @@ class TestFormatCurrent:
         s = Setting(key="a.b", name="", description="", type="int", default=0)
         assert _format_current(75, s) == "75"
 
+    def test_format_list_full_with_categories(self) -> None:
+        s = Setting(key="a.b", name="", description="", type="list", default=[])
+        cats = {"CatA": ["X", "Y"], "CatB": ["Z"]}
+        result = _format_current(["X", "Y", "Z"], s, full=True, categories=cats)
+        assert "CatA (2)" in result
+        assert "CatB (1)" in result
+        assert "X, Y" in result
+
+    def test_format_list_full_categories_other_group(self) -> None:
+        s = Setting(key="a.b", name="", description="", type="list", default=[])
+        cats = {"CatA": ["X"]}
+        result = _format_current(["X", "CUSTOM"], s, full=True, categories=cats)
+        assert "CatA (1)" in result
+        assert "Other (1)" in result
+        assert "CUSTOM" in result
+
+    def test_format_list_full_categories_omits_empty(self) -> None:
+        s = Setting(key="a.b", name="", description="", type="list", default=[])
+        cats = {"CatA": ["X"], "CatB": ["Y"]}
+        result = _format_current(["X"], s, full=True, categories=cats)
+        assert "CatA" in result
+        assert "CatB" not in result
+
 
 # ---------------------------------------------------------------------------
 # Scoring weight validation


### PR DESCRIPTION
## Summary
- Define `SERIES_CATEGORIES` dict mapping 8 category names to their ticker lists
- Derive `DEFAULT_SERIES` from it so downstream consumers are unaffected
- Add `_format_list_grouped` helper that renders items under category headings with counts
- `gimmes config get scanner.series` now shows grouped output; user-added tickers appear under "Other"
- Add regression tests for categories-to-flat-list sync and duplicate detection

Closes #336

## Test plan
- [ ] Run `uv run pytest tests/unit/` — 793 tests pass (5 new)
- [ ] `gimmes config get scanner.series` — shows tickers grouped under category headings
- [ ] After `gimmes config add scanner.series CUSTOM`, re-run — CUSTOM appears under "Other"
- [ ] Verify `DEFAULT_SERIES` content unchanged via `test_default_series_matches_categories`

🤖 Generated with [Claude Code](https://claude.com/claude-code)