### PR TITLE
Add SIZE UP bias rule for underutilized bankroll

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -144,6 +144,8 @@ If Monitor flags a position where the current edge has *increased* since entry (
 - Monitor's flag indicates an adverse price move with thesis intact, not adverse news that degrades the thesis
 - Daily loss limit is not breached
 
+**SIZE UP bias rule** — When ALL of the above criteria hold AND deployed capital is under 50% of bankroll (from Step 1 `risk-check` output), SIZE UP is the *presumptive* action, not HOLD. To decline SIZE UP in this scenario, you MUST provide a specific, articulable reason grounded in the current position or market state. "Waiting for more data" is NOT a valid reason — in a variance strategy, the existing data IS the thesis. The only valid reasons to decline are: a known directional catalyst resolving before the next cycle, or a specific change in the underlying data that the thesis depends on.
+
 **Execution flow** (mirrors the CLOSE pattern):
 
 1. **Log decision to the database BEFORE dispatching Closer** (crash-recovery anchor):


### PR DESCRIPTION
## Summary
- Adds a SIZE UP bias rule to Caddie Master Step 2d: when all SIZE UP criteria hold AND deployed capital is under 50% of bankroll, SIZE UP is the presumptive action
- Requires specific articulable reason to decline — "waiting for more data" is not valid for variance strategies
- Addresses the pattern of 8+ consecutive HOLD decisions while 87% of capital sat idle on a better-priced thesis

Closes #404

## Test plan
- [ ] Review `.claude/agents/caddie-master.md` Step 2d for bias rule clarity
- [ ] Verify existing guardrails remain (5% position cap, daily loss limit, validation pipeline)
- [ ] Run autonomous cycle with flagged position + low deployment to verify SIZE UP bias fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)