### PR TITLE
Add CLOSE execution and per-position stop-loss trigger

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -126,8 +126,8 @@ After Monitor returns, review its report. For each position Monitor flagged:
    If this command fails, do not proceed with a close — log the failure and move on.
 
 6. **If the decision is CLOSE**, dispatch Closer after writing the decision note:
-   - Cancel any resting orders first: `gimmes cancel ORDER_ID`
-   - Then dispatch the Closer agent to execute the sell.
+   - Cancel any resting orders first: `gimmes cancel ORDER_ID` (check `gimmes positions` for resting order IDs)
+   - Then dispatch the Closer agent to execute the sell. Include the ticker and current probability in the dispatch prompt so Closer can run: `gimmes order TICKER --prob P --action sell --yes --agent closer`
 
 7. **If the decision is HOLD**, no further action for this position this cycle.
 

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -35,6 +35,35 @@ When Caddie Master dispatches you for a SIZE UP (adding to an existing position)
 
 All safety checks except the duplicate position check and position count check are still enforced (SIZE UP adds to an existing position, not a new one).
 
+## CLOSE Execution
+
+When Caddie Master dispatches you for a CLOSE (exiting a losing or flagged position), execute this sequence:
+
+1. **Order**: `gimmes order TICKER --prob P --action sell --yes --agent closer` — sells the position at the current market price. The `--prob P` should use the probability provided by Caddie Master in the dispatch.
+2. **Log success**: The order command logs the trade as a CLOSE action atomically — no separate log-trade needed.
+3. **Log failure** (if the order fails): `gimmes log-trade TICKER --action skip --prob P --score 0 --rationale "CLOSE failed: [error from CLI output]" --agent closer`. If the log-trade command fails, note the failure in your output and continue. Do not retry.
+
+No validate or size step is needed for closes — you are exiting a position, not entering one.
+
+### CLOSE Output Format
+
+```
+### Close: TICKER
+- Action: SELL @ XX¢
+- Contracts: N
+- Proceeds: $X.XX (- $X.XX fee)
+- Order ID: [id]
+- Status: [filled/resting/failed]
+- Reason: [Caddie Master's close rationale summary]
+```
+
+For failed closes:
+```
+### Close Failed: TICKER
+- Reason: [specific error from order command]
+- Logged as skip
+```
+
 ## Safety Checklist (ALL MUST be true — reject if ANY fails)
 
 - [ ] Validation passed (all checks green) — REQUIRED

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -39,6 +39,7 @@ Flag a position for Caddie Master review — by writing a `flag` note — when A
 - **New information**: You find news or data published AFTER the position was opened that materially affects the probability estimate — and that information was NOT already accounted for in the original thesis.
 - **Time decay**: Resolution is < 24 hours away AND position is not yet profitable.
 - **Risk approaching**: Daily P&L loss >= 10% of bankroll.
+- **Stop-loss**: Unrealized loss on a single position exceeds the "Position Stop-Loss" threshold (from `risk-check` output, default 15%) as a percentage of cost basis. For example, if a position cost $10.00 and is now worth $8.00, the loss is 20% — which exceeds a 15% threshold.
 
 A trigger condition means Caddie Master should look at this position. It does NOT mean the position should be closed. Caddie Master decides what to do.
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1419,6 +1419,7 @@ def risk_check() -> None:
                 ("Unrealized P&L", f"${unrealized_pnl:,.2f}"),
                 ("Total Daily P&L", f"${total_daily_pnl:,.2f}"),
                 ("Price Trigger", f"{config.risk.monitor_price_trigger_pp}pp"),
+                ("Position Stop-Loss", f"{config.risk.position_stop_loss_pct:.0%}"),
             ])
             console.print(table)
 

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -405,6 +405,23 @@ class RiskConfig(BaseModel):
             "max_val": 50,
         },
     )
+    position_stop_loss_pct: float = Field(
+        default=0.15, gt=0.0, le=0.50,
+        json_schema_extra={
+            "display_name": "Position Stop-Loss",
+            "description": (
+                "Flag a position for Caddie Master review when its unrealized loss\n"
+                "exceeds this percentage of cost basis. This is a per-position trigger\n"
+                "— it does not auto-close, but ensures losing positions get reviewed.\n"
+                "\n"
+                "  • 0.15 (default): Flag when a position loses 15% of its cost\n"
+                "  • Lower (e.g. 0.10): More aggressive — flag at 10% loss\n"
+                "  • Higher (e.g. 0.25): More patient — flag at 25% loss"
+            ),
+            "min_val": 0.05,
+            "max_val": 0.50,
+        },
+    )
 
 
 class OrdersConfig(BaseModel):


### PR DESCRIPTION
## Summary
- **Closer agent**: Added CLOSE execution section so it can actually sell positions when Caddie Master decides to close (fixes the gap where close orders were dispatched but never executed)
- **Caddie Master**: Made CLOSE dispatch instructions explicit with ticker + probability for Closer
- **Monitor**: Added 5th trigger condition — per-position stop-loss (default 15% of cost basis) flags underwater positions for review
- **Config**: New `position_stop_loss_pct` parameter (default 15%, configurable 5-50%)
- **CLI**: `risk-check` now displays the stop-loss threshold

Closes #413, closes #415

## Test plan
- [ ] `gimmes risk-check` shows "Position Stop-Loss: 15%" in output
- [ ] `gimmes config` shows the new `position_stop_loss_pct` field in the risk section
- [ ] Run driving range cycle — Monitor flags positions exceeding stop-loss threshold
- [ ] Caddie Master CLOSE decision → Closer executes sell via `--action sell`
- [ ] Verify close trade appears in `gimmes trades --action close`

🤖 Generated with [Claude Code](https://claude.com/claude-code)