### PR TITLE
Integrate position-aware trade windows into autonomous loop

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3397,6 +3397,7 @@ def _autonomous_loop(
             close_time.  When positions lack a cached close_time, a
             short-lived API client fetches and caches it.
             """
+            import logging
             from datetime import datetime as _dt
 
             from gimmes.store.database import Database
@@ -3405,11 +3406,18 @@ def _autonomous_loop(
                 get_position_tickers,
             )
 
+            _log = logging.getLogger("gimmes.position_window")
+            pos_table = config.position_table
+
             now = _dt.now(ET)
             async with Database(config.db_path) as db:
-                close_times = await get_position_close_times(db)
+                close_times = await get_position_close_times(
+                    db, table=pos_table,
+                )
                 cached_tickers = {t for t, _ in close_times}
-                all_tickers = await get_position_tickers(db)
+                all_tickers = await get_position_tickers(
+                    db, table=pos_table,
+                )
                 missing = all_tickers - cached_tickers
 
             # Backfill close_times for positions that lack them
@@ -3425,7 +3433,7 @@ def _autonomous_loop(
                                     mkt = await get_market(client, ticker)
                                     if mkt.close_time:
                                         await db.conn.execute(
-                                            "UPDATE positions"
+                                            f"UPDATE {pos_table}"  # noqa: S608
                                             " SET close_time = ?"
                                             " WHERE ticker = ?",
                                             (mkt.close_time.isoformat(),
@@ -3435,10 +3443,18 @@ def _autonomous_loop(
                                             (ticker, mkt.close_time)
                                         )
                                 except Exception:
+                                    _log.warning(
+                                        "Failed to backfill close_time"
+                                        " for %s",
+                                        ticker, exc_info=True,
+                                    )
                                     continue
                             await db.conn.commit()
                 except Exception:
-                    pass  # Best-effort; proceed with whatever we have
+                    _log.warning(
+                        "Position window backfill failed",
+                        exc_info=True,
+                    )
 
             for ticker, ct in close_times:
                 pw_open, pw_close = position_window(ct)

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3382,10 +3382,69 @@ def _autonomous_loop(
     old_handler = signal.signal(signal.SIGINT, _sigint_handler)
     try:
         from gimmes.strategy.calendar import (
+            ET,
             is_in_trade_window,
             next_trade_window,
+            position_window,
             seconds_until_next_window,
         )
+
+        async def _check_position_windows() -> tuple[bool, str | None]:
+            """Check if any open position is within a settlement window.
+
+            Returns (in_position_window, ticker) if now falls within an
+            ad-hoc position window for any held position with a known
+            close_time.  When positions lack a cached close_time, a
+            short-lived API client fetches and caches it.
+            """
+            from datetime import datetime as _dt
+
+            from gimmes.store.database import Database
+            from gimmes.store.queries import (
+                get_position_close_times,
+                get_position_tickers,
+            )
+
+            now = _dt.now(ET)
+            async with Database(config.db_path) as db:
+                close_times = await get_position_close_times(db)
+                cached_tickers = {t for t, _ in close_times}
+                all_tickers = await get_position_tickers(db)
+                missing = all_tickers - cached_tickers
+
+            # Backfill close_times for positions that lack them
+            if missing:
+                try:
+                    from gimmes.kalshi.client import KalshiClient
+                    from gimmes.kalshi.markets import get_market
+
+                    async with KalshiClient(config) as client:
+                        async with Database(config.db_path) as db:
+                            for ticker in missing:
+                                try:
+                                    mkt = await get_market(client, ticker)
+                                    if mkt.close_time:
+                                        await db.conn.execute(
+                                            "UPDATE positions"
+                                            " SET close_time = ?"
+                                            " WHERE ticker = ?",
+                                            (mkt.close_time.isoformat(),
+                                             ticker),
+                                        )
+                                        close_times.append(
+                                            (ticker, mkt.close_time)
+                                        )
+                                except Exception:
+                                    continue
+                            await db.conn.commit()
+                except Exception:
+                    pass  # Best-effort; proceed with whatever we have
+
+            for ticker, ct in close_times:
+                pw_open, pw_close = position_window(ct)
+                if pw_open <= now < pw_close:
+                    return True, ticker
+            return False, None
 
         while max_cycles == 0 or cycles_run < max_cycles:
             cycle += 1
@@ -3402,22 +3461,37 @@ def _autonomous_loop(
                     f" [green bold][TRADE WINDOW: {release_name}][/green bold]"
                 )
             else:
-                cycle_type = "monitor"
-                _, next_name = next_trade_window()
-                secs_to_next = seconds_until_next_window()
-                post_sleep = min(secs_to_next, monitor_interval)
-                h, remainder = divmod(secs_to_next, 3600)
-                m, _ = divmod(remainder, 60)
-                console.print(
-                    f"[cyan]--- Cycle {cycle} ---[/cyan]"
-                    f" [yellow][MONITOR ONLY — next window:"
-                    f" {next_name} in {h}h {m:02d}m][/yellow]"
+                # Check if any held position is near settlement
+                _pw_result = asyncio.run(
+                    _check_position_windows()
                 )
-                cycle_prompt = (
-                    "Run a MONITOR-ONLY cycle. Only run Steps 0, 0.5, 1, 2,"
-                    " 6.5, and 8. Skip Scout, Caddie, Closer, Scorecard,"
-                    " and Pro."
-                )
+                in_pos_window, pos_ticker = _pw_result or (False, None)
+                if in_pos_window:
+                    cycle_type = "full"
+                    cycle_prompt = "Run one trading cycle."
+                    post_sleep = pause_seconds
+                    console.print(
+                        f"[cyan]--- Cycle {cycle} ---[/cyan]"
+                        f" [magenta bold][POSITION WINDOW:"
+                        f" {pos_ticker}][/magenta bold]"
+                    )
+                else:
+                    cycle_type = "monitor"
+                    _, next_name = next_trade_window()
+                    secs_to_next = seconds_until_next_window()
+                    post_sleep = min(secs_to_next, monitor_interval)
+                    h, remainder = divmod(secs_to_next, 3600)
+                    m, _ = divmod(remainder, 60)
+                    console.print(
+                        f"[cyan]--- Cycle {cycle} ---[/cyan]"
+                        f" [yellow][MONITOR ONLY — next window:"
+                        f" {next_name} in {h}h {m:02d}m][/yellow]"
+                    )
+                    cycle_prompt = (
+                        "Run a MONITOR-ONLY cycle. Only run Steps 0, 0.5, 1, 2,"
+                        " 6.5, and 8. Skip Scout, Caddie, Closer, Scorecard,"
+                        " and Pro."
+                    )
 
             update_session_cycle(config.db_path, session_id, cycle)
 

--- a/src/gimmes/models/portfolio.py
+++ b/src/gimmes/models/portfolio.py
@@ -29,6 +29,7 @@ class Position(BaseModel):
     market_value: float = 0.0
     unrealized_pnl: float = 0.0
     realized_pnl: float = 0.0
+    close_time: datetime | None = None  # Market close/settlement time
 
     @property
     def total_pnl(self) -> float:

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -95,6 +95,16 @@ _V12_COLUMNS: list[str] = [
     "ALTER TABLE candidates ADD COLUMN cap_blocked INTEGER NOT NULL DEFAULT 0",
 ]
 
+# ALTER TABLE ADD COLUMN statements for v16: close_time on positions.
+_V16_COLUMNS: list[str] = [
+    "ALTER TABLE positions ADD COLUMN close_time TEXT DEFAULT NULL",
+]
+
+# ALTER TABLE ADD COLUMN statements for v17: close_time on paper_positions.
+_V17_COLUMNS: list[str] = [
+    "ALTER TABLE paper_positions ADD COLUMN close_time TEXT DEFAULT NULL",
+]
+
 
 async def get_schema_version(db: Database) -> int:
     """Get the current schema version."""
@@ -296,5 +306,29 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 15
+
+    # Version 16: close_time column on positions for position-aware windows
+    if current < 16:
+        await _run_alter_columns(db, _V16_COLUMNS)
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (16,)
+        )
+        await db.conn.commit()
+        current = 16
+
+    # Version 17: close_time column on paper_positions for dashboard display
+    if current < 17:
+        # paper_positions is created by PaperBroker, not the main schema,
+        # so it may not exist yet. Only alter if present.
+        cursor = await db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='paper_positions'"
+        )
+        if await cursor.fetchone():
+            await _run_alter_columns(db, _V17_COLUMNS)
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (17,)
+        )
+        await db.conn.commit()
+        current = 17
 
     return current

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -100,10 +100,6 @@ _V16_COLUMNS: list[str] = [
     "ALTER TABLE positions ADD COLUMN close_time TEXT DEFAULT NULL",
 ]
 
-# ALTER TABLE ADD COLUMN statements for v17: close_time on paper_positions.
-_V17_COLUMNS: list[str] = [
-    "ALTER TABLE paper_positions ADD COLUMN close_time TEXT DEFAULT NULL",
-]
 
 
 async def get_schema_version(db: Database) -> int:
@@ -315,20 +311,5 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 16
-
-    # Version 17: close_time column on paper_positions for dashboard display
-    if current < 17:
-        # paper_positions is created by PaperBroker, not the main schema,
-        # so it may not exist yet. Only alter if present.
-        cursor = await db.conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='paper_positions'"
-        )
-        if await cursor.fetchone():
-            await _run_alter_columns(db, _V17_COLUMNS)
-        await db.conn.execute(
-            "INSERT INTO schema_version (version) VALUES (?)", (17,)
-        )
-        await db.conn.commit()
-        current = 17
 
     return current

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -587,10 +587,19 @@ async def get_open_trade_for_ticker(db: Database, ticker: str) -> dict | None:  
     return dict(row) if row else None
 
 
-async def get_position_close_times(db: Database) -> list[tuple[str, datetime]]:
+async def get_position_close_times(
+    db: Database, *, table: str = "positions",
+) -> list[tuple[str, datetime]]:
     """Return (ticker, close_time) pairs for open positions with a known close_time."""
+    if table not in _ALLOWED_POSITION_TABLES:
+        raise ValueError(f"Invalid position table: {table}")
+
+    from zoneinfo import ZoneInfo
+
+    _utc = ZoneInfo("UTC")
+
     cursor = await db.conn.execute(
-        "SELECT ticker, close_time FROM positions"
+        f"SELECT ticker, close_time FROM {table}"  # noqa: S608
         " WHERE count > 0 AND close_time IS NOT NULL"
     )
     rows = await cursor.fetchall()
@@ -598,6 +607,9 @@ async def get_position_close_times(db: Database) -> list[tuple[str, datetime]]:
     for row in rows:
         try:
             ct = datetime.fromisoformat(row["close_time"])
+            # Normalize naive datetimes to UTC (Kalshi API returns UTC)
+            if ct.tzinfo is None:
+                ct = ct.replace(tzinfo=_utc)
             results.append((row["ticker"], ct))
         except (ValueError, TypeError):
             continue

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TypedDict
 
 from gimmes.models.error import ErrorLogEntry
@@ -122,21 +123,26 @@ async def update_trade_outcome(db: Database, ticker: str, outcome: str) -> int:
 
 _UPSERT_POSITION_SQL = """INSERT INTO positions
     (ticker, title, side, count, avg_price, market_price,
-     cost_basis, market_value, unrealized_pnl, realized_pnl)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     cost_basis, market_value, unrealized_pnl, realized_pnl, close_time)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(ticker) DO UPDATE SET
      title=excluded.title, side=excluded.side, count=excluded.count,
      avg_price=excluded.avg_price, market_price=excluded.market_price,
      cost_basis=excluded.cost_basis, market_value=excluded.market_value,
      unrealized_pnl=excluded.unrealized_pnl, realized_pnl=excluded.realized_pnl,
