### PR TITLE
Fix staleness filter for NO variance strategy

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -298,7 +298,7 @@ def scan(
 
             candidates = filter_markets(markets, config, exclude_tickers=exclude_tickers)
 
-            # Staleness filtering — skip markets with no price change
+            # Staleness filtering — skip markets with no trading activity
             staleness_threshold = config.scanner.staleness_cycles
             if staleness_threshold > 0:
                 from gimmes.strategy.staleness import (

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -624,10 +624,12 @@ class ScannerConfig(BaseModel):
         json_schema_extra={
             "display_name": "Staleness Cycles",
             "description": (
-                "Skip markets whose price hasn't changed for this many consecutive\n"
-                "scan cycles. Set to 0 to disable staleness filtering.\n"
+                "Skip markets with no trading activity (no volume, no OI change,\n"
+                "no price change) for this many consecutive scan cycles. Markets\n"
+                "with stable prices but active volume are NOT considered stale.\n"
+                "Set to 0 to disable staleness filtering.\n"
                 "\n"
-                "  • 5 (default): Skip after 5 unchanged scans\n"
+                "  • 5 (default): Skip after 5 inactive scans\n"
                 "  • 0: Never skip for staleness\n"
                 "  • Higher (e.g. 10): More tolerant of quiet markets"
             ),

--- a/src/gimmes/strategy/staleness.py
+++ b/src/gimmes/strategy/staleness.py
@@ -1,4 +1,4 @@
-"""Market staleness tracking — skip markets that haven't moved in N cycles."""
+"""Market staleness tracking — skip markets with no trading activity."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 class StalenessEntry(TypedDict):
     price: float
     volume: int
+    open_interest: int
     count: int
     last_cycle: str
 
@@ -47,9 +48,14 @@ def check_staleness(
     *,
     threshold: int = 5,
     price_tolerance: float = 0.01,
-    volume_spike_ratio: float = 2.0,
+    volume_floor: int = 10,
 ) -> tuple[list[Market], list[str], dict[str, StalenessEntry]]:
     """Filter out stale markets and update staleness tracking.
+
+    A market is considered stale when it has no trading activity: price
+    unchanged, volume below the floor, and open interest frozen.  Markets
+    with stable prices but active volume are NOT stale — for a NO variance
+    strategy, a persistent mispricing with ongoing volume is the opportunity.
 
     Returns:
         (kept_candidates, skipped_tickers, updated_staleness_data)
@@ -64,26 +70,26 @@ def check_staleness(
     for m in candidates:
         price = m.midpoint if m.midpoint > 0 else m.last_price
         volume = m.volume_24h if m.volume_24h > 0 else m.volume
+        oi = m.open_interest
         ticker = m.ticker
 
         entry = staleness_data.get(ticker)
         if entry is not None:
-            price_unchanged = abs(price - entry["price"]) <= price_tolerance
-            volume_spiked = (
-                entry["volume"] > 0
-                and volume >= entry["volume"] * volume_spike_ratio
-            )
+            price_changed = abs(price - entry["price"]) > price_tolerance
+            has_volume = volume >= volume_floor
+            oi_changed = oi != entry.get("open_interest", 0)
 
-            if price_unchanged and not volume_spiked:
-                new_count = entry["count"] + 1
-            else:
+            if price_changed or has_volume or oi_changed:
                 new_count = 0
+            else:
+                new_count = entry["count"] + 1
         else:
             new_count = 0
 
         staleness_data[ticker] = StalenessEntry(
             price=price,
             volume=volume,
+            open_interest=oi,
             count=new_count,
             last_cycle=now,
         )

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -14,7 +14,12 @@ from gimmes.strategy.staleness import (
 )
 
 
-def _market(ticker: str = "T1", price: float = 0.65, volume: int = 500) -> Market:
+def _market(
+    ticker: str = "T1",
+    price: float = 0.65,
+    volume: int = 500,
+    open_interest: int = 1000,
+) -> Market:
     return Market(
         ticker=ticker,
         status=MarketStatus.ACTIVE,
@@ -23,6 +28,7 @@ def _market(ticker: str = "T1", price: float = 0.65, volume: int = 500) -> Marke
         last_price=price,
         volume=volume,
         volume_24h=volume,
+        open_interest=open_interest,
     )
 
 
@@ -34,25 +40,31 @@ class TestCheckStaleness:
         assert skipped == []
         assert updated["T1"]["count"] == 0
 
-    def test_unchanged_price_increments_count(self) -> None:
+    def test_inactive_market_increments_count(self) -> None:
+        """No price change, no volume, no OI change → stale count increments."""
         data: dict[str, StalenessEntry] = {
             "T1": StalenessEntry(
-                price=0.65, volume=500, count=2,
+                price=0.65, volume=0, open_interest=1000, count=2,
                 last_cycle=datetime.now(UTC).isoformat(),
             ),
         }
-        kept, skipped, updated = check_staleness([_market()], data, threshold=5)
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0)], data, threshold=5,
+        )
         assert len(kept) == 1
         assert updated["T1"]["count"] == 3
 
     def test_count_reaches_threshold_skips(self) -> None:
+        """Inactive market reaching threshold gets skipped."""
         data: dict[str, StalenessEntry] = {
             "T1": StalenessEntry(
-                price=0.65, volume=500, count=4,
+                price=0.65, volume=0, open_interest=1000, count=4,
                 last_cycle=datetime.now(UTC).isoformat(),
             ),
         }
-        kept, skipped, updated = check_staleness([_market()], data, threshold=5)
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0)], data, threshold=5,
+        )
         assert len(kept) == 0
         assert skipped == ["T1"]
         assert updated["T1"]["count"] == 5
