### PR TITLE
Add SIZE UP decision path for adverse price moves with intact thesis

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -120,11 +120,11 @@ After Monitor returns, review its report. For each position Monitor flagged:
      --cycle $GIMMES_CYCLE \
      --agent caddie-master \
      --type decision \
-     --body "Decision: [HOLD, CLOSE, or SIZE UP].
+     --body "Decision: [HOLD or CLOSE].
    Reasoning: [your specific reasoning referencing the original thesis and what Monitor reported].
    Thesis assessment: [was the new information already in the thesis, or does it genuinely change the picture?]"
    ```
-   If this command fails, do not proceed with a close — log the failure and move on. For SIZE UP decisions, skip this step and proceed directly to Step 2d (which has its own decision logging).
+   If this command fails, do not proceed with a close — log the failure and move on. For SIZE UP decisions, skip this step — Step 2d has its own decision logging.
 
 6. **If the decision is CLOSE**, dispatch Closer after writing the decision note:
    - Cancel any resting orders first: `gimmes cancel ORDER_ID`

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -35,7 +35,7 @@ You are the Monitor — the surveillance and journalism agent in the GIMMES pipe
 
 Flag a position for Caddie Master review — by writing a `flag` note — when ANY of these occur:
 
-- **Price movement**: Current price has moved >= Npp in either direction from entry price (favorable or adverse), where N is the "Price Trigger" value from `risk-check` output (default 10pp). When the move is *adverse* (price moved against the position), note in the flag body whether the original thesis appears intact or degraded based on your research, and the current price relative to entry.
+- **Price movement**: Current price has moved >= Npp in either direction from entry price (favorable or adverse), where N is the "Price Trigger" value from `risk-check` output (default 10pp). When the move is *adverse* (price moved against the position), the flag body MUST include: (1) a standardized thesis line using exactly `Thesis: intact` or `Thesis: degraded` based on your research, and (2) a price line showing entry vs current (e.g., `Price: entry $0.57 -> current $0.43 (D -14pp)`).
 - **New information**: You find news or data published AFTER the position was opened that materially affects the probability estimate — and that information was NOT already accounted for in the original thesis.
 - **Time decay**: Resolution is < 24 hours away AND position is not yet profitable.
 - **Risk approaching**: Daily P&L loss >= 10% of bankroll.


### PR DESCRIPTION
## Summary
- Monitor now notes thesis intactness when flagging adverse price movements, giving Caddie Master context for SIZE UP decisions
- Caddie Master gains SIZE UP as a third decision option in Step 2c alongside HOLD and CLOSE
- Fixes Step 2d criteria: "favorable price move" → "adverse price move with thesis intact" (the old wording was backwards for variance plays)
- Avoids double decision-note logging by routing SIZE UP directly to Step 2d

Closes #403

## Test plan
- [ ] Review `.claude/agents/monitor.md` for factual (not prescriptive) SIZE UP annotation
- [ ] Review `.claude/agents/caddie-master.md` Step 2c for three-way decision flow
- [ ] Verify Step 2d criteria fix makes sense for variance plays (adverse price = better edge)
- [ ] Run autonomous cycle with flagged position to verify SIZE UP routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)