+     close_time=COALESCE(excluded.close_time, close_time),
      updated_at=datetime('now')"""
 
 
 def _position_params(pos: Position) -> tuple:
+    close_time_str = (
+        pos.close_time.isoformat() if pos.close_time is not None else None
+    )
     return (
         pos.ticker, pos.title, pos.side, pos.count,
         pos.avg_price, pos.market_price, pos.cost_basis,
         pos.market_value, pos.unrealized_pnl, pos.realized_pnl,
+        close_time_str,
     )
 
 
@@ -223,21 +229,31 @@ async def get_positions(db: Database) -> list[Position]:
 
     cursor = await db.conn.execute("SELECT * FROM positions WHERE count > 0")
     rows = await cursor.fetchall()
-    return [
-        Position(
-            ticker=row["ticker"],
-            title=row["title"],
-            side=row["side"],
-            count=row["count"],
-            avg_price=row["avg_price"],
-            market_price=row["market_price"],
-            cost_basis=row["cost_basis"],
-            market_value=row["market_value"],
-            unrealized_pnl=row["unrealized_pnl"],
-            realized_pnl=row["realized_pnl"],
+    positions = []
+    for row in rows:
+        close_time_val = row["close_time"] if "close_time" in row.keys() else None
+        close_time_dt = None
+        if close_time_val:
+            try:
+                close_time_dt = datetime.fromisoformat(close_time_val)
+            except (ValueError, TypeError):
+                pass
+        positions.append(
+            Position(
+                ticker=row["ticker"],
+                title=row["title"],
+                side=row["side"],
+                count=row["count"],
+                avg_price=row["avg_price"],
+                market_price=row["market_price"],
+                cost_basis=row["cost_basis"],
+                market_value=row["market_value"],
+                unrealized_pnl=row["unrealized_pnl"],
+                realized_pnl=row["realized_pnl"],
+                close_time=close_time_dt,
+            )
         )
-        for row in rows
-    ]
+    return positions
 
 
 _ALLOWED_POSITION_TABLES = frozenset({"positions", "paper_positions"})
@@ -569,6 +585,23 @@ async def get_open_trade_for_ticker(db: Database, ticker: str) -> dict | None:  
     )
     row = await cursor.fetchone()
     return dict(row) if row else None
+
+
+async def get_position_close_times(db: Database) -> list[tuple[str, datetime]]:
+    """Return (ticker, close_time) pairs for open positions with a known close_time."""
+    cursor = await db.conn.execute(
+        "SELECT ticker, close_time FROM positions"
+        " WHERE count > 0 AND close_time IS NOT NULL"
+    )
+    rows = await cursor.fetchall()
+    results: list[tuple[str, datetime]] = []
+    for row in rows:
+        try:
+            ct = datetime.fromisoformat(row["close_time"])
+            results.append((row["ticker"], ct))
+        except (ValueError, TypeError):
+            continue
+    return results
 
 
 async def has_open_position(db: Database, ticker: str) -> bool:


### PR DESCRIPTION
## Summary
- When the autonomous loop is outside a standard trade window, it now checks whether any held position is approaching settlement by querying cached `close_time` values from the positions table
- If a position's `close_time` falls within a `position_window()` (18h before settlement), the loop runs a full trading cycle instead of monitor-only, ensuring positions near settlement get active management
- Missing `close_time` values are backfilled via a short-lived API client on first check, then cached for subsequent cycles

Closes #481

## Test plan
- [x] All 1027 unit tests pass
- [x] Ruff lint clean on all changed files
- [ ] Verify in driving range mode: with an open position nearing settlement, the loop prints `[POSITION WINDOW: <ticker>]` and runs a full cycle
- [ ] Verify without open positions or with distant settlements, the loop behaves as before (monitor-only outside trade windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)