### PR TITLE
Add scroll containment to Open Positions panel

### DIFF
--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -125,9 +125,9 @@
                         All sides
                     </button>
                 </h2>
-                <div class="overflow-x-auto">
+                <div id="positions-scroll" class="max-h-[500px] overflow-x-auto overflow-y-auto scrollbar-thin">
                     <table class="w-full text-sm">
-                        <thead>
+                        <thead class="sticky top-0 bg-slate-800 z-10">
                             <tr class="text-xs uppercase tracking-wider text-slate-500 border-b border-slate-700/50">
                                 <th class="text-left pb-2 pr-3">Ticker</th>
                                 <th class="text-left pb-2 pr-3">Side</th>


### PR DESCRIPTION
## Summary
- Add `max-h-[500px] overflow-y-auto scrollbar-thin` to the Open Positions panel container so it scrolls vertically when content exceeds the panel height
- Add sticky table header (`sticky top-0 bg-slate-800 z-10`) so column labels remain visible during scroll
- Scroll-to-load pagination deferred to #368 — positions are bounded by `max_open_positions` and use full SSE snapshots, making cursor pagination unnecessary for now

Closes #357

## Test plan
- [ ] Open dashboard with 15+ open positions and verify the panel scrolls at ~500px
- [ ] Verify sticky header stays visible while scrolling through positions
- [ ] Verify side filter (All/YES/NO) still works within scrollable container
- [ ] Verify row click opens position detail modal
- [ ] Verify horizontal scroll still works on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)