### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.2] - 2026-03-22
+
+### Added
+- Auto-start greeting and exit hint for Caddie Shop agent sessions
+- Agent sessions (Starter, Caddie Shop) now run without tool-permission prompts via `--allowedTools` enforcement
+
+### Fixed
+- Starter agent tour UX: auto-start greeting, complete team roster, curated help output, and exit hint
+
 ## [0.1.1] - 2026-03-22
 
 ### Added
@@ -79,5 +88,6 @@ on Kalshi prediction markets using a team of Claude Code agents.
 - Self-update command with stale-code protection and tag-based version
   checks
 
+[0.1.2]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.1.2
 [0.1.1]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.1.1
 [0.1.0]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gimmes"
-version = "0.1.1"
+version = "0.1.2"
 description = "Autonomous Claude Code agent system for trading Kalshi prediction markets"
 readme = "README.md"
 license = "MIT"

--- a/src/gimmes/__init__.py
+++ b/src/gimmes/__init__.py
@@ -1,3 +1,3 @@
 """GIMMES — We only play the gimmes."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
## Release v0.1.2

## [0.1.2] - 2026-03-22

### Added
- Auto-start greeting and exit hint for Caddie Shop agent sessions
- Agent sessions (Starter, Caddie Shop) now run without tool-permission prompts via `--allowedTools` enforcement

### Fixed
- Starter agent tour UX: auto-start greeting, complete team roster, curated help output, and exit hint

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)