### PR TITLE
Add staleness check to get_position_tickers()

### DIFF
--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -184,18 +184,17 @@ async def sync_positions_with_trade(
         return await _insert_trade_row(db, trade)
 
 
-async def get_positions(db: Database) -> list[Position]:
-    """Get all stored positions.
+async def _check_position_staleness(db: Database, table: str) -> None:
+    """Log a warning if position data may be stale.
 
-    Logs a warning if positions are stale (updated_at older than the most
-    recent trade timestamp), which can happen after a crash between trade
-    insertion and position sync.
+    Only applies to the ``positions`` table — paper_positions are updated
+    inline by the paper broker and cannot become stale in this way.
     """
+    if table != "positions":
+        return
     logger = logging.getLogger(__name__)
-
-    # Check for staleness: latest trade newer than latest position update.
-    # Normalize timestamps with datetime() since trades use ISO format (T separator)
-    # while positions use SQLite datetime() format (space separator).
+    # Normalize timestamps with datetime() since trades use ISO format
+    # (T separator) while positions use SQLite datetime() format (space).
     stale_cursor = await db.conn.execute(
         """SELECT
             datetime((SELECT MAX(timestamp) FROM trades)) AS latest_trade,
@@ -211,6 +210,16 @@ async def get_positions(db: Database) -> list[Position]:
                 stale_row["latest_trade"],
                 stale_row["latest_pos"],
             )
+
+
+async def get_positions(db: Database) -> list[Position]:
+    """Get all stored positions.
+
+    Logs a warning if positions are stale (updated_at older than the most
+    recent trade timestamp), which can happen after a crash between trade
+    insertion and position sync.
+    """
+    await _check_position_staleness(db, "positions")
 
     cursor = await db.conn.execute("SELECT * FROM positions WHERE count > 0")
     rows = await cursor.fetchall()
@@ -240,6 +249,7 @@ async def get_position_tickers(
     """Return tickers of all open positions (count > 0)."""
     if table not in _ALLOWED_POSITION_TABLES:
         raise ValueError(f"Invalid position table: {table}")
+    await _check_position_staleness(db, table)
     cursor = await db.conn.execute(
         f"SELECT ticker FROM {table} WHERE count > 0"  # noqa: S608
     )

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -11,6 +11,7 @@ import httpx
 
 from gimmes.models.error import ErrorCategory, ErrorSeverity
 from gimmes.models.order import Order, OrderAction, OrderSide
+from gimmes.models.portfolio import Position
 
 _ORDER_CLI_ARGS = [
     "order", "TEST-TICKER",
@@ -585,9 +586,7 @@ class TestTradeRationalePropagation:
 # ---------------------------------------------------------------------------
 
 
-def _position_for_size_up():
-    from gimmes.models.portfolio import Position
-
+def _position_for_size_up() -> Position:
     return Position(
         ticker="TEST-TICKER", side="yes", count=5,
         avg_price=0.40, cost_basis=2.0,
@@ -725,6 +724,20 @@ class TestSizeUpThesisAnchoring:
 # ---------------------------------------------------------------------------
 
 
+def _assert_thesis_fetch_error(mock_insert) -> None:
+    """Verify the first logged error is a thesis_fetch_failed DATA_INTEGRITY entry."""
+    entry = _error_entry(mock_insert)
+    assert entry.severity == ErrorSeverity.WARNING
+    assert entry.category == ErrorCategory.DATA_INTEGRITY
+    assert entry.error_code == "thesis_fetch_failed"
+    assert "TEST-TICKER" in entry.message
+    ctx = json.loads(entry.context)
+    assert ctx == {
+        "ticker": "TEST-TICKER", "side": "yes",
+        "count": 10, "price": 0.4,
+    }
+
+
 class TestThesisFetchErrorLogging:
     """Verify thesis fetch failures create structured DATA_INTEGRITY errors."""
 
@@ -742,17 +755,7 @@ class TestThesisFetchErrorLogging:
             )
 
         assert result.exit_code == 0
-        assert mock_insert.call_count >= 1
-        entry = mock_insert.call_args_list[0].args[1]
-        assert entry.severity == ErrorSeverity.WARNING
-        assert entry.category == ErrorCategory.DATA_INTEGRITY
-        assert entry.error_code == "thesis_fetch_failed"
-        assert "TEST-TICKER" in entry.message
-        ctx = json.loads(entry.context)
-        assert ctx == {
-            "ticker": "TEST-TICKER", "side": "yes",
-            "count": 10, "price": 0.4,
-        }
+        _assert_thesis_fetch_error(mock_insert)
 
     def test_size_up_thesis_fetch_db_error_creates_structured_error(self) -> None:
         """sqlite3.Error during size-up thesis fetch records a DATA_INTEGRITY error."""
@@ -779,14 +782,4 @@ class TestThesisFetchErrorLogging:
             )
 
         assert result.exit_code == 0
-        assert mock_insert.call_count >= 1
-        entry = mock_insert.call_args_list[0].args[1]
-        assert entry.severity == ErrorSeverity.WARNING
-        assert entry.category == ErrorCategory.DATA_INTEGRITY
-        assert entry.error_code == "thesis_fetch_failed"
-        assert "TEST-TICKER" in entry.message
-        ctx = json.loads(entry.context)
-        assert ctx == {
-            "ticker": "TEST-TICKER", "side": "yes",
-            "count": 10, "price": 0.4,
-        }
+        _assert_thesis_fetch_error(mock_insert)

--- a/tests/unit/test_prune_candidates.py
+++ b/tests/unit/test_prune_candidates.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
 
 from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
 from gimmes.store.database import Database
 from gimmes.store.queries import (
     get_position_tickers,
     insert_candidate,
+    insert_trade,
     prune_candidates,
     upsert_position,
 )
@@ -45,6 +48,36 @@ def _pos(ticker: str) -> Position:
         ticker=ticker, side="yes", count=10, avg_price=0.5,
         market_price=0.5, cost_basis=5.0,
     )
