### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] - 2026-04-10
+
+### Fixed
+- Backtest engine now supports dual-side mode — runs per-side filter, score, and trade passes with correct price perspective instead of passing `side="both"` to the scanner (#501)
+- Backtest series filter uses ticker prefix matching since `series_ticker` is empty on settled markets from the live API; also unions all per-side series for the initial fetch (#502)
+
 ## [0.5.0] - 2026-04-10
 
 ### Added
@@ -183,6 +189,7 @@ on Kalshi prediction markets using a team of Claude Code agents.
 - Self-update command with stale-code protection and tag-based version
   checks
 
+[0.5.1]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.5.1
 [0.5.0]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.5.0
 [0.4.2]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.4.2
 [0.4.1]: https://github.com/allan-mobley-jr/gimmes/releases/tag/v0.4.1

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ gimmes errors            # View error logs (--severity, --category, --unresolved
 ### Strategy
 ```bash
 gimmes backtest --from D --to D  # Backtest strategy on historical markets (--balance, --edge, --json)
+                                 # Supports dual-side mode — runs per-side passes when strategy.side=both
 gimmes lesson                    # Run strategy analysis and recommendations
 gimmes recommendations           # View past strategy recommendations
 gimmes tune                      # Apply pending strategy recommendations
@@ -483,6 +484,8 @@ Hard limits applied regardless of sizing mode:
 - 80% per-position take-profit trigger
 - 15% max exposure per event, 30% max per series
 - No positions in markets with ambiguous settlement language
+
+In dual-side mode, these limits apply independently per side — each side's positions are sized and validated using the side-specific config from `effective_config_for_side()`. Concentration limits aggregate across both sides.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gimmes"
-version = "0.5.0"
+version = "0.5.1"
 description = "Autonomous Claude Code agent system for trading Kalshi prediction markets"
 readme = "README.md"
 license = "MIT"

--- a/src/gimmes/__init__.py
+++ b/src/gimmes/__init__.py
@@ -1,3 +1,3 @@
 """GIMMES — We only play the gimmes."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
## Release v0.5.1

### Fixed
- Backtest engine now supports dual-side mode — runs per-side filter, score, and trade passes with correct price perspective (#501)
- Backtest series filter uses ticker prefix matching since series_ticker is empty on settled markets; unions all per-side series for fetch (#502)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)