### PR TITLE
Filter open positions from candidate pipeline

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -255,13 +255,32 @@ def scan(
     config = load_config()
 
     async def _scan() -> None:
+        import logging
+        import sqlite3
+
         from gimmes.kalshi.client import KalshiClient
         from gimmes.kalshi.markets import list_all_markets
         from gimmes.reporting.formatter import format_scan_results
+        from gimmes.store.database import Database
+        from gimmes.store.queries import get_position_tickers
         from gimmes.strategy.scanner import filter_markets
         from gimmes.strategy.scorer import quick_score
 
+        logger = logging.getLogger("gimmes.cli")
+
         series_tickers = series or config.scanner.series
+
+        # Exclude tickers with open positions
+        exclude_tickers: set[str] = set()
+        try:
+            async with Database(config.db_path) as db:
+                exclude_tickers = await get_position_tickers(db)
+            if exclude_tickers:
+                console.print(
+                    f"Excluding {len(exclude_tickers)} ticker(s) with open positions"
+                )
+        except sqlite3.OperationalError:
+            logger.debug("Could not load position tickers", exc_info=True)
 
         async with KalshiClient(config) as client:
             console.print("[cyan]Scanning markets...[/cyan]")
@@ -277,7 +296,7 @@ def scan(
                 markets = await list_all_markets(client)
                 console.print(f"Fetched {len(markets)} markets (all)")
 
-            candidates = filter_markets(markets, config)
+            candidates = filter_markets(markets, config, exclude_tickers=exclude_tickers)
             console.print(f"Filtered to {len(candidates)} candidates")
 
             scored = []

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -231,6 +231,13 @@ async def get_positions(db: Database) -> list[Position]:
     ]
 
 
+async def get_position_tickers(db: Database) -> set[str]:
+    """Return tickers of all open positions (count > 0)."""
+    cursor = await db.conn.execute("SELECT ticker FROM positions WHERE count > 0")
+    rows = await cursor.fetchall()
+    return {row["ticker"] for row in rows}
+
+
 async def delete_position(db: Database, ticker: str) -> None:
     """Remove a position (e.g., after settlement)."""
     await db.conn.execute("DELETE FROM positions WHERE ticker = ?", (ticker,))

--- a/src/gimmes/strategy/scanner.py
+++ b/src/gimmes/strategy/scanner.py
@@ -19,10 +19,16 @@ def days_until(dt: datetime | None) -> float | None:
     return delta.total_seconds() / 86400
 
 
-def filter_markets(markets: list[Market], config: GimmesConfig) -> list[Market]:
+def filter_markets(
+    markets: list[Market],
+    config: GimmesConfig,
+    *,
+    exclude_tickers: set[str] | None = None,
+) -> list[Market]:
     """Filter markets by gimme scanning criteria.
 
     Filters by:
+    - Excluded tickers (e.g. open positions)
     - Price range (min_market_price to max_market_price)
     - Minimum volume / open interest
     - Market status (active only)
@@ -36,6 +42,10 @@ def filter_markets(markets: list[Market], config: GimmesConfig) -> list[Market]:
     candidates: list[Market] = []
 
     for m in markets:
+        # Skip tickers with open positions
+        if exclude_tickers and m.ticker in exclude_tickers:
+            continue
+
         # Must be active
         if m.status != MarketStatus.ACTIVE:
             continue

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -72,3 +72,29 @@ class TestFilterMarkets:
 
     def test_empty_list(self, config: GimmesConfig) -> None:
         assert filter_markets([], config) == []
+
+    def test_exclude_tickers_filtered(self, config: GimmesConfig) -> None:
+        markets = [
+            _make_market(ticker="A"),
+            _make_market(ticker="B"),
+            _make_market(ticker="C"),
+        ]
+        result = filter_markets(markets, config, exclude_tickers={"A", "C"})
+        assert len(result) == 1
+        assert result[0].ticker == "B"
+
+    def test_exclude_tickers_none_passes_all(self, config: GimmesConfig) -> None:
+        markets = [
+            _make_market(ticker="A"),
+            _make_market(ticker="B"),
+        ]
+        result = filter_markets(markets, config, exclude_tickers=None)
+        assert len(result) == 2
+
+    def test_exclude_tickers_empty_set_passes_all(self, config: GimmesConfig) -> None:
+        markets = [
+            _make_market(ticker="A"),
+            _make_market(ticker="B"),
+        ]
+        result = filter_markets(markets, config, exclude_tickers=set())
+        assert len(result) == 2


### PR DESCRIPTION
## Summary
- Query open position tickers (`count > 0`) before scanning and pass them to `filter_markets()` as an `exclude_tickers` set
- Markets matching open positions are skipped at the earliest filter step, preventing wasted Caddie/Closer dispatches and spurious `skip` trades
- Narrowed error handling from bare `except Exception: pass` to `sqlite3.OperationalError` with debug logging

Closes #354

## Test plan
- [x] New unit tests: `test_exclude_tickers_filtered`, `test_exclude_tickers_none_passes_all`, `test_exclude_tickers_empty_set_passes_all`
- [x] Full unit test suite passes (812 tests)
- [x] Lint clean (`ruff check`)
- [ ] Run `gimmes scan` with open positions and verify excluded tickers message appears
- [ ] Run a full cycle and verify no re-research of held tickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)