### PR TITLE
Fix gimmes update failing with untracked files

### DIFF
--- a/bin/gimmes.sh
+++ b/bin/gimmes.sh
@@ -174,9 +174,10 @@ case "${1:-}" in
             exit 1
         fi
 
-        if ! git checkout . --quiet 2>/dev/null; then
-            echo "Warning: could not clean local changes; update may fail."
-        fi
+        # Restore tracked files and remove untracked files that would
+        # block checkout of a new tag (e.g. new files added in the release).
+        git checkout . --quiet 2>/dev/null || true
+        git clean -fd --quiet 2>/dev/null || true
 
         latest_tag=$(latest_remote_tag)
 
@@ -187,7 +188,7 @@ case "${1:-}" in
                 echo "Already on latest version $latest_tag"
                 exit 0
             fi
-            if ! git checkout "$latest_tag" --quiet 2>/dev/null; then
+            if ! git checkout "$latest_tag" --quiet; then
                 echo "Error: could not checkout $latest_tag."
                 echo "Try: cd $REPO && git status"
                 exit 1


### PR DESCRIPTION
## Summary
`gimmes update` failed silently when a new release introduced files that already existed as untracked in `~/.gimmes/repo`. Added `git clean -fd` after `git checkout .` to remove untracked files before checking out the new tag. Also stopped suppressing the checkout error so users see what failed.

Closes #478

## Test plan
- [x] Verified the update command section in `bin/gimmes.sh` now cleans untracked files
- [ ] Manual: create an untracked file in `~/.gimmes/repo/src/`, run `gimmes update`, confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)