### PR TITLE
Constrain historical market fetch with per-page filtering

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -272,11 +272,7 @@ async def run_backtest(
     threshold = gc.strategy.gimme_threshold
     ledger = BacktestLedger(config.starting_balance)
 
-    # --- 1. Fetch historical markets ---
-    logger.info("Fetching historical markets...")
-    all_markets = await list_all_historical_markets(client)
-
-    # Keep only markets with a known result within the date range
+    # --- 1. Fetch historical markets with per-page filtering ---
     start_dt = datetime(
         config.start_date.year, config.start_date.month,
         config.start_date.day, tzinfo=UTC,
@@ -285,15 +281,21 @@ async def run_backtest(
         config.end_date.year, config.end_date.month,
         config.end_date.day, 23, 59, 59, tzinfo=UTC,
     )
+    series_set = set(gc.scanner.series) if gc.scanner.series else None
+    logger.info(
+        "Fetching historical markets (series filter: %s)...",
+        f"{len(series_set)} tickers" if series_set else "none",
+    )
+    all_markets = await list_all_historical_markets(
+        client,
+        series_tickers=series_set,
+        min_close_time=start_dt,
+        max_close_time=end_dt,
+    )
 
-    def _in_range(m: Market) -> bool:
-        if m.result not in ("yes", "no") or m.close_time is None:
-            return False
-        ct = m.close_time if m.close_time.tzinfo else m.close_time.replace(tzinfo=UTC)
-        return start_dt <= ct <= end_dt
-
-    settled = [m for m in all_markets if _in_range(m)]
-    logger.info("Fetched %d markets, %d settled in date range", len(all_markets), len(settled))
+    # Keep only markets with a known result (date/series already filtered)
+    settled = [m for m in all_markets if m.result in ("yes", "no")]
+    logger.info("Fetched %d markets, %d settled", len(all_markets), len(settled))
 
     # --- 2. Filter ---
     adapted = _adapt_for_filter(settled)

--- a/src/gimmes/kalshi/historical.py
+++ b/src/gimmes/kalshi/historical.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 from gimmes.kalshi.client import KalshiClient
 from gimmes.kalshi.markets import parse_market
@@ -86,18 +87,58 @@ async def list_all_historical_markets(
     *,
     event_ticker: str | None = None,
     max_pages: int = 100,
+    series_tickers: set[str] | None = None,
+    min_close_time: datetime | None = None,
+    max_close_time: datetime | None = None,
 ) -> list[Market]:
-    """Fetch all settled historical markets, handling pagination automatically."""
+    """Fetch settled historical markets with optional per-page filtering.
+
+    Filters are applied per-page to reduce memory usage. Markets that
+    don't match are discarded immediately rather than accumulated.
+
+    Args:
+        series_tickers: Keep only markets in these series (by series_ticker).
+        min_close_time: Keep only markets with close_time >= this value.
+        max_close_time: Keep only markets with close_time <= this value.
+    """
+    def _in_window(m: Market) -> bool:
+        ct = m.close_time
+        if ct is None:
+            return False
+        if ct.tzinfo is None:
+            ct = ct.replace(tzinfo=UTC)
+        if min_close_time and ct < min_close_time:
+            return False
+        if max_close_time and ct > max_close_time:
+            return False
+        return True
+
     all_markets: list[Market] = []
     cursor: str | None = None
+    has_date_filter = min_close_time is not None or max_close_time is not None
 
-    for _ in range(max_pages):
+    for page in range(max_pages):
         markets, cursor = await list_historical_markets(
             client,
             cursor=cursor,
             event_ticker=event_ticker,
         )
-        all_markets.extend(markets)
+
+        # Per-page filtering to reduce memory
+        filtered = markets
+        if series_tickers is not None:
+            filtered = [m for m in filtered if m.series_ticker in series_tickers]
+        if has_date_filter:
+            filtered = [m for m in filtered if _in_window(m)]
+
+        all_markets.extend(filtered)
+
+        if page % 10 == 9:
+            logger.info(
+                "Historical fetch: page %d, %d markets matched so far",
+                page + 1, len(all_markets),
+            )
+
         if not cursor or not markets:
             break
     else:

--- a/tests/unit/test_historical.py
+++ b/tests/unit/test_historical.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from gimmes.kalshi.historical import Candle, get_candlesticks, list_historical_markets
+from gimmes.kalshi.historical import (
+    Candle,
+    get_candlesticks,
+    list_all_historical_markets,
+    list_historical_markets,
+)
 
 
 @pytest.fixture
@@ -132,3 +137,80 @@ class TestGetCandlesticks:
         )
 
         assert candles == []
+
+
+class TestListAllHistoricalMarketsFiltering:
+    @pytest.mark.asyncio
+    async def test_filters_by_series_tickers(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = {
+            "markets": [
+                {
+                    "ticker": "KXCPI-26MAR-T3.0",
+                    "series_ticker": "KXCPI",
+                    "status": "finalized",
+                    "result": "yes",
+                },
+                {
+                    "ticker": "KXFED-26MAR-T5.0",
+                    "series_ticker": "KXFED",
+                    "status": "finalized",
+                    "result": "no",
+                },
+            ],
+            "cursor": None,
+        }
+
+        markets = await list_all_historical_markets(
+            mock_client, series_tickers={"KXCPI"},
+        )
+
+        assert len(markets) == 1
+        assert markets[0].ticker == "KXCPI-26MAR-T3.0"
+
+    @pytest.mark.asyncio
+    async def test_filters_by_date_range(self, mock_client: AsyncMock) -> None:
+        from datetime import UTC, datetime
+
+        mock_client.get.return_value = {
+            "markets": [
+                {
+                    "ticker": "EARLY",
+                    "status": "finalized",
+                    "close_time": "2024-01-15T00:00:00Z",
+                },
+                {
+                    "ticker": "INRANGE",
+                    "status": "finalized",
+                    "close_time": "2025-06-15T00:00:00Z",
+                },
+                {
+                    "ticker": "LATE",
+                    "status": "finalized",
+                    "close_time": "2026-12-15T00:00:00Z",
+                },
+            ],
+            "cursor": None,
+        }
+
+        markets = await list_all_historical_markets(
+            mock_client,
+            min_close_time=datetime(2025, 1, 1, tzinfo=UTC),
+            max_close_time=datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC),
+        )
+
+        assert len(markets) == 1
+        assert markets[0].ticker == "INRANGE"
+
+    @pytest.mark.asyncio
+    async def test_no_filters_returns_all(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = {
+            "markets": [
+                {"ticker": "A", "status": "finalized"},
+                {"ticker": "B", "status": "finalized"},
+            ],
+            "cursor": None,
+        }
+
+        markets = await list_all_historical_markets(mock_client)
+
+        assert len(markets) == 2


### PR DESCRIPTION
## Summary
- Adds `series_tickers`, `min_close_time`, `max_close_time` params to `list_all_historical_markets()`
- Filters applied per-page to reduce peak memory — non-matching markets discarded immediately
- Backtest engine now passes scanner series list and date range to the fetch
- Doesn't reduce API calls (Kalshi has no server-side filter) but significantly reduces memory for narrow backtests

Closes #410

## Test plan
- [ ] `uv run pytest tests/unit/test_historical.py` — 12 tests pass (3 new)
- [ ] `uv run pytest tests/unit/` — 937 tests pass
- [ ] `gimmes backtest --from 2025-06-01 --to 2025-06-30` uses less memory than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)