### PR TITLE
Auto-retry truncated monthly chunks with weekly slices

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -280,6 +280,18 @@ def monthly_chunks(start: date, end: date) -> list[tuple[int, int]]:
     return chunks
 
 
+def weekly_chunks(min_ts: int, max_ts: int) -> list[tuple[int, int]]:
+    """Split a timestamp range into ~7-day ``(min_ts, max_ts)`` pairs."""
+    chunks: list[tuple[int, int]] = []
+    current = min_ts
+    week = 7 * 24 * 60 * 60  # 7 days in seconds
+    while current <= max_ts:
+        chunk_end = min(current + week - 1, max_ts)
+        chunks.append((current, chunk_end))
+        current = chunk_end + 1
+    return chunks
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -335,12 +347,31 @@ async def run_backtest(
                     max_close_ts=max_ts,
                 )
                 if len(markets) >= pagination_cap:
+                    # Monthly chunk too large — re-fetch in weekly slices
                     label = datetime.fromtimestamp(min_ts, tz=UTC).strftime("%Y-%m")
-                    truncated_chunks.append(f"{series} ({label})")
-                    logger.warning(
-                        "Pagination limit hit for %s in %s (%d markets)",
+                    logger.info(
+                        "Re-fetching %s %s in weekly chunks (monthly hit %d cap)",
                         series, label, len(markets),
                     )
+                    markets = []
+                    still_truncated = False
+                    for wk_min, wk_max in weekly_chunks(min_ts, max_ts):
+                        wk_markets = await list_all_markets(
+                            client, status="settled", series_ticker=series,
+                            max_pages=max_pages,
+                            min_close_ts=wk_min,
+                            max_close_ts=wk_max,
+                        )
+                        if len(wk_markets) >= pagination_cap:
+                            still_truncated = True
+                        markets.extend(wk_markets)
+                    if still_truncated:
+                        truncated_chunks.append(f"{series} ({label})")
+                        logger.warning(
+                            "Pagination limit hit for %s in %s"
+                            " even with weekly chunks (%d markets)",
+                            series, label, len(markets),
+                        )
                 all_markets.extend(markets)
             except Exception:
                 label = datetime.fromtimestamp(min_ts, tz=UTC).strftime("%Y-%m")

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -11,6 +11,7 @@ from gimmes.backtest.engine import (
     monthly_chunks,
     pick_entry_candle,
     synthesize_orderbook,
+    weekly_chunks,
 )
 from gimmes.kalshi.historical import Candle
 
@@ -273,3 +274,34 @@ class TestMonthlyChunks:
 
     def test_empty_range(self) -> None:
         assert monthly_chunks(date(2025, 3, 1), date(2025, 2, 1)) == []
+
+
+class TestWeeklyChunks:
+    def test_single_week(self) -> None:
+        start = _ts(date(2025, 1, 1))
+        end = _ts_end(date(2025, 1, 5))
+        chunks = weekly_chunks(start, end)
+        assert len(chunks) == 1
+        assert chunks[0] == (start, end)
+
+    def test_two_weeks(self) -> None:
+        start = _ts(date(2025, 1, 1))
+        end = _ts_end(date(2025, 1, 14))
+        chunks = weekly_chunks(start, end)
+        assert len(chunks) == 2
+        # First chunk: Jan 1 00:00:00 to Jan 7 23:59:59
+        assert chunks[0][0] == start
+        # Second chunk starts right after first ends
+        assert chunks[1][1] == end
+
+    def test_full_month_produces_about_5_chunks(self) -> None:
+        start = _ts(date(2025, 1, 1))
+        end = _ts_end(date(2025, 1, 31))
+        chunks = weekly_chunks(start, end)
+        assert 4 <= len(chunks) <= 5
+
+    def test_single_day(self) -> None:
+        ts = _ts(date(2025, 6, 15))
+        chunks = weekly_chunks(ts, ts)
+        assert len(chunks) == 1
+        assert chunks[0] == (ts, ts)


### PR DESCRIPTION
## Summary
- When a monthly chunk hits the 40K pagination cap, automatically re-fetch it in ~7-day weekly slices
- Only reports truncation if weekly chunks also hit the cap (very unlikely — ~5.7K markets/week for the worst series)
- Added `weekly_chunks()` helper and 4 tests

Closes #462

## Test plan
- [x] 977 unit tests pass
- [x] Lint clean
- [ ] Run `gimmes backtest --from 2025-01-01 --to 2026-04-01` — verify no truncation warnings for KXINXU/KXNASDAQ100U

🤖 Generated with [Claude Code](https://claude.com/claude-code)