### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ on Kalshi prediction markets using a team of Claude Code agents.
 - Self-update command with stale-code protection and tag-based version
   checks
 
+[0.4.1]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.4.1
 [0.4.0]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.4.0
 [0.3.0]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.3.0
 [0.2.0]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.1] - 2026-04-10
+
+### Added
+- Position-aware trade windows in autonomous loop: full pipeline cycles automatically run near position settlement dates, not just during scheduled data release windows (#484)
+- Code staleness detection: autonomous loop warns when installed code changes or remote has newer commits available (#490)
+- Settlement date column in Clubhouse dashboard open positions table (#485)
+
+### Fixed
+- CPI and GDP trade windows now use actual BLS/BEA release dates instead of hardcoded approximations — includes 2025-2026 lookup tables with fallback heuristic for future years (#482)
+- Recalculate sleep after monitor cycles to catch newly opened trade windows (#491)
+- `gimmes update` no longer fails when new releases add files that exist as untracked in the repo (#483)
+
 ## [0.4.0] - 2026-04-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gimmes"
-version = "0.4.0"
+version = "0.4.1"
 description = "Autonomous Claude Code agent system for trading Kalshi prediction markets"
 readme = "README.md"
 license = "MIT"

--- a/src/gimmes/__init__.py
+++ b/src/gimmes/__init__.py
@@ -1,3 +1,3 @@
 """GIMMES — We only play the gimmes."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
## Release v0.4.1

### Added
- Position-aware trade windows in autonomous loop: full pipeline cycles automatically run near position settlement dates, not just during scheduled data release windows (#484)
- Code staleness detection: autonomous loop warns when installed code changes or remote has newer commits available (#490)
- Settlement date column in Clubhouse dashboard open positions table (#485)

### Fixed
- CPI and GDP trade windows now use actual BLS/BEA release dates instead of hardcoded approximations — includes 2025-2026 lookup tables with fallback heuristic for future years (#482)
- Recalculate sleep after monitor cycles to catch newly opened trade windows (#491)
- `gimmes update` no longer fails when new releases add files that exist as untracked in the repo (#483)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)