### PR TITLE
Add expected-value position sizing for variance plays

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -351,6 +351,7 @@ async def run_backtest(
             fraction=gc.sizing.kelly_fraction,
             max_position_pct=gc.sizing.max_position_pct,
             fees=fees,
+            mode=gc.sizing.mode,
         )
         if count <= 0:
             continue

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -391,6 +391,7 @@ def size(
                 bankroll, price, probability,
                 fraction=config.sizing.kelly_fraction,
                 max_position_pct=config.sizing.max_position_pct, fees=fees,
+                mode=config.sizing.mode,
             )
             fee = fee_for_order(contracts, price, is_taker=False, fees=fees)
             edge = edge_after_fees(price, probability, fees=fees)
@@ -453,6 +454,7 @@ def validate(
                     bankroll, price, probability,
                     fraction=config.sizing.kelly_fraction,
                     max_position_pct=config.sizing.max_position_pct, fees=fees,
+                    mode=config.sizing.mode,
                 )
                 trade_dollars = contracts * price
             else:
@@ -603,6 +605,7 @@ def order(
                     bankroll, eff_price, probability,
                     fraction=config.sizing.kelly_fraction,
                     max_position_pct=config.sizing.max_position_pct, fees=fees,
+                    mode=config.sizing.mode,
                 )
             else:
                 final_count = count

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -256,12 +256,30 @@ class SizingConfig(BaseModel):
     model_config = ConfigDict(json_schema_extra={
         "section_name": "Position Sizing",
         "section_description": (
-            "How much money to put into each trade. Uses the Kelly Criterion —\n"
-            "a mathematical formula for optimal bet sizing — with conservative adjustments."
+            "How much money to put into each trade. Supports Kelly Criterion\n"
+            "(optimal for high-conviction plays) and expected-value sizing\n"
+            "(better for variance plays with moderate probability)."
         ),
         "section_order": 3,
     })
 
