### PR TITLE
Checkout latest release tag on fresh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,19 @@ check_command() {
     return 0
 }
 
+checkout_latest_tag() {
+    local tag
+    tag=$(git tag -l 'v[0-9]*' --sort=-v:refname 2>/dev/null | head -1)
+    if [ -z "$tag" ]; then
+        return 1
+    fi
+    if ! git checkout --quiet "$tag" 2>/dev/null; then
+        warn "Could not check out tag $tag; staying on current branch"
+        return 1
+    fi
+    ok "Checked out $tag"
+}
+
 show_banner() {
     local version
     version=$(git -C "$REPO_DIR" describe --tags 2>/dev/null || git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo "dev")
@@ -124,8 +137,16 @@ fi
 if [ -d "$REPO_DIR/.git" ]; then
     info "Updating existing installation..."
     cd "$REPO_DIR"
-    git pull --ff-only origin main
-    ok "Updated to $(git rev-parse --short HEAD)"
+    if ! git fetch --quiet --tags origin main 2>/dev/null; then
+        err "Could not reach the remote repository."
+        err "Check your network connection and try again."
+        exit 1
+    fi
+    if ! checkout_latest_tag; then
+        git checkout --quiet main 2>/dev/null || true
+        git pull --ff-only origin main
+        ok "Updated to $(git rev-parse --short HEAD)"
+    fi
 else
     info "Cloning gimmes..."
     MAX_RETRIES=3
@@ -145,6 +166,10 @@ else
         fi
     done
     ok "Cloned to $REPO_DIR"
+    cd "$REPO_DIR"
+    if ! checkout_latest_tag; then
+        info "No release tags found; staying on default branch"
+    fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `checkout_latest_tag()` function to `install.sh` that resolves the latest `v*` tag and checks it out
- Fresh clone path now checks out the latest tag after cloning (falls back to main if no tags)
- Update-via-install path now fetches tags and checks out the latest (falls back to main with detached HEAD recovery)
- Explicit error handling for git fetch failures, checkout failures, and detached HEAD state

Closes #372

## Test plan
- [x] `uv run pytest tests/unit/` — 836 tests pass
- [x] Verified `checkout_latest_tag` checks exit code of `git checkout` before printing success
- [x] Verified `git fetch` failure gives user-friendly error message
- [x] Verified detached HEAD from prior tag checkout doesn't break update fallback (`git checkout main` before `git pull`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)