### PR TITLE
Fix initial_prompt argument order for agent auto-start

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2542,13 +2542,14 @@ def _launch_claude_agent(
     project_root = Path(__file__).resolve().parent.parent.parent
     console.print(opening_message)
 
-    cmd = [
-        claude_path, "--agent", agent,
-        "--name", session_name,
-        "--allowedTools", ",".join(allowed_tools),
-    ]
+    cmd = [claude_path]
     if initial_prompt is not None:
         cmd.append(initial_prompt)
+    cmd.extend([
+        "--agent", agent,
+        "--name", session_name,
+        "--allowedTools", ",".join(allowed_tools),
+    ])
 
     try:
         result = subprocess.run(

--- a/tests/unit/test_caddie_shop.py
+++ b/tests/unit/test_caddie_shop.py
@@ -43,7 +43,7 @@ class TestCaddieShopCommand:
         assert "--name" in cmd
         assert "GIMMES Caddie Shop" in cmd
         # Initial prompt is a positional arg (not -p which is non-interactive)
-        assert cmd[-1] == "Hi, I am testplayer"
+        assert cmd[1] == "Hi, I am testplayer"
         assert "-p" not in cmd
         # Tools pre-approved so agent runs without permission prompts
         allowed = set(cmd[cmd.index("--allowedTools") + 1].split(","))
@@ -59,7 +59,7 @@ class TestCaddieShopCommand:
             caddie_shop()
 
         cmd = mock_run.call_args.args[0]
-        assert cmd[-1] == "Hi, I am there"
+        assert cmd[1] == "Hi, I am there"
 
     def test_reports_nonzero_exit(self) -> None:
         with (

--- a/tests/unit/test_tour_guide.py
+++ b/tests/unit/test_tour_guide.py
@@ -43,7 +43,7 @@ class TestTourGuideCommand:
         assert "--name" in cmd
         assert "GIMMES Tour" in cmd
         # Initial prompt is a positional arg (not -p which is non-interactive)
-        assert cmd[-1] == "Hi, I am testplayer"
+        assert cmd[1] == "Hi, I am testplayer"
         assert "-p" not in cmd
         # Tools pre-approved so agent runs without permission prompts
         allowed = set(cmd[cmd.index("--allowedTools") + 1].split(","))
@@ -59,7 +59,7 @@ class TestTourGuideCommand:
             tour_guide()
 
         cmd = mock_run.call_args.args[0]
-        assert cmd[-1] == "Hi, I am there"
+        assert cmd[1] == "Hi, I am there"
 
     def test_reports_nonzero_exit(self) -> None:
         with (
@@ -79,7 +79,7 @@ class TestTourGuideCommand:
                 tour_guide()
             assert exc_info.value.exit_code == 130
 
-    def test_os_error_exits_with_message(self, capsys) -> None:  # type: ignore[no-untyped-def]
+    def test_os_error_exits_with_message(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch("subprocess.run", side_effect=OSError("Permission denied")),
@@ -107,5 +107,3 @@ class TestStarterAgent:
         content = self._agent_path.read_text()
         assert "name: Starter" in content
         assert "tools:" in content
-
-


### PR DESCRIPTION
## Summary

- Move `initial_prompt` from end of subprocess command to position 1 (right after `claude_path`, before flags)
- Claude CLI ignores positional prompts that appear after `--agent`; placing the prompt before flags fixes this
- Both Starter and Caddie Shop sessions now auto-start with the personalized greeting

Closes #393

## Test plan

- [ ] Run `gimmes tour_guide` and verify the Starter greets immediately without user input
- [ ] Run `gimmes caddie_shop` and verify the Caddie Shop greets immediately without user input
- [ ] Verify existing tests pass (assertions updated from `cmd[-1]` to `cmd[1]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)