### PR TITLE
Add profit-taking trigger for Monitor

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -118,8 +118,10 @@ After Monitor returns, review its report. For each position Monitor flagged:
 
 4. Make your own deliberate decision — **HOLD**, **CLOSE**, or **SIZE UP**:
    - **HOLD**: The flagged information was already in the thesis, or the price move appears liquidity-driven, or the thesis is still materially intact but edge hasn't improved enough to warrant adding. When choosing HOLD, you MUST specify a re-evaluation condition so Monitor knows when to re-flag (prevents the flag-HOLD-re-flag-HOLD loop).
-   - **CLOSE**: Genuinely new information (not in the original thesis) materially changes the probability estimate, or risk limits require action.
+   - **CLOSE**: Genuinely new information (not in the original thesis) materially changes the probability estimate, risk limits require action, or a profit-taking flag indicates the position has captured most of its available edge.
    - **SIZE UP**: Price moved adversely while the original thesis remains fully intact, resulting in a larger edge than at entry. Proceed to Step 2d.
+
+   When reviewing a **profit-taking flag**: the position has captured a large share of its maximum possible profit. The default action is CLOSE to lock in gains, UNLESS resolution is imminent (< 24h) and remaining upside is nearly risk-free.
 
 5. **Log your decision to the database BEFORE dispatching Closer** (crash-recovery anchor):
    ```bash

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -41,6 +41,7 @@ Flag a position for Caddie Master review — by writing a `flag` note — when A
 - **Time decay**: Resolution is < 24 hours away AND position is not yet profitable.
 - **Risk approaching**: Daily P&L loss approaching the configured daily loss limit (from the "Daily Loss Limit" line in `risk-check` output).
 - **Stop-loss breach**: The position's unrealized P&L (from `gimmes positions`, negative when losing) is <= -(Position Stop-Loss % x cost basis). Equivalently, the absolute loss >= the "Position Stop-Loss" percentage (from `risk-check` output) multiplied by cost basis. For example, at 15% stop-loss and $100 cost basis, flag when unrealized P&L <= -$15.
+- **Profit-taking threshold**: The position's unrealized gain >= the "Position Take-Profit" percentage (from `risk-check` output) multiplied by maximum possible profit. Max profit for a YES position = (1.00 - entry_price) x contracts; for NO = entry_price x contracts. For example, at 80% take-profit, entry $0.40, and 10 contracts, max profit = $6.00 and the flag triggers when unrealized P&L >= $4.80.
 
 A trigger condition means Caddie Master should look at this position. It does NOT mean the position should be closed. Caddie Master decides what to do.
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1449,6 +1449,7 @@ def risk_check() -> None:
                 ("Total Daily P&L", f"${total_daily_pnl:,.2f}"),
                 ("Price Trigger", f"{config.risk.monitor_price_trigger_pp}pp"),
                 ("Position Stop-Loss", f"{config.risk.position_stop_loss_pct:.0%}"),
+                ("Position Take-Profit", f"{config.risk.position_take_profit_pct:.0%}"),
             ])
             console.print(table)
 

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -441,6 +441,23 @@ class RiskConfig(BaseModel):
             "max_val": 0.50,
         },
     )
+    position_take_profit_pct: float = Field(
+        default=0.80, ge=0.50, le=0.95,
+        json_schema_extra={
+            "display_name": "Position Take-Profit",
+            "description": (
+                "Flag a position when its unrealized gain reaches this percentage\n"
+                "of its maximum possible profit. This triggers a Monitor flag so\n"
+                "Caddie Master can review — it does NOT automatically sell.\n"
+                "\n"
+                "  • 0.80 (default, 80%): Flag when gain hits 80% of max profit\n"
+                "  • Lower (e.g. 0.60): Flag earlier to lock in gains sooner\n"
+                "  • Higher (e.g. 0.95): Only flag when nearly at max profit"
+            ),
+            "min_val": 0.50,
+            "max_val": 0.95,
+        },
+    )
 
 
 class OrdersConfig(BaseModel):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -261,6 +261,20 @@ class TestPositionStopLoss:
         assert config.risk.position_stop_loss_pct == 0.25
 
 
+class TestPositionTakeProfit:
+    def test_default_is_080(self, tmp_path):
+        config = load_config(db_path=tmp_path / "nonexistent.db")
+        assert config.risk.position_take_profit_pct == 0.80
+
+    def test_loads_from_db(self, tmp_path):
+        db = tmp_path / "test.db"
+        _create_config_db(db)
+        save_config_value("risk.position_take_profit_pct", 0.70, db_path=db)
+
+        config = load_config(db_path=db)
+        assert config.risk.position_take_profit_pct == 0.70
+
+
 class TestPrivateKeyPasswordConfig:
     def test_reads_password_from_env(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KALSHI_PRIVATE_KEY_PASSWORD", "my-secret")


### PR DESCRIPTION
## Summary
- Adds `position_take_profit_pct` config (default 80%) — flags when gain hits threshold of max profit
- Display in `risk-check` output
- 6th Monitor trigger condition for profit-taking
- Caddie Master guidance: default CLOSE to lock in gains

Closes #453

## Test plan
- [ ] `uv run pytest tests/unit/` — 954 tests pass
- [ ] `gimmes risk-check` shows "Position Take-Profit: 80%"
- [ ] Monitor flags positions where gain >= 80% of max profit

🤖 Generated with [Claude Code](https://claude.com/claude-code)