### PR TITLE
Fix config set double-encoding JSON array values

### DIFF
--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import get_origin
@@ -218,6 +219,14 @@ def _parse_input(raw: str, setting: Setting) -> int | float | str | list[str]:
         return raw
 
     if setting.type == "list":
+        stripped = raw.strip()
+        if stripped.startswith("["):
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, list):
+                    return [str(item).strip() for item in parsed if str(item).strip()]
+            except json.JSONDecodeError:
+                pass  # Fall through to comma-split
         return [item.strip() for item in raw.split(",") if item.strip()]
 
     return raw

--- a/tests/unit/test_config_set.py
+++ b/tests/unit/test_config_set.py
@@ -96,6 +96,42 @@ class TestConfigSet:
         assert row is not None
         assert json.loads(row[0]) == ["KXCPI", "KXGDP", "KXFED"]
 
+    def test_set_list_json_array(self, db_file: Path) -> None:
+        """JSON array input should be parsed correctly (not double-encoded)."""
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(
+                app, ["config", "set", "scanner.series", '["KXCPI", "KXCPICORE"]'],
+            )
+
+        assert result.exit_code == 0
+
+        conn = sqlite3.connect(str(db_file))
+        row = conn.execute(
+            "SELECT value FROM config WHERE key = 'scanner.series'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert json.loads(row[0]) == ["KXCPI", "KXCPICORE"]
+
+    def test_set_list_malformed_json_falls_back(self, db_file: Path) -> None:
+        """Malformed JSON starting with [ should fall back to comma-split."""
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(
+                app, ["config", "set", "scanner.series", "[KXCPI, KXCPICORE"],
+            )
+
+        assert result.exit_code == 0
+
+        conn = sqlite3.connect(str(db_file))
+        row = conn.execute(
+            "SELECT value FROM config WHERE key = 'scanner.series'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        saved = json.loads(row[0])
+        assert isinstance(saved, list)
+        assert len(saved) == 2
+
     def test_set_str_choice_value(self, db_file: Path) -> None:
         with patch("gimmes.config.GIMMES_HOME", db_file.parent):
             result = runner.invoke(app, ["config", "set", "orders.preferred_order_type", "taker"])


### PR DESCRIPTION
## Summary
- Fixes `gimmes config set scanner.series '["KXCPI", "KXCPICORE"]'` double-encoding JSON values
- `_parse_input()` now detects JSON array syntax and parses with `json.loads()`, falling back to comma-split on failure
- Previously, the scanner silently returned 0 markets because series tickers had literal quotes baked in

Closes #399

## Test plan
- [ ] `uv run pytest tests/unit/test_config_set.py` — 33 tests pass (2 new)
- [ ] `gimmes config set scanner.series '["KXCPI", "KXCPICORE"]'` stores `["KXCPI", "KXCPICORE"]` (not double-encoded)
- [ ] `gimmes config set scanner.series 'KXCPI, KXCPICORE'` still works (comma-separated)
- [ ] `gimmes config set scanner.series '[KXCPI, KXCPICORE'` falls back to comma-split gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)