### PR TITLE
Fix test_get_risk reading user config instead of defaults

### DIFF
--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -35,10 +35,12 @@ from gimmes.store.migrations import run_migrations
 
 
 @pytest.fixture(autouse=True)
-def _reset_config_cache(monkeypatch):
-    """Reset the clubhouse data module's config cache and ensure driving_range mode."""
+def _reset_config_cache(monkeypatch, tmp_path):
+    """Reset the clubhouse data module's config cache and use isolated config."""
     import gimmes.clubhouse.data as data_mod
+    import gimmes.config as config_mod
     monkeypatch.setenv("GIMMES_MODE", "driving_range")
+    monkeypatch.setattr(config_mod, "GIMMES_HOME", tmp_path)
     data_mod._cached_config = None
     data_mod._kalshi_client = None
     yield


### PR DESCRIPTION
## Summary
- Monkepatches `GIMMES_HOME` to `tmp_path` in the clubhouse test fixture so `load_config()` uses Pydantic defaults instead of reading the user's real database
- Root cause: the user's DB had `max_open_positions=50` but the test expected the default of `15`

Closes #406

## Test plan
- [ ] `uv run pytest tests/unit/test_clubhouse.py` — 54 tests pass (0 failures)
- [ ] `uv run pytest tests/unit/` — 920 tests pass, fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)