### PR TITLE
Add event and series concentration limits

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -519,12 +519,18 @@ def validate(
                 if match:
                     existing_cost_basis = match.cost_basis
 
+            from gimmes.risk.limits import compute_exposure_for_group
+
             existing_tickers = [p.ticker for p in positions]
+            event_exp = compute_exposure_for_group(positions, market.event_ticker)
+            series_exp = compute_exposure_for_group(positions, market.series_ticker)
             result = validate_trade(
                 market, trade_dollars, probability, bankroll,
                 total_daily_pnl, len(positions), existing_tickers, config,
                 fees=fees, deployed_cost_basis=deployed, size_up=size_up,
                 existing_cost_basis=existing_cost_basis,
+                event_exposure=event_exp,
+                series_exposure=series_exp,
             )
 
             console.print(f"\n[bold]Validation: {ticker}[/bold]")
@@ -733,13 +739,19 @@ def order(
                         return
                     existing_cost_basis = match.cost_basis
 
+                from gimmes.risk.limits import compute_exposure_for_group
+
                 existing_tickers = [p.ticker for p in positions]
+                evt_exp = compute_exposure_for_group(positions, market.event_ticker)
+                ser_exp = compute_exposure_for_group(positions, market.series_ticker)
                 validation = validate_trade(
                     market, trade_dollars, true_prob, bankroll,
                     total_daily_pnl, len(positions), existing_tickers,
                     config, is_taker=is_taker, fees=fees,
                     deployed_cost_basis=deployed, size_up=size_up,
                     existing_cost_basis=existing_cost_basis,
+                    event_exposure=evt_exp,
+                    series_exposure=ser_exp,
                 )
 
                 if not validation.approved:

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -458,6 +458,40 @@ class RiskConfig(BaseModel):
             "max_val": 0.95,
         },
     )
+    max_event_exposure_pct: float = Field(
+        default=0.15, gt=0.0, le=1.0,
+        json_schema_extra={
+            "display_name": "Max Event Exposure",
+            "description": (
+                "Maximum percentage of bankroll deployed in a single event.\n"
+                "An event groups related markets (e.g. all CPI brackets for March).\n"
+                "Prevents over-concentration in correlated outcomes.\n"
+                "\n"
+                "  • 0.15 (default, 15%): Max $1,500 per event on $10K bankroll\n"
+                "  • Lower (e.g. 0.10): Stricter diversification\n"
+                "  • Higher (e.g. 0.25): Allow more concentrated event bets"
+            ),
+            "min_val": 0.01,
+            "max_val": 1.0,
+        },
+    )
+    max_series_exposure_pct: float = Field(
+        default=0.30, gt=0.0, le=1.0,
+        json_schema_extra={
+            "display_name": "Max Series Exposure",
+            "description": (
+                "Maximum percentage of bankroll deployed in a single series.\n"
+                "A series groups all events of a kind (e.g. all CPI across months).\n"
+                "Prevents over-concentration in a single economic indicator.\n"
+                "\n"
+                "  • 0.30 (default, 30%): Max $3,000 per series on $10K bankroll\n"
+                "  • Lower (e.g. 0.15): Stricter series diversification\n"
+                "  • Higher (e.g. 0.50): Allow more concentrated series bets"
+            ),
+            "min_val": 0.01,
+            "max_val": 1.0,
+        },
+    )
 
 
 class OrdersConfig(BaseModel):

--- a/src/gimmes/risk/limits.py
+++ b/src/gimmes/risk/limits.py
@@ -68,3 +68,58 @@ def check_bankroll(
             f"> ${bankroll:.2f} bankroll",
         )
     return RiskLimitCheck(passed=True)
