### PR TITLE
Add threshold ladder support via event-grouped scan and research

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -278,6 +278,8 @@ For each PROCEED candidate:
    - **APPROVE**: The thesis survives scrutiny, signals are genuinely independent, and the opportunity is not redundant with the existing portfolio.
    - **REJECT**: The thesis has a hole the Caddie cannot close, signals are not truly independent, the position would over-concentrate the portfolio, or the timing is wrong.
 
+   **Cross-threshold consistency (when multiple PROCEED candidates share the same event):** Verify that probability estimates are monotonic — P(metric > low threshold) >= P(metric > high threshold). If probabilities are inconsistent, REJECT ALL candidates from that event and log the inconsistency. When approving multiple thresholds, verify total proposed deployment fits within the event concentration limit (max_event_exposure_pct). Approve only the highest-edge thresholds that fit.
+
 4. **Log the decision BEFORE dispatching Closer** (audit trail):
    ```bash
    gimmes position-note TICKER \

--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -26,11 +26,24 @@ You are the Caddie — the research agent in the GIMMES trading pipeline. You ta
 
    **Side awareness:** When `trading_side` is `no`, you are evaluating the NO outcome. Your true probability estimate (`--prob`) should reflect the probability of the NO outcome (i.e., 1 - P(YES)). The `--price` argument should still be the YES price as shown by `market-info` — the CLI converts it internally.
 
-1. For each candidate from the Scout's shortlist:
+1. For each candidate (or event group) from the Scout's shortlist:
    - Run `gimmes market-info TICKER` for detailed market data
    - Research the underlying event using web search
    - Gather at least 2 independent confirming signals (see definitions below)
    - Estimate the true probability of the event
+
+## Event-Grouped Research (Threshold Ladder)
+
+When the Scout's shortlist contains **multiple candidates from the same event** (same Event column), research the underlying event ONCE and apply the analysis to all thresholds:
+
+1. Run `gimmes market-info TICKER` for EACH ticker in the group to get prices
+2. Research the underlying event once (e.g., "What will April CPI MoM be?") using the Research Framework below
+3. Estimate the **probability distribution** for the underlying metric (e.g., "CPI MoM will be 0.2-0.4% with 70% confidence")
+4. Derive the true probability for EACH threshold from the distribution (e.g., P(CPI > 0.3%), P(CPI > 0.5%), P(CPI > 0.8%))
+5. Compute edge and GimmeScore independently for each threshold using the derived probability
+6. Log each threshold as a separate candidate via `gimmes log-candidate`
+
+**Consistency rule:** Probabilities across thresholds on the same event MUST be monotonic — P(metric > low threshold) >= P(metric > high threshold). For BUY NO, this means NO probability at a higher threshold >= NO probability at a lower threshold.
    - Assess settlement risk from the contract rules
 
 2. Produce a GimmeScore and structured research memo for each candidate

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -55,22 +55,31 @@ If a `log-trade` skip command fails, note the failure in the Scout output and co
 
 ## Output Format
 
-MUST produce a structured shortlist in this exact format:
+MUST produce a structured shortlist in this exact format. When multiple candidates share the same Event (shown in the scan results), group them together so Caddie can research the underlying event once:
 
 ```
 ## Scout Shortlist — [date]
 
 ### Top Candidates
 
-1. **TICKER** — Title
+#### Event: KXCPI-26APR (3 thresholds)
+1. **KXCPI-26APR-T0.8** — CPI above 0.8%
+   - Price: $X.XX | Volume 24h: N | OI: N
+   - Quick Score: N/100
+2. **KXCPI-26APR-T0.5** — CPI above 0.5%
+   - Price: $X.XX | Volume 24h: N | OI: N
+   - Quick Score: N/100
+
+#### Standalone
+3. **KXGDP-26Q1-T2.0** — GDP above 2.0%
    - Price: $X.XX | Volume 24h: N | OI: N
    - Quick Score: N/100
    - Why: [brief rationale]
 
-2. ...
-
 ### Skipped (N candidates logged)
 ```
+
+When there are no multi-threshold events, use the simpler flat format without event headers.
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -333,6 +333,7 @@ def scan(
                 qs = quick_score(m, config)
                 scored.append({
                     "ticker": m.ticker,
+                    "event_ticker": m.event_ticker,
                     "title": m.title,
                     "price": m.midpoint or m.last_price,
                     "volume_24h": m.volume_24h or m.volume,

--- a/src/gimmes/reporting/formatter.py
+++ b/src/gimmes/reporting/formatter.py
@@ -109,18 +109,31 @@ def format_positions(positions: list[dict]) -> None:  # type: ignore[type-arg]
 
 def format_scan_results(markets: list[dict], title: str = "Scan Results") -> None:  # type: ignore[type-arg]
     """Display scanned markets as a Rich table."""
+    # Count siblings per event for the annotation
+    from collections import Counter
+
+    event_counts: Counter[str] = Counter(
+        m.get("event_ticker", "") for m in markets
+        if m.get("event_ticker")
+    )
+
     table = Table(title=title)
     table.add_column("Ticker", style="cyan")
-    table.add_column("Title", max_width=40)
+    table.add_column("Event", style="dim", max_width=25)
+    table.add_column("Title", max_width=20)
     table.add_column("Price", justify="right")
     table.add_column("Vol 24h", justify="right")
     table.add_column("OI", justify="right")
     table.add_column("Score", justify="right")
 
     for m in markets:
+        evt = m.get("event_ticker", "")
+        count = event_counts.get(evt, 0)
+        evt_label = f"{evt} ({count})" if count > 1 else evt
         table.add_row(
             m.get("ticker", ""),
-            m.get("title", "")[:40],
+            evt_label,
+            m.get("title", "")[:20],
             f"${m.get('price', 0):.2f}",
             str(m.get("volume_24h", 0)),
             str(m.get("open_interest", 0)),


### PR DESCRIPTION
## Summary
- Scan output now includes `event_ticker` with sibling counts (e.g., "KXCPI-26APR (3)") so agents can identify multi-threshold events
- Caddie researches the underlying event once and derives per-threshold probabilities from a distribution estimate
- Caddie Master validates cross-threshold probability consistency (monotonic) and respects event concentration limits
- Scout groups multi-threshold candidates under event headers in the shortlist

Closes #488

## Test plan
- [x] 1035 unit tests pass
- [x] Lint clean
- [ ] Run `gimmes scan` — verify Event column shows sibling counts for multi-threshold events
- [ ] Run driving_range cycle with CPI candidates at multiple thresholds — verify Caddie researches once and scores each threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)