### PR TITLE
Add exponential backoff on transient cycle failures

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3735,6 +3735,11 @@ def _autonomous_loop(
                     )
                     session_status = "crashed"
                     break
+                backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
+                console.print(
+                    f"[dim]Backoff: retrying in {backoff}s...[/dim]"
+                )
+                time.sleep(backoff)
                 continue
 
             if returncode != 0:
@@ -3754,6 +3759,12 @@ def _autonomous_loop(
                     )
                     session_status = "crashed"
                     break
+                backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
+                console.print(
+                    f"[dim]Backoff: retrying in {backoff}s...[/dim]"
+                )
+                time.sleep(backoff)
+                continue
             else:
                 consecutive_failures = 0
 


### PR DESCRIPTION
## Summary
- Replace fixed sleep with exponential backoff (30/60/120/240s) on consecutive failures
- Applies to both timeout and non-zero exit failures
- Uses `continue` to skip normal post_sleep, so successful cycles are unchanged
- Circuit breaker still trips at 5 consecutive failures

Closes #505

## Test plan
- [x] Lint clean
- [ ] Simulate a transient failure — verify 30s retry instead of full interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)