+
+
+def compute_exposure_for_group(
+    positions: list,  # type: ignore[type-arg]
+    group_ticker: str,
+) -> float:
+    """Sum cost_basis of positions whose ticker starts with group_ticker-."""
+    if not group_ticker or not isinstance(group_ticker, str):
+        return 0.0
+    prefix = group_ticker + "-"
+    return sum(p.cost_basis for p in positions if p.ticker.startswith(prefix))
+
+
+def check_event_exposure(
+    event_cost_basis: float,
+    trade_dollars: float,
+    bankroll: float,
+    config: GimmesConfig,
+) -> RiskLimitCheck:
+    """Check if proposed trade would exceed event concentration limit."""
+    max_dollars = config.risk.max_event_exposure_pct * bankroll
+    projected = event_cost_basis + trade_dollars
+    if projected > max_dollars:
+        return RiskLimitCheck(
+            passed=False,
+            reason=(
+                f"Event exposure ${projected:.2f} exceeds "
+                f"${max_dollars:.2f} limit "
+                f"({config.risk.max_event_exposure_pct:.0%} of "
+                f"${bankroll:.2f})"
+            ),
+        )
+    return RiskLimitCheck(passed=True)
+
+
+def check_series_exposure(
+    series_cost_basis: float,
+    trade_dollars: float,
+    bankroll: float,
+    config: GimmesConfig,
+) -> RiskLimitCheck:
+    """Check if proposed trade would exceed series concentration limit."""
+    max_dollars = config.risk.max_series_exposure_pct * bankroll
+    projected = series_cost_basis + trade_dollars
+    if projected > max_dollars:
+        return RiskLimitCheck(
+            passed=False,
+            reason=(
+                f"Series exposure ${projected:.2f} exceeds "
+                f"${max_dollars:.2f} limit "
+                f"({config.risk.max_series_exposure_pct:.0%} of "
+                f"${bankroll:.2f})"
+            ),
+        )
+    return RiskLimitCheck(passed=True)

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -9,8 +9,10 @@ from gimmes.models.market import Market
 from gimmes.risk.limits import (
     check_bankroll,
     check_daily_loss,
+    check_event_exposure,
     check_position_count,
     check_position_size,
+    check_series_exposure,
 )
 from gimmes.risk.settlement import scan_settlement_rules
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, edge_after_fees
@@ -47,6 +49,8 @@ def validate_trade(
     fees: FeeMultipliers = DEFAULT_FEE_MULTIPLIERS,
     size_up: bool = False,
     existing_cost_basis: float = 0.0,
+    event_exposure: float = 0.0,
+    series_exposure: float = 0.0,
 ) -> ValidationResult:
     """Run all pre-trade validation checks.
 
@@ -116,6 +120,34 @@ def validate_trade(
         checks.append(f"Bankroll OK (${deployed_cost_basis + trade_dollars:.2f}/${bankroll:.2f})")
     else:
         failures.append(bankroll_check.reason)
+
+    # 4c. Event concentration limit
+    if market.event_ticker:
+        evt_check = check_event_exposure(
+            event_exposure, trade_dollars, bankroll, config,
+        )
+        if evt_check.passed:
+            checks.append(
+                f"Event exposure OK "
+                f"(${event_exposure + trade_dollars:.2f}"
+                f"/${config.risk.max_event_exposure_pct * bankroll:.2f})"
+            )
+        else:
+            failures.append(evt_check.reason)
+
+    # 4d. Series concentration limit
+    if market.series_ticker:
+        ser_check = check_series_exposure(
+            series_exposure, trade_dollars, bankroll, config,
+        )
+        if ser_check.passed:
+            checks.append(
+                f"Series exposure OK "
+                f"(${series_exposure + trade_dollars:.2f}"
+                f"/${config.risk.max_series_exposure_pct * bankroll:.2f})"
+            )
+        else:
+            failures.append(ser_check.reason)
 
     # 5. Minimum true probability gate (skipped when probability is unknown)
     if true_probability is not None:


### PR DESCRIPTION
## Summary
- Adds `max_event_exposure_pct` (15%) and `max_series_exposure_pct` (30%) to RiskConfig
- Validates concentration before every trade via event_ticker/series_ticker prefix matching
- Both `validate` and `order` commands enforce the limits

Closes #456

## Test plan
- [ ] `uv run pytest tests/unit/` — 954 tests pass
- [ ] `gimmes validate TICKER --prob P` shows event/series exposure checks
- [ ] Second position in same event rejected when it would exceed 15% of bankroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)