### PR TITLE
Add auto-start and exit hint to Caddie Shop agent

### DIFF
--- a/.claude/agents/caddie-shop.md
+++ b/.claude/agents/caddie-shop.md
@@ -179,3 +179,4 @@ Stay on topic. If the user drifts, redirect politely:
 - For multi-parameter suggestions, explain the rationale for the package of changes
 - Never set `risk.bankroll_real` to a non-zero value without warning the user that this is real money
 - Keep explanations concise — let the user ask follow-ups rather than over-explaining
+- After completing the user's first request, mention that they can type `/exit` when they're done

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2499,6 +2499,16 @@ def clubhouse(
 # ---------------------------------------------------------------------------
 
 
+def _get_username() -> str:
+    """Return the OS username, or ``'there'`` as a safe fallback."""
+    import getpass
+
+    try:
+        return getpass.getuser()
+    except Exception:
+        return "there"
+
+
 def _launch_claude_agent(
     agent: str,
     session_name: str,
@@ -2559,13 +2569,6 @@ def _launch_claude_agent(
 @app.command(name="tour_guide", rich_help_panel="Setup & Config")
 def tour_guide() -> None:
     """Launch The Starter — an interactive GIMMES product tour."""
-    import getpass
-
-    try:
-        username = getpass.getuser()
-    except Exception:
-        username = "there"
-
     _launch_claude_agent(
         "Starter", "GIMMES Tour",
         opening_message=(
@@ -2574,7 +2577,7 @@ def tour_guide() -> None:
         ),
         closing_message="\n[yellow]Tour ended. Happy trading![/yellow]",
         interrupt_message="\n[dim]Tour interrupted.[/dim]",
-        initial_prompt=f"Hi, I am {username}",
+        initial_prompt=f"Hi, I am {_get_username()}",
     )
 
 
@@ -2589,6 +2592,7 @@ def caddie_shop() -> None:
         ),
         closing_message="\n[yellow]Caddie Shop session ended.[/yellow]",
         interrupt_message="\n[dim]Caddie Shop closed.[/dim]",
+        initial_prompt=f"Hi, I am {_get_username()}",
     )
 
 

--- a/tests/unit/test_caddie_shop.py
+++ b/tests/unit/test_caddie_shop.py
@@ -1,0 +1,106 @@
+"""Tests for gimmes caddie_shop command (The Caddie Shop)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.exceptions import Exit as ClickExit
+
+from gimmes.cli import app, caddie_shop
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+class TestCaddieShopCommand:
+    def test_command_exists(self) -> None:
+        commands = {cmd.name for cmd in app.registered_commands}
+        assert "caddie_shop" in commands
+
+    def test_exits_when_claude_not_found(self) -> None:
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(ClickExit) as exc_info:
+                caddie_shop()
+            assert exc_info.value.exit_code == 1
+
+    def test_passes_correct_subprocess_args(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+            patch("getpass.getuser", return_value="testplayer"),
+        ):
+            caddie_shop()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "/usr/bin/claude"
+        assert "--agent" in cmd
+        assert "Caddie Shop" in cmd
+        assert "--name" in cmd
+        assert "GIMMES Caddie Shop" in cmd
+        # Initial prompt is a positional arg (not -p which is non-interactive)
+        assert cmd[-1] == "Hi, I am testplayer"
+        assert "-p" not in cmd
+        assert mock_run.call_args.kwargs["cwd"] is not None
+
+    def test_username_fallback_on_getuser_failure(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+            patch("getpass.getuser", side_effect=KeyError("getpwuid")),
+        ):
+            caddie_shop()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[-1] == "Hi, I am there"
+
+    def test_reports_nonzero_exit(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", return_value=MagicMock(returncode=2)),
+        ):
+            with pytest.raises(ClickExit) as exc_info:
+                caddie_shop()
+            assert exc_info.value.exit_code == 1
+
+    def test_keyboard_interrupt_exits_130(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", side_effect=KeyboardInterrupt),
+        ):
+            with pytest.raises(ClickExit) as exc_info:
+                caddie_shop()
+            assert exc_info.value.exit_code == 130
+
+    def test_os_error_exits_with_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", side_effect=OSError("Permission denied")),
+        ):
+            with pytest.raises(ClickExit) as exc_info:
+                caddie_shop()
+            assert exc_info.value.exit_code == 1
+
+        output = capsys.readouterr().out
+        assert "Permission denied" in output
+
+
+# ---------------------------------------------------------------------------
+# Agent files
+# ---------------------------------------------------------------------------
+
+
+class TestCaddieShopAgent:
+    _agent_path = _PROJECT_ROOT / ".claude" / "agents" / "caddie-shop.md"
+
+    def test_agent_file_exists(self) -> None:
+        assert self._agent_path.exists()
+
+    def test_agent_has_frontmatter(self) -> None:
+        content = self._agent_path.read_text()
+        assert "name: Caddie Shop" in content
+        assert "tools:" in content


### PR DESCRIPTION
## Summary

- Extract shared `_get_username()` helper for OS username resolution with fallback
- Pass `initial_prompt` to `caddie_shop()` so the session starts immediately with a personalized greeting instead of waiting for user input
- Add `/exit` hint to Caddie Shop Rules so the agent mentions it after handling the user's first request
- Add `test_caddie_shop.py` with full CLI command and agent file coverage

Closes #388

## Test plan

- [ ] Run `gimmes caddie_shop` and verify it greets immediately without needing user input
- [ ] Verify the Welcome message addresses the user by name
- [ ] Verify the agent mentions `/exit` after handling the first request

🤖 Generated with [Claude Code](https://claude.com/claude-code)