### PR TITLE
Backfill trade detail modal title from market API

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -758,9 +758,11 @@
                     if (item.ticker) {
                         const reqId = ++marketDetailRequestId;
                         fetchMarketDetail(item.ticker).then(function(md) {
-                            if (reqId !== marketDetailRequestId) return;
                             if (md && md.title) {
                                 tickerTitles[item.ticker] = md.title;
+                            }
+                            if (reqId !== marketDetailRequestId) return;
+                            if (md && md.title) {
                                 const titleEl = document.getElementById('modal-body-title');
                                 if (titleEl && titleEl.classList.contains('hidden')) {
                                     titleEl.textContent = md.title;


### PR DESCRIPTION
## Summary
- Always render the modal body title `<p>` element (hidden when empty) so it can be targeted for backfill
- After `fetchMarketDetail()` resolves, populate the title from `md.title` if the element is still hidden
- Also caches the title in `tickerTitles` so subsequent opens are instant

Closes #352

## Test plan
- [ ] Open a trade detail modal for a ticker with an **open position** — title should display immediately (no regression)
- [ ] Open a trade detail modal for a ticker **not** in positions or candidates (e.g., a historical/closed trade) — title should appear after market detail loads
- [ ] Open a trade detail modal for a ticker in the **candidates** list — title should display immediately (no regression)
- [ ] Verify 806 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)