### PR TITLE
Pass --allowedTools to Starter and Caddie Shop sessions

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2516,9 +2516,14 @@ def _launch_claude_agent(
     opening_message: str,
     closing_message: str,
     interrupt_message: str,
+    allowed_tools: list[str],
     initial_prompt: str | None = None,
 ) -> None:
     """Find the 'claude' CLI and launch a named agent session.
+
+    *allowed_tools* lists tool names to pre-approve via ``--allowedTools``
+    so the agent can run without permission prompts.  Must match the
+    agent's frontmatter ``tools:`` list.
 
     If *initial_prompt* is provided it is passed as a positional argument
     so the agent session opens in interactive mode with pre-filled input.
@@ -2537,7 +2542,11 @@ def _launch_claude_agent(
     project_root = Path(__file__).resolve().parent.parent.parent
     console.print(opening_message)
 
-    cmd = [claude_path, "--agent", agent, "--name", session_name]
+    cmd = [
+        claude_path, "--agent", agent,
+        "--name", session_name,
+        "--allowedTools", ",".join(allowed_tools),
+    ]
     if initial_prompt is not None:
         cmd.append(initial_prompt)
 
@@ -2577,6 +2586,7 @@ def tour_guide() -> None:
         ),
         closing_message="\n[yellow]Tour ended. Happy trading![/yellow]",
         interrupt_message="\n[dim]Tour interrupted.[/dim]",
+        allowed_tools=["Bash", "Read", "Glob", "Grep", "WebSearch", "WebFetch"],
         initial_prompt=f"Hi, I am {_get_username()}",
     )
 
@@ -2592,6 +2602,7 @@ def caddie_shop() -> None:
         ),
         closing_message="\n[yellow]Caddie Shop session ended.[/yellow]",
         interrupt_message="\n[dim]Caddie Shop closed.[/dim]",
+        allowed_tools=["Bash", "Read", "Glob", "Grep"],
         initial_prompt=f"Hi, I am {_get_username()}",
     )
 

--- a/tests/unit/test_caddie_shop.py
+++ b/tests/unit/test_caddie_shop.py
@@ -45,6 +45,10 @@ class TestCaddieShopCommand:
         # Initial prompt is a positional arg (not -p which is non-interactive)
         assert cmd[-1] == "Hi, I am testplayer"
         assert "-p" not in cmd
+        # Tools pre-approved so agent runs without permission prompts
+        allowed = set(cmd[cmd.index("--allowedTools") + 1].split(","))
+        assert {"Bash", "Grep"} <= allowed
+        assert allowed.isdisjoint({"WebSearch", "WebFetch"})
         assert mock_run.call_args.kwargs["cwd"] is not None
 
     def test_username_fallback_on_getuser_failure(self) -> None:

--- a/tests/unit/test_tour_guide.py
+++ b/tests/unit/test_tour_guide.py
@@ -45,6 +45,9 @@ class TestTourGuideCommand:
         # Initial prompt is a positional arg (not -p which is non-interactive)
         assert cmd[-1] == "Hi, I am testplayer"
         assert "-p" not in cmd
+        # Tools pre-approved so agent runs without permission prompts
+        allowed = set(cmd[cmd.index("--allowedTools") + 1].split(","))
+        assert {"Bash", "WebSearch", "WebFetch"} <= allowed
         assert mock_run.call_args.kwargs["cwd"] is not None
 
     def test_username_fallback_on_getuser_failure(self) -> None:


### PR DESCRIPTION
## Summary

- Add required `allowed_tools: list[str]` parameter to `_launch_claude_agent()` that is forwarded as `--allowedTools` in the subprocess command
- Starter gets `Bash,Read,Glob,Grep,WebSearch,WebFetch`; Caddie Shop gets `Bash,Read,Glob,Grep` — matching their agent frontmatter
- Both agent sessions now run without interrupting the user with permission prompts

Closes #389

## Test plan

- [ ] Run `gimmes tour_guide` and verify demo commands execute without permission prompts
- [ ] Run `gimmes caddie_shop` and verify commands execute without permission prompts
- [ ] Verify the autonomous loop still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)