### PR TITLE
Fix Caddie and Closer hardcoded 90% probability gate

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -123,7 +123,7 @@ The GimmeScore is a weighted composite (0-100) computed from five components:
 - GimmeScore 50-74 → **NEEDS MORE RESEARCH** — gather one additional signal, re-score once. If still 50-74 after re-evaluation, treat as PASS and log the skip.
 - GimmeScore < 50 → **PASS**
 
-True probability estimate MUST be >= the configured `min_true_probability` (from step 0) to qualify for PROCEED, regardless of GimmeScore.
+Additionally, true probability MUST be >= the configured `min_true_probability` (from step 0). Even if GimmeScore >= 75, PASS the candidate if true probability is below this threshold.
 
 ## Output Format
 

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -51,7 +51,7 @@ No validate or size step is needed — the order command validates that the posi
 
 - [ ] Validation passed (all checks green) — REQUIRED
 - [ ] Edge after fees >= 5pp (`min_edge_after_fees`) — REQUIRED
-- [ ] True probability >= configured `min_true_probability` — REQUIRED
+- [ ] True probability >= configured `strategy.min_true_probability` — REQUIRED
 - [ ] Position size <= 5% of bankroll (`max_position_pct`) — REQUIRED
 - [ ] Not a duplicate position — REQUIRED (waived for SIZE UP via `--size-up`)
 - [ ] Settlement rules are clear (no red flags from Caddie) — REQUIRED


### PR DESCRIPTION
## Summary
- Caddie now reads `min_true_probability` from config before processing candidates instead of hardcoding 0.90
- Adds failure guard: stops processing if config read fails
- Closer safety checklist references configured value instead of hardcoded 90%
- Unblocks variance play trades where probability is moderate (30-70%) but EV is positive

Closes #441

## Test plan
- [ ] Review `.claude/agents/caddie.md` step 0 and recommendation thresholds
- [ ] Review `.claude/agents/closer.md` safety checklist
- [ ] Run autonomous cycle — Caddie should use configured min_true_probability (50%) instead of 90%
- [ ] Candidates like KXPAYROLLS-26MAR-T70000 (GimmeScore 93, NO prob 72%) should now PROCEED

🤖 Generated with [Claude Code](https://claude.com/claude-code)