### PR TITLE
Recalculate sleep after cycle to catch newly opened trade windows

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3736,6 +3736,11 @@ def _autonomous_loop(
             if max_cycles > 0 and cycles_run >= max_cycles:
                 break
 
+            # Recalculate sleep after cycle completes — a trade window
+            # may have opened during the cycle execution.
+            if cycle_type == "monitor":
+                fresh_secs = seconds_until_next_window()
+                post_sleep = min(fresh_secs, monitor_interval)
             console.print(f"[dim]Next cycle in {post_sleep}s...[/dim]")
             time.sleep(post_sleep)
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- Recalculate `seconds_until_next_window()` after monitor cycles complete instead of using the pre-cycle value
- If a trade window opened during the 5-15 minute monitor cycle, the next iteration starts immediately instead of sleeping for the stale pre-cycle duration

Closes #487

## Test plan
- [x] 1035 unit tests pass
- [x] Lint clean
- [ ] Run driving_range with a monitor cycle ending just before a trade window — verify the next cycle starts promptly as a full cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)