+
+
+def _trade(ticker: str) -> TradeDecision:
+    return TradeDecision(
+        ticker=ticker, action=TradeDecision.Action.OPEN,
+        side="yes", count=10, price=0.50,
+    )
+
+
+async def _create_paper_position(db: Database, ticker: str, count: int = 5) -> None:
+    """Create the paper_positions table and insert a single row."""
+    await db.conn.execute(
+        """CREATE TABLE IF NOT EXISTS paper_positions (
+            ticker TEXT NOT NULL,
+            side TEXT NOT NULL DEFAULT 'yes',
+            count INTEGER NOT NULL DEFAULT 0,
+            avg_price REAL NOT NULL DEFAULT 0,
+            market_price REAL NOT NULL DEFAULT 0,
+            cost_basis REAL NOT NULL DEFAULT 0,
+            market_value REAL NOT NULL DEFAULT 0,
+            unrealized_pnl REAL NOT NULL DEFAULT 0,
+            realized_pnl REAL NOT NULL DEFAULT 0,
+            PRIMARY KEY (ticker, side)
+        )"""
+    )
+    await db.conn.execute(
+        "INSERT INTO paper_positions (ticker, count) VALUES (?, ?)",
+        (ticker, count),
+    )
+    await db.conn.commit()
 
 
 class TestPruneCandidates:
@@ -204,25 +237,7 @@ class TestGetPositionTickers:
         assert result == set()
 
     async def test_custom_table(self, db):
-        # Create paper_positions table
-        await db.conn.execute(
-            """CREATE TABLE IF NOT EXISTS paper_positions (
-                ticker TEXT NOT NULL,
-                side TEXT NOT NULL DEFAULT 'yes',
-                count INTEGER NOT NULL DEFAULT 0,
-                avg_price REAL NOT NULL DEFAULT 0,
-                market_price REAL NOT NULL DEFAULT 0,
-                cost_basis REAL NOT NULL DEFAULT 0,
-                market_value REAL NOT NULL DEFAULT 0,
-                unrealized_pnl REAL NOT NULL DEFAULT 0,
-                realized_pnl REAL NOT NULL DEFAULT 0,
-                PRIMARY KEY (ticker, side)
-            )"""
-        )
-        await db.conn.execute(
-            "INSERT INTO paper_positions (ticker, count) VALUES ('PAPER-1', 5)"
-        )
-        await db.conn.commit()
+        await _create_paper_position(db, "PAPER-1")
 
         result = await get_position_tickers(db, table="paper_positions")
         assert result == {"PAPER-1"}
@@ -230,3 +245,43 @@ class TestGetPositionTickers:
     async def test_invalid_table_raises(self, db):
         with pytest.raises(ValueError, match="Invalid position table"):
             await get_position_tickers(db, table="evil_table")
+
+
+class TestGetPositionTickersStalenessWarning:
+    async def test_warns_when_stale(self, db, caplog):
+        """Warning when latest trade is newer than latest position update."""
+        await upsert_position(db, _pos("TICK-1"))
+        await insert_trade(db, _trade("TICK-1"))
+        # Push trade timestamp ahead of position updated_at
+        await db.conn.execute(
+            "UPDATE trades SET timestamp = datetime('now', '+1 minute') "
+            "WHERE ticker = 'TICK-1'"
+        )
+        await db.conn.commit()
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
+            result = await get_position_tickers(db)
+
+        assert "stale" in caplog.text.lower()
+        assert result == {"TICK-1"}
+
+    async def test_no_warning_when_fresh(self, db, caplog):
+        """No warning when positions are fresher than trades."""
+        await insert_trade(db, _trade("TICK-1"))
+        await upsert_position(db, _pos("TICK-1"))
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
+            result = await get_position_tickers(db)
+
+        assert "stale" not in caplog.text.lower()
+        assert result == {"TICK-1"}
+
+    async def test_no_warning_for_paper_positions(self, db, caplog):
+        """Staleness check is skipped for paper_positions table."""
+        await _create_paper_position(db, "PAPER-1")
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
+            result = await get_position_tickers(db, table="paper_positions")
+
+        assert "stale" not in caplog.text.lower()
+        assert result == {"PAPER-1"}


### PR DESCRIPTION
## Summary
- Extract `_check_position_staleness()` helper from the inline staleness logic in `get_positions()` so both `get_positions()` and `get_position_tickers()` share the same check
- `get_position_tickers()` now warns when position data lags behind trade data, matching the behavior of `get_positions()`
- Staleness check is skipped for `paper_positions` since the paper broker updates positions inline

Closes #365

## Test plan
- [x] `test_warns_when_stale` — verifies warning when trades are newer than positions
- [x] `test_no_warning_when_fresh` — verifies no warning when positions are current
- [x] `test_no_warning_for_paper_positions` — verifies check is skipped for paper table
- [x] Existing `TestGetPositionsStalenessWarning` tests pass (refactor preserved behavior)
- [x] All 857 unit tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)