### PR TITLE
Add per-side strategy config for dual-side trading

### DIFF
--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -105,6 +105,15 @@ class PaperTradingConfig(BaseModel):
     )
 
 
+class SideOverrides(BaseModel):
+    """Per-side parameter overrides, used when strategy.side = 'both'."""
+
+    min_market_price: float | None = None
+    max_market_price: float | None = None
+    min_true_probability: float | None = None
+    gimme_threshold: int | None = None
+
+
 class StrategyConfig(BaseModel):
     model_config = ConfigDict(json_schema_extra={
         "section_name": "Strategy",
@@ -132,7 +141,7 @@ class StrategyConfig(BaseModel):
             "max_val": 100,
         },
     )
-    side: Literal["yes", "no"] = Field(
+    side: Literal["yes", "no", "both"] = Field(
         default="no",
         json_schema_extra={
             "display_name": "Trading Side",
@@ -141,6 +150,9 @@ class StrategyConfig(BaseModel):
                 "\n"
                 "  'yes': Buy YES contracts — profit when the event happens.\n"
                 "  'no' (default): Buy NO contracts — profit when the event does NOT happen.\n"
+                "  'both': Run both YES and NO strategies simultaneously with per-side\n"
+                "    parameters. Set overrides via strategy.yes_overrides.* and\n"
+                "    strategy.no_overrides.* (and scanner.yes_series / scanner.no_series).\n"
                 "\n"
                 "When set to 'no', the scanner and scorer flip their perspective:\n"
                 "the price range, sweet spots, and edge calculations all operate\n"
@@ -150,8 +162,14 @@ class StrategyConfig(BaseModel):
                 "interpreted from the configured side's perspective. When side='no',\n"
                 "provide your confidence that NO wins (not YES)."
             ),
-            "choices": ["yes", "no"],
+            "choices": ["yes", "no", "both"],
         },
+    )
+    yes_overrides: SideOverrides = Field(
+        default_factory=SideOverrides,
+    )
+    no_overrides: SideOverrides = Field(
+        default_factory=SideOverrides,
     )
     min_market_price: float = Field(
         default=0.55, gt=0.0, lt=1.0,
@@ -637,6 +655,8 @@ class ScannerConfig(BaseModel):
             "max_val": 50,
         },
     )
+    yes_series: list[str] | None = None
+    no_series: list[str] | None = None
 
 
 class ScoringWeights(BaseModel):
@@ -789,6 +809,60 @@ class GimmesConfig(BaseModel):
         if self.is_championship:
             return self.risk.bankroll_real
         return self.risk.bankroll_paper