+    mode: Literal["kelly", "ev"] = Field(
+        default="kelly",
+        json_schema_extra={
+            "display_name": "Sizing Mode",
+            "description": (
+                "Which formula to use for calculating position sizes.\n"
+                "\n"
+                "  'kelly' (default): Kelly Criterion — optimal for high-conviction\n"
+                "  plays where your estimated probability is 90%+.\n"
+                "\n"
+                "  'ev': Expected-Value sizing — better for variance plays where\n"
+                "  probability is moderate (30-60%) but expected value is positive.\n"
+                "  Sizes scale linearly with edge-to-cost ratio."
+            ),
+            "choices": ["kelly", "ev"],
+        },
+    )
     kelly_fraction: float = Field(
         default=0.25, gt=0.0, le=1.0,
         json_schema_extra={

--- a/src/gimmes/strategy/kelly.py
+++ b/src/gimmes/strategy/kelly.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, fee_for_order
 
 
@@ -55,6 +57,40 @@ def kelly_fraction(
     return fraction * full_kelly
 
 
+def ev_fraction(
+    market_price: float,
+    true_probability: float,
+    *,
+    is_taker: bool = False,
+    fraction: float = 0.25,
+    fees: FeeMultipliers = DEFAULT_FEE_MULTIPLIERS,
+) -> float:
+    """EV-based sizing fraction for variance plays.
+
+    Sizes proportionally to the edge-to-cost ratio, scaled by fraction.
+    Better than Kelly for moderate-probability variance plays (30-60%)
+    where expected value is positive but Kelly produces tiny sizes.
+
+    Returns:
+        Fraction of bankroll to bet (>= 0). Returns 0 if EV is non-positive.
+    """
+    if not (0 < market_price < 1) or not (0 < true_probability <= 1):
+        return 0.0
+
+    fee = fee_for_order(1, market_price, is_taker=is_taker, fees=fees)
+    cost_per_contract = market_price + fee
+
+    if cost_per_contract >= 1.0:
+        return 0.0
+
+    edge_dollars = true_probability - cost_per_contract
+    if edge_dollars <= 0:
+        return 0.0
+
+    ratio = edge_dollars / cost_per_contract
+    return fraction * ratio
+
+
 def position_size(
     bankroll: float,
     market_price: float,
@@ -65,10 +101,14 @@ def position_size(
     max_position_pct: float = 0.05,
     max_position_dollars: float | None = None,
     fees: FeeMultipliers = DEFAULT_FEE_MULTIPLIERS,
+    mode: Literal["kelly", "ev"] = "kelly",
 ) -> int:
     """Calculate number of contracts to buy.
 
-    Applies Kelly sizing clamped by risk limits.
+    Applies Kelly or EV sizing clamped by risk limits.
+
+    Args:
+        mode: "kelly" for Kelly Criterion, "ev" for expected-value sizing.
 
     Returns:
         Number of contracts (integer, minimum 0).
@@ -76,21 +116,30 @@ def position_size(
     if bankroll <= 0:
         return 0
 
-    kelly = kelly_fraction(
-        market_price, true_probability,
-        is_taker=is_taker, fraction=fraction, fees=fees,
-    )
-    if kelly <= 0:
+    if mode == "ev":
+        frac = ev_fraction(
+            market_price, true_probability,
+            is_taker=is_taker, fraction=fraction, fees=fees,
+        )
+    elif mode == "kelly":
+        frac = kelly_fraction(
+            market_price, true_probability,
+            is_taker=is_taker, fraction=fraction, fees=fees,
+        )
+    else:
+        msg = f"Unknown sizing mode: {mode!r}. Expected 'kelly' or 'ev'."
+        raise ValueError(msg)
+    if frac <= 0:
         return 0
 
-    # Dollar amount from Kelly
-    kelly_dollars = kelly * bankroll
+    # Dollar amount from sizing formula
+    sized_dollars = frac * bankroll
 
     # Clamp by max position percent
     max_from_pct = max_position_pct * bankroll
 
     # Clamp by absolute dollar limit
-    max_dollars = min(kelly_dollars, max_from_pct)
+    max_dollars = min(sized_dollars, max_from_pct)
     if max_position_dollars is not None:
         max_dollars = min(max_dollars, max_position_dollars)
 

--- a/tests/unit/test_kelly.py
+++ b/tests/unit/test_kelly.py
@@ -1,7 +1,7 @@
 """Unit tests for Kelly criterion sizing."""
 
 from gimmes.strategy.fees import FeeMultipliers, fee_for_order
-from gimmes.strategy.kelly import kelly_fraction, position_size
+from gimmes.strategy.kelly import ev_fraction, kelly_fraction, position_size
 
 
 class TestKellyFraction:
@@ -80,3 +80,53 @@ class TestPositionSize:
             10000, 0.65, 0.90, fees=FeeMultipliers(maker=0.10),
         )
         assert high_fee_contracts <= default_contracts
+
+
+class TestEvFraction:
+    def test_positive_ev(self) -> None:
+        # Price 0.40, prob 0.55 => edge ~0.15 minus fees > 0
+        ef = ev_fraction(0.40, 0.55, fraction=0.25)
+        assert ef > 0
+
+    def test_no_ev(self) -> None:
+        # Price 0.50, prob 0.50 => zero edge after fees
+        ef = ev_fraction(0.50, 0.50)
+        assert ef == 0.0
+
+    def test_negative_ev(self) -> None:
+        ef = ev_fraction(0.60, 0.55)
+        assert ef == 0.0
+
+    def test_fraction_scales_linearly(self) -> None:
+        full = ev_fraction(0.40, 0.60, fraction=1.0)
+        quarter = ev_fraction(0.40, 0.60, fraction=0.25)
+        assert abs(quarter - full * 0.25) < 1e-10
+
+    def test_invalid_inputs(self) -> None:
+        assert ev_fraction(0, 0.50) == 0.0
+        assert ev_fraction(1.0, 0.50) == 0.0
+
+    def test_variance_play_ev_larger_than_kelly(self) -> None:
+        """At moderate prob, EV produces larger sizes than Kelly."""
+        kelly = kelly_fraction(0.25, 0.35, fraction=0.25)
+        ev = ev_fraction(0.25, 0.35, fraction=0.25)
+        assert ev > kelly  # EV sizes more aggressively for variance plays
+
+
+class TestPositionSizeEV:
+    def test_ev_mode_produces_contracts(self) -> None:
+        contracts = position_size(10000, 0.40, 0.55, mode="ev")
+        assert contracts > 0
+
+    def test_ev_mode_respects_max_pct(self) -> None:
+        contracts = position_size(
+            10000, 0.40, 0.60, mode="ev", max_position_pct=0.05,
+        )
+        fee = fee_for_order(1, 0.40)
+        max_contracts = int(0.05 * 10000 / (0.40 + fee))
+        assert contracts <= max_contracts
+
+    def test_kelly_mode_default(self) -> None:
+        c1 = position_size(10000, 0.65, 0.90)
+        c2 = position_size(10000, 0.65, 0.90, mode="kelly")
+        assert c1 == c2


### PR DESCRIPTION
## Summary
- Adds `sizing.mode` config (`"kelly"` | `"ev"`) for selecting position sizing formula
- New `ev_fraction()` function sizes proportionally to edge-to-cost ratio, producing larger positions than Kelly at moderate probabilities (30-60%)
- `position_size()` dispatches based on mode, with `ValueError` for unknown modes
- All callers (CLI size/validate/order, backtest engine) pass mode from config
- Default remains `"kelly"` for backward compatibility

Closes #402

## Test plan
- [ ] `uv run pytest tests/unit/test_kelly.py` — 23 tests pass (9 new)
- [ ] `uv run pytest tests/unit/` — 932 tests pass
- [ ] `gimmes config set sizing.mode ev` switches to EV sizing
- [ ] `gimmes size TICKER --prob 0.35` with mode=ev produces nonzero contracts for variance plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)