@@ -60,37 +72,115 @@ class TestCheckStaleness:
     def test_price_change_resets_count(self) -> None:
         data: dict[str, StalenessEntry] = {
             "T1": StalenessEntry(
-                price=0.60, volume=500, count=4,
+                price=0.60, volume=0, open_interest=1000, count=4,
                 last_cycle=datetime.now(UTC).isoformat(),
             ),
         }
         # Market at 0.65, prior was 0.60 — 5¢ change
-        kept, skipped, updated = check_staleness([_market()], data, threshold=5)
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0)], data, threshold=5,
+        )
         assert len(kept) == 1
         assert updated["T1"]["count"] == 0
 
-    def test_volume_spike_resets_count(self) -> None:
+    def test_stable_price_with_volume_not_stale(self) -> None:
+        """Same price but active volume → NOT stale. This is the key fix."""
         data: dict[str, StalenessEntry] = {
             "T1": StalenessEntry(
-                price=0.65, volume=200, count=4,
+                price=0.65, volume=500, open_interest=1000, count=4,
                 last_cycle=datetime.now(UTC).isoformat(),
             ),
         }
-        # Same price but volume 500 > 200 * 2.0 = 400
         kept, skipped, updated = check_staleness(
             [_market(volume=500)], data, threshold=5,
         )
         assert len(kept) == 1
         assert updated["T1"]["count"] == 0
 
-    def test_threshold_zero_disables(self) -> None:
+    def test_oi_change_resets_count(self) -> None:
+        """Same price, no volume, but OI changed → not stale."""
         data: dict[str, StalenessEntry] = {
             "T1": StalenessEntry(
-                price=0.65, volume=500, count=99,
+                price=0.65, volume=0, open_interest=800, count=4,
                 last_cycle=datetime.now(UTC).isoformat(),
             ),
         }
