### PR TITLE
Display per-side config values in Clubhouse for dual-side mode

### DIFF
--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -592,6 +592,22 @@ async def get_recommendations_data(db_path: Path, limit: int = 10) -> list[Recom
 async def get_config_data() -> ConfigResponse:
     """Get current configuration (read-only)."""
     config = _config()
+
+    yes_strategy = None
+    no_strategy = None
+    if config.strategy.side == "both":
+        drop = {"yes_overrides", "no_overrides", "side"}
+        yes_cfg = config.effective_config_for_side("yes")
+        no_cfg = config.effective_config_for_side("no")
+        yes_strategy = {
+            k: v for k, v in yes_cfg.strategy.model_dump().items()
+            if k not in drop
+        }
+        no_strategy = {
+            k: v for k, v in no_cfg.strategy.model_dump().items()
+            if k not in drop
+        }
+
     return ConfigResponse(
         mode=config.mode.value,
         strategy=config.strategy.model_dump(),
@@ -601,6 +617,8 @@ async def get_config_data() -> ConfigResponse:
         scanner=config.scanner.model_dump(),
         scoring=config.scoring.model_dump(),
         paper=config.paper.model_dump(),
+        yes_strategy=yes_strategy,
+        no_strategy=no_strategy,
     )
 
 

--- a/src/gimmes/clubhouse/models.py
+++ b/src/gimmes/clubhouse/models.py
@@ -149,3 +149,5 @@ class ConfigResponse(BaseModel):
     scanner: dict = {}
     scoring: dict = {}
     paper: dict = {}
+    yes_strategy: dict | None = None
+    no_strategy: dict | None = None

--- a/src/gimmes/templates/clubhouse.html
+++ b/src/gimmes/templates/clubhouse.html
@@ -1383,6 +1383,23 @@
             container.innerHTML = html;
         }
 
+        function renderConfigDl(data, skipKeys) {
+            let html = '';
+            Object.keys(data).forEach(function(key) {
+                if (skipKeys && skipKeys.includes(key)) return;
+                const val = data[key];
+                if (val !== null && typeof val === 'object' && !Array.isArray(val)) return;
+                const displayVal = Array.isArray(val)
+                    ? '<span title="' + escapeHtml(val.join(', ')).replace(/"/g, '&quot;') + '">' + val.length + ' items</span>'
+                    : escapeHtml(String(val));
+                html += '<div class="flex justify-between gap-2">'
+                    + '<dt class="text-slate-500 truncate">' + escapeHtml(key) + '</dt>'
+                    + '<dd class="text-slate-300 font-mono text-right shrink-0">' + displayVal + '</dd>'
+                    + '</div>';
+            });
+            return html;
+        }
+
         function updateConfig(config) {
             const sectionMap = {
                 strategy: 'config-strategy',
@@ -1399,18 +1416,19 @@
                     el.innerHTML = '<div class="text-slate-500 text-xs">--</div>';
                     return;
                 }
-                let html = '';
-                Object.keys(data).forEach(function(key) {
-                    const val = data[key];
-                    const displayVal = Array.isArray(val)
-                        ? '<span title="' + escapeHtml(val.join(', ')).replace(/"/g, '&quot;') + '">' + val.length + ' items</span>'
-                        : escapeHtml(String(val));
-                    html += '<div class="flex justify-between gap-2">'
-                        + '<dt class="text-slate-500 truncate">' + escapeHtml(key) + '</dt>'
-                        + '<dd class="text-slate-300 font-mono text-right shrink-0">' + displayVal + '</dd>'
-                        + '</div>';
-                });
-                el.innerHTML = html;
+
+                if (section === 'strategy' && config.yes_strategy && config.no_strategy) {
+                    let html = '<div class="flex justify-between gap-2">'
+                        + '<dt class="text-slate-500">side</dt>'
+                        + '<dd class="text-slate-300 font-mono">both</dd></div>';
+                    html += '<div class="mt-2 mb-1 text-xs font-semibold text-green-400">YES Side</div>';
+                    html += renderConfigDl(config.yes_strategy);
+                    html += '<div class="mt-2 mb-1 text-xs font-semibold text-red-400">NO Side</div>';
+                    html += renderConfigDl(config.no_strategy);
+                    el.innerHTML = html;
+                } else {
+                    el.innerHTML = renderConfigDl(data, ['yes_overrides', 'no_overrides']);
+                }
             });
         }
 


### PR DESCRIPTION
## Summary
- When `side=both`, Clubhouse Configuration panel shows effective YES and NO side values with colored headers instead of raw override objects
- Backend computes merged configs via `effective_config_for_side()`
- Skips nested override objects from display in single-side mode

Closes #504

## Test plan
- [x] 54 clubhouse tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)