+
+    @property
+    def sides_to_scan(self) -> list[Literal["yes", "no"]]:
+        """Return the list of sides to scan for candidates."""
+        if self.strategy.side == "both":
+            return ["yes", "no"]
+        return [self.strategy.side]  # type: ignore[list-item]
+
+    def effective_config_for_side(
+        self, side: Literal["yes", "no"],
+    ) -> GimmesConfig:
+        """Return a config tuned for a specific side.
+
+        When ``strategy.side`` is ``"yes"`` or ``"no"``, returns *self*
+        unchanged.  When ``"both"``, returns a copy with strategy and
+        scanner fields overridden from the per-side settings.
+        """
+        if self.strategy.side != "both":
+            return self
+
+        overrides = (
+            self.strategy.yes_overrides
+            if side == "yes"
+            else self.strategy.no_overrides
+        )
+
+        strategy_kwargs = self.strategy.model_dump()
+        strategy_kwargs["side"] = side
+        strategy_kwargs.pop("yes_overrides", None)
+        strategy_kwargs.pop("no_overrides", None)
+
+        for field_name in (
+            "min_market_price",
+            "max_market_price",
+            "min_true_probability",
+            "gimme_threshold",
+        ):
+            val = getattr(overrides, field_name)
+            if val is not None:
+                strategy_kwargs[field_name] = val
+
+        scanner_kwargs = self.scanner.model_dump()
+        side_series = (
+            self.scanner.yes_series
+            if side == "yes"
+            else self.scanner.no_series
+        )
+        if side_series is not None:
+            scanner_kwargs["series"] = side_series
+
+        return self.model_copy(update={
+            "strategy": StrategyConfig(**strategy_kwargs),
+            "scanner": ScannerConfig(**scanner_kwargs),
+        })
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,9 @@ from gimmes.config import (
     GimmesConfig,
     Mode,
     RiskConfig,
+    ScannerConfig,
+    SideOverrides,
+    StrategyConfig,
     _load_config_from_db,
     config_keys_in_db,
     load_config,
@@ -394,3 +397,94 @@ class TestMigrationV14:
             version = await run_migrations(db)
 
         assert version >= 14
+
+
+class TestSidesConfig:
+    def test_sides_to_scan_single_yes(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="yes"),
+        )
+        assert config.sides_to_scan == ["yes"]
+
+    def test_sides_to_scan_single_no(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="no"),
+        )
+        assert config.sides_to_scan == ["no"]
+
+    def test_sides_to_scan_both(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="both"),
+        )
+        assert config.sides_to_scan == ["yes", "no"]
+
+    def test_effective_config_single_side_returns_self(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="no"),
+        )
+        assert config.effective_config_for_side("no") is config
+
+    def test_effective_config_both_applies_yes_overrides(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(
+                side="both",
+                min_market_price=0.40,
+                yes_overrides=SideOverrides(
+                    min_market_price=0.70,
+                    min_true_probability=0.85,
+                ),
+            ),
+        )
+        yes_cfg = config.effective_config_for_side("yes")
+        assert yes_cfg.strategy.side == "yes"
+        assert yes_cfg.strategy.min_market_price == 0.70
+        assert yes_cfg.strategy.min_true_probability == 0.85
+        assert yes_cfg.strategy.max_market_price == config.strategy.max_market_price
+
+    def test_effective_config_both_applies_no_overrides(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(
+                side="both",
+                min_market_price=0.55,
+                no_overrides=SideOverrides(
+                    min_market_price=0.40,
+                    gimme_threshold=65,
+                ),
+            ),
+        )
+        no_cfg = config.effective_config_for_side("no")
+        assert no_cfg.strategy.side == "no"
+        assert no_cfg.strategy.min_market_price == 0.40
+        assert no_cfg.strategy.gimme_threshold == 65
+
+    def test_effective_config_both_applies_side_series(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="both"),
+            scanner=ScannerConfig(
+                series=["KXCPI", "KXGDP"],
+                yes_series=["KXINX", "KXNASDAQ100"],
+                no_series=["KXCPI", "KXGDP", "KXPAYROLLS"],
+            ),
+        )
+        yes_cfg = config.effective_config_for_side("yes")
+        assert yes_cfg.scanner.series == ["KXINX", "KXNASDAQ100"]
+
+        no_cfg = config.effective_config_for_side("no")
+        assert no_cfg.scanner.series == ["KXCPI", "KXGDP", "KXPAYROLLS"]
+
+    def test_effective_config_preserves_other_sections(self) -> None:
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="both"),
+            risk=RiskConfig(bankroll_paper=8000.0),
+        )
+        yes_cfg = config.effective_config_for_side("yes")
+        assert yes_cfg.risk.bankroll_paper == 8000.0
+        assert yes_cfg.mode == Mode.DRIVING_RANGE


### PR DESCRIPTION
## Summary
- Extended `strategy.side` to accept `"both"` for dual-side trading
- Added `SideOverrides` model with per-side `min_market_price`, `max_market_price`, `min_true_probability`, `gimme_threshold`
- Added `yes_series`/`no_series` to `ScannerConfig` for per-side series watchlists
- Added `GimmesConfig.effective_config_for_side(side)` that returns a side-tuned config copy when `side="both"`, or self unchanged for single-side
- Added `GimmesConfig.sides_to_scan` property returning `["yes", "no"]` for both, or single-item list
- 8 new tests covering all override scenarios

Closes #469

## Test plan
- [x] 1043 unit tests pass
- [x] Lint clean
- [x] Single-side mode (`side="yes"` or `side="no"`) returns self unchanged
- [x] Both mode applies yes/no overrides correctly
- [x] Per-side series override works
- [x] Non-strategy config sections preserved in copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)