### PR TITLE
Fix cooldown blocking candidates after strategy change

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1279,6 +1279,42 @@ def mark_cap_blocked_cmd(
     _run(_mark())
 
 
+@app.command(name="reset-cooldown", rich_help_panel="Trading")
+def reset_cooldown(
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Clear all cached candidate scores to reset the cooldown system.
+
+    Use this after changing strategy parameters (side, price range, etc.)
+    so the system re-evaluates all markets with the new strategy.
+    """
+
+    async def _reset() -> None:
+        from gimmes.store.database import Database
+        from gimmes.store.queries import clear_all_candidates
+
+        if not force:
+            typer.confirm(
+                "Clear all cached candidates? This resets cooldown for every market.",
+                abort=True,
+            )
+
+        async with Database() as db:
+            count = await clear_all_candidates(db)
+
+        if count > 0:
+            console.print(
+                f"[green]Cleared {count} cached candidate(s)"
+                f" — cooldown reset[/green]"
+            )
+        else:
+            console.print("[dim]No cached candidates to clear[/dim]")
+
+    _run(_reset())
+
+
 @app.command(rich_help_panel="Portfolio")
 def positions() -> None:
     """List open positions."""
@@ -2399,6 +2435,24 @@ def config_set(
         f"[cyan]{key}[/cyan]: {_format_current(current, setting)} → "
         f"[bold]{_format_current(parsed, setting)}[/bold]"
     )
+
+    # Auto-clear cached candidates when strategy params change
+    if key.startswith("strategy."):
+        import asyncio
+
+        from gimmes.store.database import Database
+        from gimmes.store.queries import clear_all_candidates
+
+        async def _auto_clear() -> int:
+            async with Database(db_path) as db:
+                return await clear_all_candidates(db)
+
+        cleared = asyncio.run(_auto_clear())
+        if cleared:
+            console.print(
+                f"[yellow]Cleared {cleared} cached candidate(s)"
+                f" — scores from prior strategy no longer apply[/yellow]"
+            )
 
     # Warn if scoring weights no longer sum to 1.0
     if key.startswith("scoring.weights."):

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -414,6 +414,13 @@ async def mark_cap_blocked(db: Database, ticker: str) -> bool:
     return cursor.rowcount > 0
 
 
+async def clear_all_candidates(db: Database) -> int:
+    """Delete all cached candidates. Returns the number of rows deleted."""
+    cursor = await db.conn.execute("DELETE FROM candidates")
+    await db.conn.commit()
+    return cursor.rowcount
+
+
 # ---------------------------------------------------------------------------
 # P&L queries
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_clear_candidates.py
+++ b/tests/unit/test_clear_candidates.py
@@ -1,0 +1,55 @@
+"""Tests for clear_all_candidates (cooldown reset)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from gimmes.store.database import Database
+from gimmes.store.queries import clear_all_candidates, insert_candidate
+
+
+@pytest.fixture
+async def db(tmp_path: Path) -> AsyncIterator[Database]:
+    """Create a temp database."""
+    db = Database(tmp_path / "test.db")
+    await db.connect()
+    yield db
+    await db.close()
+
+
+async def _insert(db: Database, ticker: str) -> int:
+    return await insert_candidate(
+        db, ticker, f"Title {ticker}", 0.50, 0.80, 0.10, 70, "memo",
+    )
+
+
+class TestClearAllCandidates:
+    @pytest.mark.asyncio
+    async def test_clears_and_returns_count(self, db: Database) -> None:
+        await _insert(db, "A")
+        await _insert(db, "B")
+        await _insert(db, "C")
+
+        count = await clear_all_candidates(db)
+        assert count == 3
+
+        # Verify table is empty
+        cursor = await db.conn.execute("SELECT COUNT(*) FROM candidates")
+        row = await cursor.fetchone()
+        assert row[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_table_returns_zero(self, db: Database) -> None:
+        count = await clear_all_candidates(db)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_idempotent(self, db: Database) -> None:
+        await _insert(db, "A")
+        first = await clear_all_candidates(db)
+        second = await clear_all_candidates(db)
+        assert first == 1
+        assert second == 0


### PR DESCRIPTION
## Summary
- Adds `gimmes reset-cooldown` command to manually clear all cached candidate scores
- Auto-clears candidates when any `strategy.*` config key changes via `gimmes config set`
- Prevents stale scores from a prior strategy (e.g., BUY YES) from blocking re-research after pivoting to a new strategy (e.g., BUY NO)

Closes #400

## Test plan
- [ ] `uv run pytest tests/unit/test_clear_candidates.py` — 3 tests pass
- [ ] `gimmes reset-cooldown --force` clears cached candidates
- [ ] `gimmes config set strategy.side no` auto-clears candidates with yellow warning
- [ ] `gimmes config set risk.max_open_positions 20` does NOT clear candidates
- [ ] After strategy change, autonomous cycle re-researches candidates instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)