### PR TITLE
Add CLOSE execution procedure to Closer agent

### DIFF
--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -39,11 +39,11 @@ All safety checks except the duplicate position check and position count check a
 
 When Caddie Master dispatches you to CLOSE a position (sell all held contracts), execute this sequence:
 
-1. **Look up position**: Run `gimmes positions` and find the position for TICKER. Note the side and count. If no position exists (already settled or closed), log a skip and report — do not proceed.
-2. **Cancel resting orders**: If any resting orders exist for TICKER, cancel them first with `gimmes cancel ORDER_ID`.
+1. **Look up position**: Run `gimmes positions` and find the position for TICKER. Note the side and count. If no position exists (already settled or closed), log a skip: `gimmes log-trade TICKER --action skip --rationale "Close skipped: no open position found" --agent closer` and report — do not proceed.
+2. **Cancel resting orders**: If any resting orders exist for TICKER, cancel them first with `gimmes cancel ORDER_ID --yes`.
 3. **Order**: `gimmes order TICKER --action sell --side SIDE --count COUNT --yes --agent closer` — sell the full held count.
 4. **Log success**: The order command logs the close trade and syncs positions atomically.
-5. **Log failure** (if order fails): `gimmes log-trade TICKER --action close --side SIDE --count COUNT --rationale "Close order failed: [error from CLI output]" --agent closer`. If the command fails, note the failure in your output and continue. Do not retry.
+5. **Log failure** (if order fails): `gimmes log-trade TICKER --action skip --rationale "Close order failed: [error from CLI output]" --agent closer`. If the command fails, note the failure in your output and continue. Do not retry.
 
 No validate or size step is needed — the order command validates that the position exists and the count is valid. No risk checks apply to sells.
 


### PR DESCRIPTION
## Summary
- Adds CLOSE execution section to Closer agent definition with position lookup, resting order cancellation, sell order, and success/failure logging
- Adds CLOSE output format to the execution report template
- Adds rule: always sell full held count (no partial closes)
- The Closer previously had BUY and SIZE UP procedures but no way to exit positions, so dispatched close orders never executed

Closes #413

## Test plan
- [ ] Review `.claude/agents/closer.md` for correct sell command syntax
- [ ] Verify CLOSE procedure references correct CLI commands (`gimmes order --action sell`, `gimmes cancel`, `gimmes log-trade --action close`)
- [ ] Verify output format matches BUY format style
- [ ] Run autonomous cycle with a position flagged for close to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)