### PR TITLE
Add YES-side equity index series defaults for dual-side trading

### DIFF
--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -66,6 +66,13 @@ DEFAULT_SERIES: list[str] = [
     t for tickers in SERIES_CATEGORIES.values() for t in tickers
 ]
 
+# YES-side equity index series — backtesting shows BUY YES is only
+# profitable on equity index contracts at high prices (>= 70c).
+YES_SIDE_SERIES: list[str] = [
+    "KXINX", "KXINXW", "KXINXM", "KXINXAB", "KXINXZ",
+    "KXNASDAQ100", "KXNASDAQ100W", "KXNASDAQ100M", "KXNASDAQ100Z",
+]
+
 
 class Mode(StrEnum):
     DRIVING_RANGE = "driving_range"
@@ -655,7 +662,9 @@ class ScannerConfig(BaseModel):
             "max_val": 50,
         },
     )
-    yes_series: list[str] | None = None
+    yes_series: list[str] = Field(
+        default_factory=lambda: list(YES_SIDE_SERIES),
+    )
     no_series: list[str] | None = None
 
 


### PR DESCRIPTION
## Summary
- Added `YES_SIDE_SERIES` constant with 9 equity index series (KXINX, KXINXW, KXINXM, KXINXAB, KXINXZ, KXNASDAQ100, KXNASDAQ100W, KXNASDAQ100M, KXNASDAQ100Z)
- Set as default for `scanner.yes_series` so dual-side mode uses equity indices for YES and the full macro watchlist for NO
- Backtesting shows BUY YES is only profitable on equity index contracts at >= 70c (90% WR)

Closes #470

## Test plan
- [x] 1043 unit tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)