-        kept, skipped, updated = check_staleness([_market()], data, threshold=0)
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0, open_interest=1000)], data, threshold=5,
+        )
+        assert len(kept) == 1
+        assert updated["T1"]["count"] == 0
+
+    def test_no_volume_no_oi_no_price_increments(self) -> None:
+        """Truly dead market: no price move, no volume, same OI → stale."""
+        data: dict[str, StalenessEntry] = {
+            "T1": StalenessEntry(
+                price=0.65, volume=0, open_interest=1000, count=0,
+                last_cycle=datetime.now(UTC).isoformat(),
+            ),
+        }
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0)], data, threshold=5,
+        )
+        assert len(kept) == 1
+        assert updated["T1"]["count"] == 1
+
+    def test_volume_at_floor_not_stale(self) -> None:
+        """Volume exactly at floor → active, count resets."""
+        data: dict[str, StalenessEntry] = {
+            "T1": StalenessEntry(
+                price=0.65, volume=10, open_interest=1000, count=4,
+                last_cycle=datetime.now(UTC).isoformat(),
+            ),
+        }
+        kept, skipped, updated = check_staleness(
+            [_market(volume=10)], data, threshold=5, volume_floor=10,
+        )
+        assert len(kept) == 1
+        assert updated["T1"]["count"] == 0
+
+    def test_volume_below_floor_stale(self) -> None:
+        """Volume just below floor → inactive, count increments."""
+        data: dict[str, StalenessEntry] = {
+            "T1": StalenessEntry(
+                price=0.65, volume=9, open_interest=1000, count=3,
+                last_cycle=datetime.now(UTC).isoformat(),
+            ),
+        }
+        kept, skipped, updated = check_staleness(
+            [_market(volume=9)], data, threshold=5, volume_floor=10,
+        )
+        assert len(kept) == 1
+        assert updated["T1"]["count"] == 4
+
+    def test_old_entry_missing_open_interest(self) -> None:
+        """Backward compat: old entries without open_interest don't crash."""
+        data: dict[str, StalenessEntry] = {
+            "T1": {  # type: ignore[typeddict-item]
+                "price": 0.65,
+                "volume": 0,
+                "count": 3,
+                "last_cycle": datetime.now(UTC).isoformat(),
+            },
+        }
+        # OI defaults to 0, market has OI=1000, so oi_changed=True → reset
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0)], data, threshold=5,
+        )
+        assert len(kept) == 1
+        assert updated["T1"]["count"] == 0
+        assert updated["T1"]["open_interest"] == 1000
+
+    def test_threshold_zero_disables(self) -> None:
+        data: dict[str, StalenessEntry] = {
+            "T1": StalenessEntry(
+                price=0.65, volume=0, open_interest=1000, count=99,
+                last_cycle=datetime.now(UTC).isoformat(),
+            ),
+        }
+        kept, skipped, updated = check_staleness(
+            [_market(volume=0)], data, threshold=0,
+        )
         assert len(kept) == 1
         assert skipped == []
 
@@ -98,10 +188,11 @@ class TestCheckStaleness:
         old_time = (datetime.now(UTC) - timedelta(hours=49)).isoformat()
         data: dict[str, StalenessEntry] = {
             "OLD": StalenessEntry(
-                price=0.50, volume=100, count=3, last_cycle=old_time,
+                price=0.50, volume=100, open_interest=500, count=3,
+                last_cycle=old_time,
             ),
             "T1": StalenessEntry(
-                price=0.65, volume=500, count=0,
+                price=0.65, volume=500, open_interest=1000, count=0,
                 last_cycle=datetime.now(UTC).isoformat(),
             ),
         }
@@ -125,7 +216,7 @@ class TestLoadSave:
         path = tmp_path / "staleness.json"
         data: dict[str, StalenessEntry] = {
             "T1": StalenessEntry(
-                price=0.65, volume=500, count=3,
+                price=0.65, volume=500, open_interest=1000, count=3,
                 last_cycle="2026-04-03T12:00:00+00:00",
             ),
         }


### PR DESCRIPTION
## Summary

The staleness filter was removing 77 of 83 eligible markets because their prices hadn't changed in 5 cycles. For a BUY NO variance strategy, stable prices with active volume represent persistent mispricings — the ideal opportunity, not staleness.

Changed the staleness signal from "price unchanged" to "no trading activity": a market is stale only when price is unchanged AND volume is below a floor (default 10) AND open interest hasn't changed. Markets with stable prices but active trading now pass through correctly.

- Replaced `volume_spike_ratio` parameter with `volume_floor` (minimum volume to consider active)
- Added `open_interest` tracking to StalenessEntry for OI-change detection
- Backward compatible with existing `scan_staleness.json` files (old entries missing `open_interest` default to 0)

Closes #467

## Test plan
- [x] 15 unit tests pass (was 10, added 5 new tests for volume floor boundary, OI changes, backward compat)
- [x] Full test suite passes (985 tests)
- [x] Lint clean on all changed files
- [ ] Verify next scan cycle surfaces more candidates (expect ~80 instead of ~3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)