### PR TITLE
Add code staleness detection to autonomous loop

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3179,6 +3179,75 @@ def _detect_rate_limit(output: bytes) -> tuple[bool, int]:
     return True, 1800  # 30 min fallback
 
 
+def _check_code_staleness(
+    project_root: Path,
+    startup_commit: str | None,
+) -> tuple[str, bool, str | None]:
+    """Check if the running code has changed since startup.
+
+    Returns ``(current_commit, is_stale, message)``.  Fails open —
+    any git error returns ``("", False, None)``.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return "", False, None
+        current = result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return "", False, None
+
+    if startup_commit is None:
+        return current, False, None
+
+    if current != startup_commit:
+        return current, True, (
+            f"Installed code changed: startup={startup_commit[:8]}"
+            f" current={current[:8]}."
+            f" Restart to pick up changes."
+        )
+    return current, False, None
+
+
+def _check_remote_staleness(
+    project_root: Path,
+    current_commit: str,
+) -> str | None:
+    """Check if remote has commits ahead of *current_commit*.
+
+    Returns a warning message or ``None`` if up to date.
+    Uses ``git ls-remote`` (read-only, no fetch).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "origin", "HEAD"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        remote_sha = (
+            result.stdout.split()[0] if result.stdout.strip() else None
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    if remote_sha and remote_sha != current_commit:
+        return (
+            f"Remote has newer code: local={current_commit[:8]}"
+            f" remote={remote_sha[:8]}."
+            f" Run `gimmes update` and restart."
+        )
+    return None
+
+
 def _extract_terminal_text(json_bytes: bytes) -> bytes:
     """Extract human-readable assistant text from Claude JSON output.
 
@@ -3364,6 +3433,11 @@ def _autonomous_loop(
     consecutive_failures = 0
     session_status = "stopped"
 
+    # Code staleness detection
+    _startup_commit: str | None = None
+    _last_remote_check: float = 0.0
+    _staleness_warned = False
+
     # Custom SIGINT handler — Python's default SIGINT → KeyboardInterrupt
     # delivery is blocked by Thread.join() on macOS (CPython bpo-45274).
     # This handler fires at the C level and sends SIGTERM to the subprocess
@@ -3471,6 +3545,30 @@ def _autonomous_loop(
         while max_cycles == 0 or cycles_run < max_cycles:
             cycle += 1
             cycles_run += 1
+
+            # Code staleness check
+            _cur, _stale, _stale_msg = _check_code_staleness(
+                project_root, _startup_commit,
+            )
+            if _startup_commit is None and _cur:
+                _startup_commit = _cur
+            if _stale and _stale_msg:
+                console.print(
+                    f"[red bold]CODE STALE: {_stale_msg}[/red bold]"
+                )
+            elif _cur and not _staleness_warned:
+                _now_ts = time.time()
+                if _now_ts - _last_remote_check >= monitor_interval:
+                    _remote_msg = _check_remote_staleness(
+                        project_root, _cur,
+                    )
+                    _last_remote_check = _now_ts
+                    if _remote_msg:
+                        console.print(
+                            f"[yellow bold]UPDATE AVAILABLE:"
+                            f" {_remote_msg}[/yellow bold]"
+                        )
+                        _staleness_warned = True
 
             # Determine cycle type based on trade window calendar
             in_window, release_name, _secs_to_close = is_in_trade_window()

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3241,7 +3241,8 @@ def _check_remote_staleness(
 
     if remote_sha and remote_sha != current_commit:
         return (
-            f"Remote has newer code: local={current_commit[:8]}"
+            f"Remote differs from local:"
+            f" local={current_commit[:8]}"
             f" remote={remote_sha[:8]}."
             f" Run `gimmes update` and restart."
         )
@@ -3556,19 +3557,34 @@ def _autonomous_loop(
                 console.print(
                     f"[red bold]CODE STALE: {_stale_msg}[/red bold]"
                 )
-            elif _cur and not _staleness_warned:
-                _now_ts = time.time()
-                if _now_ts - _last_remote_check >= monitor_interval:
-                    _remote_msg = _check_remote_staleness(
-                        project_root, _cur,
+            elif _cur:
+                if _staleness_warned:
+                    # Re-print cached warning each cycle
+                    console.print(
+                        "[yellow bold]UPDATE AVAILABLE:"
+                        " Run `gimmes update` and restart."
+                        "[/yellow bold]"
                     )
-                    _last_remote_check = _now_ts
-                    if _remote_msg:
-                        console.print(
-                            f"[yellow bold]UPDATE AVAILABLE:"
-                            f" {_remote_msg}[/yellow bold]"
+                else:
+                    # Throttled remote check — skip during trade
+                    # windows to avoid blocking time-sensitive cycles
+                    _now_ts = time.time()
+                    _in_tw = is_in_trade_window()[0]
+                    if (
+                        not _in_tw
+                        and _now_ts - _last_remote_check
+                        >= monitor_interval
+                    ):
+                        _remote_msg = _check_remote_staleness(
+                            project_root, _cur,
                         )
-                        _staleness_warned = True
+                        _last_remote_check = _now_ts
+                        if _remote_msg:
+                            console.print(
+                                f"[yellow bold]UPDATE AVAILABLE:"
+                                f" {_remote_msg}[/yellow bold]"
+                            )
+                            _staleness_warned = True
 
             # Determine cycle type based on trade window calendar
             in_window, release_name, _secs_to_close = is_in_trade_window()

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -13,6 +13,8 @@ from typer.testing import CliRunner
 
 from gimmes.cli import (
     _autonomous_loop,
+    _check_code_staleness,
+    _check_remote_staleness,
     _communicate_interruptible,
     _detect_rate_limit,
     _extract_terminal_text,
@@ -118,6 +120,14 @@ class TestAutonomousLoop:
             patch(
                 "gimmes.strategy.calendar.seconds_until_next_window",
                 return_value=3600,
+            ),
+            patch(
+                "gimmes.cli._check_code_staleness",
+                return_value=("abc123", False, None),
+            ),
+            patch(
+                "gimmes.cli._check_remote_staleness",
+                return_value=None,
             ),
         ):
             yield
@@ -1181,3 +1191,87 @@ class TestCaddieMasterAgent:
         assert "name: Caddie Master" in content
         assert "tools:" in content
         assert "Agent" in content
+
+
+class TestCheckCodeStaleness:
+    def test_first_call_returns_commit(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="abc123def\n",
+            )
+            commit, stale, msg = _check_code_staleness(tmp_path, None)
+            assert commit == "abc123def"
+            assert stale is False
+            assert msg is None
+
+    def test_same_commit_not_stale(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="abc123def\n",
+            )
+            _, stale, msg = _check_code_staleness(
+                tmp_path, "abc123def",
+            )
+            assert stale is False
+            assert msg is None
+
+    def test_different_commit_is_stale(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="new456ghi\n",
+            )
+            _, stale, msg = _check_code_staleness(
+                tmp_path, "old123abc",
+            )
+            assert stale is True
+            assert "old123ab" in msg
+            assert "new456gh" in msg
+
+    def test_git_failure_returns_empty(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=128, stdout="",
+            )
+            commit, stale, msg = _check_code_staleness(
+                tmp_path, "abc",
+            )
+            assert commit == ""
+            assert stale is False
+
+    def test_git_not_found(self, tmp_path: Path) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            commit, stale, msg = _check_code_staleness(
+                tmp_path, "abc",
+            )
+            assert commit == ""
+            assert stale is False
+
+
+class TestCheckRemoteStaleness:
+    def test_same_commit_returns_none(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="abc123def\tHEAD\n",
+            )
+            msg = _check_remote_staleness(tmp_path, "abc123def")
+            assert msg is None
+
+    def test_different_commit_returns_warning(
+        self, tmp_path: Path,
+    ) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="remote99\tHEAD\n",
+            )
+            msg = _check_remote_staleness(tmp_path, "local123")
+            assert msg is not None
+            assert "remote99" in msg
+            assert "local123" in msg
+
+    def test_network_failure_returns_none(self, tmp_path: Path) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = _subprocess.TimeoutExpired(
+                cmd="git", timeout=10,
+            )
+            msg = _check_remote_staleness(tmp_path, "abc")
+            assert msg is None

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -1267,6 +1267,7 @@ class TestCheckRemoteStaleness:
             assert msg is not None
             assert "remote99" in msg
             assert "local123" in msg
+            assert "differs" in msg.lower()
 
     def test_network_failure_returns_none(self, tmp_path: Path) -> None:
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary
- Detect when installed code changes under a running driving_range process (e.g., after `gimmes update`)
- Detect when remote has newer commits available
- Prints `CODE STALE` (red) or `UPDATE AVAILABLE` (yellow) warnings at the top of each cycle
- Fails open — git errors never block trading cycles
- Remote checks throttled to once per monitor_interval (default 1h)
- 8 new unit tests for both staleness functions

Closes #486

## Test plan
- [x] 1035 unit tests pass
- [x] Lint clean
- [ ] Start driving_range, run `gimmes update` in another terminal → see `CODE STALE` warning on next cycle
- [ ] Push a commit to remote → see `UPDATE AVAILABLE` warning within monitor_interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)