### PR TITLE
Add gimmes monitor command for local health checks

### DIFF
--- a/bin/monitor.sh
+++ b/bin/monitor.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# GIMMES Driving Range Monitor
+# Runs periodic health checks and sends iMessage alerts for problems.
+#
+# Usage (managed by `gimmes monitor`):
+#   monitor.sh [--quiet]
+
+set -uo pipefail
+
+GIMMES_HOME="${GIMMES_HOME:-$HOME/.gimmes}"
+REPO="${GIMMES_HOME}/repo"
+PYTHON="${REPO}/.venv/bin/python"
+GIMMES="${PYTHON} -m gimmes"
+LOG_DIR="${GIMMES_HOME}/logs"
+MONITOR_LOG="${LOG_DIR}/monitor.log"
+CONFIG_FILE="${GIMMES_HOME}/monitor.conf"
+NOTIFY_PHONE="+17706162336"
+
+QUIET=false
+[[ "${1:-}" == "--quiet" ]] && QUIET=true
+if [[ -f "${CONFIG_FILE}" ]] && grep -q "quiet" "${CONFIG_FILE}" 2>/dev/null; then
+    QUIET=true
+fi
+
+mkdir -p "$LOG_DIR"
+
+ts() { date "+%Y-%m-%d %H:%M:%S"; }
+log() { echo "$(ts) $1" >> "$MONITOR_LOG"; }
+
+alert() {
+    local msg="$1"
+    log "ALERT: $msg"
+    if [[ "$QUIET" == "false" ]]; then
+        osascript -e "tell application \"Messages\" to send \"GIMMES ALERT: $msg\" to participant \"$NOTIFY_PHONE\"" 2>/dev/null || true
+    fi
+}
+
+issues=()
+
+# 1. Risk check (uses exit code — non-zero means limit breached)
+if ! $GIMMES risk-check > /dev/null 2>&1; then
+    issues+=("Risk check FAILED — limit may be breached")
+fi
+
+# 2. Check for unresolved errors
+error_output=$($GIMMES errors --unresolved --summary 2>&1) || true
+if echo "$error_output" | grep -qE "[5-9][0-9]+ unresolved|[0-9]{2,} unresolved"; then
+    issues+=("Many unresolved errors: $error_output")
+fi
+
+# 3. Check latest cycle for failures
+latest_log=$(ls -t "$LOG_DIR"/cycle-*.json 2>/dev/null | head -1)
+if [[ -n "$latest_log" ]]; then
+    # Check if last 3 cycles all failed
+    fail_count=0
+    for log_file in $(ls -t "$LOG_DIR"/cycle-*.json 2>/dev/null | head -3); do
+        if grep -q "hit your limit\|crashed\|circuit.breaker\|exited with an error" "$log_file" 2>/dev/null; then
+            ((fail_count++)) || true
+        fi
+    done
+    if [[ "$fail_count" -ge 3 ]]; then
+        issues+=("Last $fail_count cycles failed")
+    fi
+
+    # Check cycle age — alert if no cycle in >2 hours
+    if [[ "$(uname)" == "Darwin" ]]; then
+        log_age=$(( $(date +%s) - $(stat -f %m "$latest_log") ))
+    else
+        log_age=$(( $(date +%s) - $(stat -c %Y "$latest_log") ))
+    fi
+    hours_ago=$((log_age / 3600))
+    if [[ "$log_age" -gt 7200 ]]; then
+        issues+=("No cycle in ${hours_ago}h — driving range may have stopped")
+    fi
+fi
+
+# --- Report ---
+
+if [[ ${#issues[@]} -eq 0 ]]; then
+    log "OK: All checks passed"
+    exit 0
+else
+    summary=""
+    for issue in "${issues[@]}"; do
+        summary="${summary}- ${issue}\n"
+    done
+    alert "$(echo -e "$summary")"
+
+    # Create GitHub issue for critical problems (>= 3 issues)
+    if [[ ${#issues[@]} -ge 3 ]]; then
+        cd "$REPO" 2>/dev/null || true
+        existing=$(gh issue list --state open --search "Monitor alert" --limit 1 --json number --jq '.[0].number' 2>/dev/null || echo "")
+        if [[ -z "$existing" || "$existing" == "null" ]]; then
+            gh issue create \
+                --title "Monitor alert: ${#issues[@]} issues detected" \
+                --body "$(echo -e "## Monitor Alert — $(ts)\n\n$(echo -e "$summary")\n\nFiled automatically by \`gimmes monitor\`.")" \
+                --label "bug" 2>/dev/null || true
+        fi
+    fi
+
+    exit 1
+fi

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3833,5 +3833,130 @@ def championship(
                      monitor_interval=monitor_interval, no_dashboard=no_dashboard)
 
 
+@app.command(name="monitor", rich_help_panel="Diagnostics")
+def monitor_cmd(
+    action: str = typer.Argument(
+        "status",
+        help="on | off | status | run | quiet | notify",
+    ),
+) -> None:
+    """Manage the hourly driving range health monitor.
+
+    \b
+    Actions:
+      on      Enable the cron job (weekday trade window hours)
+      off     Disable the cron job
+      status  Show if monitor is active
+      run     Run a single check now
+      quiet   Disable iMessage alerts (log only)
+      notify  Re-enable iMessage alerts
+    """
+    import subprocess
+
+    project_root = Path(__file__).resolve().parent.parent.parent
+    script = project_root / "bin" / "monitor.sh"
+    config_file = GIMMES_HOME / "monitor.conf"
+    cron_tag = "# GIMMES_MONITOR"
+
+    # Cron schedule: every hour 11 AM - 6 PM PT (6 PM - 1 AM UTC) weekdays
+    cron_line = (
+        f"0 18,19,20,21,22,23,0,1 * * 1-5"
+        f" {script} {cron_tag}"
+    )
+
+    if action == "on":
+        # Remove existing entry, add fresh
+        try:
+            result = subprocess.run(
+                ["crontab", "-l"], capture_output=True, text=True,
+            )
+            existing = result.stdout if result.returncode == 0 else ""
+        except FileNotFoundError:
+            existing = ""
+
+        lines = [
+            l for l in existing.splitlines()
+            if cron_tag not in l
+        ]
+        lines.append(cron_line)
+        subprocess.run(
+            ["crontab", "-"],
+            input="\n".join(lines) + "\n",
+            text=True, check=True,
+        )
+        console.print("[green]Monitor enabled.[/green] Runs hourly during weekday trade windows.")
+        console.print(f"[dim]Script: {script}[/dim]")
+
+    elif action == "off":
+        try:
+            result = subprocess.run(
+                ["crontab", "-l"], capture_output=True, text=True,
+            )
+            if result.returncode != 0:
+                console.print("[yellow]No crontab found.[/yellow]")
+                return
+            lines = [
+                l for l in result.stdout.splitlines()
+                if cron_tag not in l
+            ]
+            subprocess.run(
+                ["crontab", "-"],
+                input="\n".join(lines) + "\n",
+                text=True, check=True,
+            )
+        except FileNotFoundError:
+            pass
+        console.print("[yellow]Monitor disabled.[/yellow]")
+
+    elif action == "status":
+        try:
+            result = subprocess.run(
+                ["crontab", "-l"], capture_output=True, text=True,
+            )
+            active = (
+                result.returncode == 0
+                and cron_tag in result.stdout
+            )
+        except FileNotFoundError:
+            active = False
+
+        quiet = config_file.exists() and "quiet" in config_file.read_text()
+
+        if active:
+            mode = "quiet (log only)" if quiet else "notify (iMessage alerts)"
+            console.print(f"[green]Monitor is ON[/green] — {mode}")
+        else:
+            console.print("[yellow]Monitor is OFF[/yellow]")
+
+    elif action == "run":
+        quiet_flag = (
+            ["--quiet"]
+            if config_file.exists() and "quiet" in config_file.read_text()
+            else []
+        )
+        result = subprocess.run(
+            [str(script)] + quiet_flag, check=False,
+        )
+        if result.returncode == 0:
+            console.print("[green]All checks passed.[/green]")
+        else:
+            console.print("[yellow]Issues found — check monitor log.[/yellow]")
+
+    elif action == "quiet":
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text("quiet\n")
+        console.print("[yellow]iMessage alerts disabled.[/yellow] Monitor will log only.")
+
+    elif action == "notify":
+        if config_file.exists():
+            config_file.write_text("notify\n")
+        console.print("[green]iMessage alerts enabled.[/green]")
+
+    else:
+        console.print(f"[red]Unknown action: {action}[/red]")
+        console.print("Use: on | off | status | run | quiet | notify")
+        raise typer.Exit(1)
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary
- New `gimmes monitor` CLI command to manage a local cron-based health monitor
- Checks risk limits, error logs, consecutive cycle failures, and cycle age
- Sends iMessage alerts for problems, creates GitHub issues for critical failures
- Controls: `on|off|status|run|quiet|notify`
- Runs hourly during weekday trade windows (11 AM - 6 PM PT)

## Test plan
- [x] `gimmes monitor run` executes and reports correctly
- [x] `gimmes monitor on` adds crontab entry
- [x] `gimmes monitor off` removes crontab entry
- [x] `gimmes monitor quiet` silences iMessage alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)