### PR TITLE
Add recommendation column to candidates for skip reason tracking

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -162,7 +162,8 @@ gimmes log-candidate TICKER \
   --title "Event title" --price 0.XX --prob 0.XX --score NN \
   --memo "Brief research summary" \
   --edge-size NN --signal-strength NN --liquidity-depth NN \
-  --settlement-clarity NN --time-to-resolution NN
+  --settlement-clarity NN --time-to-resolution NN \
+  --recommendation "proceed|pass|needs_more_research"
 ```
 
 If a `log-candidate` command fails, note the failure in your output and continue. Do not retry.

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1154,10 +1154,12 @@ def candidates(
         table.add_column("Prob", justify="right")
         table.add_column("Edge", justify="right")
         table.add_column("Status")
+        table.add_column("Rec")
         table.add_column("Scanned")
 
         for c in records:
             status = "[yellow]CAP BLOCKED[/yellow]" if c.get("cap_blocked") else ""
+            rec = str(c.get("recommendation", ""))
             table.add_row(
                 str(c.get("ticker", "")),
                 f"{c.get('gimme_score', 0):.0f}",
@@ -1165,6 +1167,7 @@ def candidates(
                 f"{c.get('model_probability', 0):.1%}",
                 f"{c.get('edge', 0):+.1%}",
                 status,
+                rec,
                 format_local_timestamp(str(c.get("scanned_at", ""))),
             )
 
@@ -1670,6 +1673,9 @@ def log_candidate(
     time_to_resolution: float = typer.Option(
         0, "--time-to-resolution", help="Time to resolution score",
     ),
+    recommendation: str = typer.Option(
+        "", "--recommendation", help="Caddie recommendation (proceed/pass/needs_more_research)",
+    ),
 ) -> None:
     """Log a scanned candidate to the candidates table."""
     config = load_config()
@@ -1688,6 +1694,7 @@ def log_candidate(
                 liquidity_depth_score=liquidity_depth,
                 settlement_clarity_score=settlement_clarity,
                 time_to_resolution_score=time_to_resolution,
+                recommendation=recommendation,
             )
             console.print(f"[green]Logged candidate #{row_id}: {ticker}[/green]")
 

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -285,4 +285,16 @@ async def run_migrations(db: Database) -> int:
         await db.conn.commit()
         current = 14
 
+    if current < 15:
+        _v15 = [
+            "ALTER TABLE candidates ADD COLUMN recommendation"
+            " TEXT NOT NULL DEFAULT ''",
+        ]
+        await _run_alter_columns(db, _v15)
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (15,)
+        )
+        await db.conn.commit()
+        current = 15
+
     return current

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -318,6 +318,7 @@ async def insert_candidate(
     liquidity_depth_score: float = 0,
     settlement_clarity_score: float = 0,
     time_to_resolution_score: float = 0,
+    recommendation: str = "",
 ) -> int:
     """Insert a scanned gimme candidate with optional component scores.
 
@@ -327,12 +328,13 @@ async def insert_candidate(
         """INSERT INTO candidates
            (ticker, title, market_price, model_probability, edge, gimme_score,
             research_memo, cap_blocked, edge_size_score, signal_strength_score,
-            liquidity_depth_score, settlement_clarity_score, time_to_resolution_score)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            liquidity_depth_score, settlement_clarity_score,
+            time_to_resolution_score, recommendation)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (ticker, title, market_price, model_prob, edge, score, memo,
          int(cap_blocked), edge_size_score, signal_strength_score,
          liquidity_depth_score, settlement_clarity_score,
-         time_to_resolution_score),
+         time_to_resolution_score, recommendation),
     )
     await db.conn.commit()
     return cursor.lastrowid or 0


### PR DESCRIPTION
## Summary
- Adds `recommendation` column to candidates table (migration v15) to persist why candidates were rejected
- `insert_candidate()` and `log-candidate` CLI support the new field
- Candidates display shows "Rec" column
- Caddie agent updated to pass `--recommendation` when logging candidates

Closes #446

## Test plan
- [ ] `uv run pytest tests/unit/` — 942 tests pass
- [ ] `gimmes log-candidate TEST --recommendation pass` stores the value
- [ ] `gimmes candidates` shows Rec column
- [ ] Existing candidates display with empty recommendation (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)