### PR TITLE
Fix Starter agent tour UX

### DIFF
--- a/.claude/agents/starter.md
+++ b/.claude/agents/starter.md
@@ -78,6 +78,9 @@ Introduce the agent crew at a product level — what each one does, not how they
 - **The Scorecard** — Tracks performance — P&L, win rate, edge accuracy. Keeps score.
 - **The Groundskeeper** — Reviews errors and escalates problems. Keeps the course in shape.
 - **The Pro** — Analyzes strategy performance and recommends parameter changes backed by data.
+- **The Caddie Master** — Orchestrates the autonomous trading pipeline, dispatches agents and manages cycle state.
+- **The Caddie Shop** — Conversational configuration advisor, helps tune strategy parameters through the CLI.
+- **The Starter** — The tour guide. That's you.
 
 No demo command for this stop — just the introductions.
 
@@ -121,7 +124,7 @@ Explain how the autonomous loop works — MUST mention all of these:
 - You can also run individual steps manually: `gimmes scan`, `gimmes positions`, `gimmes report`
 - Ctrl+C stops the loop anytime
 
-Demo: `gimmes --help`
+Demo: `gimmes help`
 
 Show the full list of available commands and briefly highlight the key ones.
 
@@ -130,7 +133,8 @@ Show the full list of available commands and briefly highlight the key ones.
 After the last stop, wrap up:
 - Suggest next steps the user can take after the tour: run `gimmes init` for first-time setup, or `gimmes driving_range` to start paper trading — but do not run these yourself
 - Remind them about the Clubhouse dashboard
-- Ask if they have any questions or feature ideas they'd like to share
+- Let the user know that if they have improvement ideas, you can file them as GitHub issues on their behalf — just describe the idea and you'll handle the rest
+- Tell the user they can type `/exit` to leave the tour
 
 ## Safe Demo Commands
 
@@ -138,7 +142,7 @@ These are the ONLY `gimmes` commands you are allowed to run. NEVER run any `gimm
 
 ```
 gimmes mode
-gimmes --help
+gimmes help
 gimmes scan [--limit N]
 gimmes score TICKER
 gimmes market-info TICKER

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2506,8 +2506,12 @@ def _launch_claude_agent(
     opening_message: str,
     closing_message: str,
     interrupt_message: str,
+    initial_prompt: str | None = None,
 ) -> None:
     """Find the 'claude' CLI and launch a named agent session.
+
+    If *initial_prompt* is provided it is passed as a positional argument
+    so the agent session opens in interactive mode with pre-filled input.
 
     Handles missing binary, KeyboardInterrupt, OSError, and non-zero exit.
     """
@@ -2523,9 +2527,13 @@ def _launch_claude_agent(
     project_root = Path(__file__).resolve().parent.parent.parent
     console.print(opening_message)
 
+    cmd = [claude_path, "--agent", agent, "--name", session_name]
+    if initial_prompt is not None:
+        cmd.append(initial_prompt)
+
     try:
         result = subprocess.run(
-            [claude_path, "--agent", agent, "--name", session_name],
+            cmd,
             cwd=project_root,
             check=False,
         )
@@ -2551,6 +2559,13 @@ def _launch_claude_agent(
 @app.command(name="tour_guide", rich_help_panel="Setup & Config")
 def tour_guide() -> None:
     """Launch The Starter — an interactive GIMMES product tour."""
+    import getpass
+
+    try:
+        username = getpass.getuser()
+    except Exception:
+        username = "there"
+
     _launch_claude_agent(
         "Starter", "GIMMES Tour",
         opening_message=(
@@ -2559,6 +2574,7 @@ def tour_guide() -> None:
         ),
         closing_message="\n[yellow]Tour ended. Happy trading![/yellow]",
         interrupt_message="\n[dim]Tour interrupted.[/dim]",
+        initial_prompt=f"Hi, I am {username}",
     )
 
 

--- a/tests/unit/test_tour_guide.py
+++ b/tests/unit/test_tour_guide.py
@@ -32,6 +32,7 @@ class TestTourGuideCommand:
         with (
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+            patch("getpass.getuser", return_value="testplayer"),
         ):
             tour_guide()
 
@@ -41,7 +42,21 @@ class TestTourGuideCommand:
         assert "Starter" in cmd
         assert "--name" in cmd
         assert "GIMMES Tour" in cmd
+        # Initial prompt is a positional arg (not -p which is non-interactive)
+        assert cmd[-1] == "Hi, I am testplayer"
+        assert "-p" not in cmd
         assert mock_run.call_args.kwargs["cwd"] is not None
+
+    def test_username_fallback_on_getuser_failure(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+            patch("getpass.getuser", side_effect=KeyError("getpwuid")),
+        ):
+            tour_guide()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[-1] == "Hi, I am there"
 
     def test_reports_nonzero_exit(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Pass initial prompt as positional arg so tour auto-starts with personalized greeting ("Hi, I am {username}") instead of waiting for user input
- Add Caddie Master, Caddie Shop, and Starter to Stop 2 team introductions (was missing 3 of 10 agents)
- Change Stop 5 demo from `gimmes --help` (raw Typer output) to `gimmes help` (curated reference card)
- Update Tour Complete wrap-up to mention `/exit` and feature request filing capability

Closes #386

## Test plan

- [ ] Run `gimmes tour_guide` and verify the Starter greets immediately without needing user input
- [ ] Verify the Welcome message addresses the user by name
- [ ] Take the guided tour and confirm Stop 2 introduces all 10 agents
- [ ] Confirm Stop 5 runs `gimmes help` and shows the curated reference card
- [ ] Confirm Tour Complete wrap-up mentions `/exit`
- [ ] Confirm Tour Complete wrap-up mentions the ability to file feature requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)