### PR TITLE
Add dual-side scanning support (BUY YES + BUY NO simultaneously)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -274,8 +274,6 @@ def scan(
 
         logger = logging.getLogger("gimmes.cli")
 
-        series_tickers = series or config.scanner.series
-
         # Exclude tickers with open positions
         exclude_tickers: set[str] = set()
         try:
@@ -291,58 +289,83 @@ def scan(
         async with KalshiClient(config) as client:
             console.print("[cyan]Scanning markets...[/cyan]")
 
-            if series_tickers and not all_markets:
-                # Fetch markets only for curated series — fast and focused
-                markets = []
-                for st in series_tickers:
-                    batch = await list_all_markets(client, series_ticker=st)
-                    markets.extend(batch)
-                console.print(f"Fetched {len(markets)} markets from {len(series_tickers)} series")
-            else:
-                markets = await list_all_markets(client)
-                console.print(f"Fetched {len(markets)} markets (all)")
+            all_scored: list[dict] = []  # type: ignore[type-arg]
+            seen_tickers: set[str] = set()
 
-            candidates = filter_markets(markets, config, exclude_tickers=exclude_tickers)
-
-            # Staleness filtering — skip markets with no trading activity
-            staleness_threshold = config.scanner.staleness_cycles
-            if staleness_threshold > 0:
-                from gimmes.strategy.staleness import (
-                    check_staleness,
-                    load_staleness,
-                    save_staleness,
+            for scan_side in config.sides_to_scan:
+                side_cfg = config.effective_config_for_side(scan_side)
+                side_series = (
+                    series
+                    or side_cfg.scanner.series
                 )
 
-                staleness_path = GIMMES_HOME / "scan_staleness.json"
-                staleness_data = load_staleness(staleness_path)
-                candidates, stale_skipped, staleness_data = check_staleness(
-                    candidates, staleness_data,
-                    threshold=staleness_threshold,
+                if side_series and not all_markets:
+                    markets = []
+                    for st in side_series:
+                        batch = await list_all_markets(
+                            client, series_ticker=st,
+                        )
+                        markets.extend(batch)
+                else:
+                    markets = await list_all_markets(client)
+
+                candidates = filter_markets(
+                    markets, side_cfg,
+                    exclude_tickers=exclude_tickers,
                 )
-                save_staleness(staleness_data, staleness_path)
-                if stale_skipped:
-                    console.print(
-                        f"[dim]Skipped {len(stale_skipped)} stale"
-                        f" market(s)[/dim]"
+
+                # Staleness filtering
+                staleness_threshold = side_cfg.scanner.staleness_cycles
+                if staleness_threshold > 0:
+                    from gimmes.strategy.staleness import (
+                        check_staleness,
+                        load_staleness,
+                        save_staleness,
                     )
 
-            console.print(f"Filtered to {len(candidates)} candidates")
+                    staleness_path = GIMMES_HOME / "scan_staleness.json"
+                    staleness_data = load_staleness(staleness_path)
+                    candidates, stale_skipped, staleness_data = (
+                        check_staleness(
+                            candidates, staleness_data,
+                            threshold=staleness_threshold,
+                        )
+                    )
+                    save_staleness(staleness_data, staleness_path)
+                    if stale_skipped:
+                        console.print(
+                            f"[dim]Skipped {len(stale_skipped)}"
+                            f" stale market(s)[/dim]"
+                        )
 
-            scored = []
-            for m in candidates:
-                qs = quick_score(m, config)
-                scored.append({
-                    "ticker": m.ticker,
-                    "event_ticker": m.event_ticker,
-                    "title": m.title,
-                    "price": m.midpoint or m.last_price,
-                    "volume_24h": m.volume_24h or m.volume,
-                    "open_interest": m.open_interest,
-                    "score": qs,
-                })
+                side_label = (
+                    f" [{scan_side.upper()}]"
+                    if config.strategy.side == "both"
+                    else ""
+                )
+                console.print(
+                    f"Fetched {len(markets)} markets,"
+                    f" {len(candidates)} candidates{side_label}"
+                )
 
-            scored.sort(key=lambda r: r["score"], reverse=True)
-            format_scan_results(scored[:limit])
+                for m in candidates:
+                    if m.ticker in seen_tickers:
+                        continue
+                    seen_tickers.add(m.ticker)
+                    qs = quick_score(m, side_cfg)
+                    all_scored.append({
+                        "ticker": m.ticker,
+                        "event_ticker": m.event_ticker,
+                        "title": m.title,
+                        "price": m.midpoint or m.last_price,
+                        "volume_24h": m.volume_24h or m.volume,
+                        "open_interest": m.open_interest,
+                        "score": qs,
+                        "side": scan_side,
+                    })
+
+            all_scored.sort(key=lambda r: r["score"], reverse=True)
+            format_scan_results(all_scored[:limit])
 
     _run(_scan())
 

--- a/src/gimmes/reporting/formatter.py
+++ b/src/gimmes/reporting/formatter.py
@@ -117,8 +117,12 @@ def format_scan_results(markets: list[dict], title: str = "Scan Results") -> Non
         if m.get("event_ticker")
     )
 
+    has_side = any(m.get("side") for m in markets)
+
     table = Table(title=title)
     table.add_column("Ticker", style="cyan")
+    if has_side:
+        table.add_column("Side", style="bold")
     table.add_column("Event", style="dim", max_width=25)
     table.add_column("Title", max_width=20)
     table.add_column("Price", justify="right")
@@ -130,15 +134,18 @@ def format_scan_results(markets: list[dict], title: str = "Scan Results") -> Non
         evt = m.get("event_ticker", "")
         count = event_counts.get(evt, 0)
         evt_label = f"{evt} ({count})" if count > 1 else evt
-        table.add_row(
-            m.get("ticker", ""),
+        row: list[str] = [m.get("ticker", "")]
+        if has_side:
+            row.append(m.get("side", "").upper())
+        row.extend([
             evt_label,
             m.get("title", "")[:20],
             f"${m.get('price', 0):.2f}",
             str(m.get("volume_24h", 0)),
             str(m.get("open_interest", 0)),
             f"{m.get('score', 0):.0f}",
-        )
+        ])
+        table.add_row(*row)
 
     console.print(table)
 


### PR DESCRIPTION
## Summary
- Scanner runs per-side passes when `strategy.side='both'`, using `effective_config_for_side()` from #469
- Each side gets its own price range, series, threshold, and probability settings
- YES defaults to equity index series (KXINX, KXNASDAQ100 families from #470)
- NO uses the full macro watchlist
- Candidates deduplicated across sides, tagged with scan side
- Formatter shows Side column when both sides are present
- Single-side mode (`side="yes"` or `side="no"`) behavior unchanged

Closes #452

## Test plan
- [x] 1043 unit tests pass
- [x] Lint clean
- [ ] `gimmes config set strategy.side both` then `gimmes scan` — verify YES and NO candidates appear with Side column
- [ ] Verify YES candidates use equity index series, NO candidates use macro series

🤖 Generated with [Claude Code](https://claude.com/claude-code)