### PR TITLE
Remove non-gimme categories from default scanner watchlist

### DIFF
--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -66,6 +66,22 @@ DEFAULT_SERIES: list[str] = [
     t for tickers in SERIES_CATEGORIES.values() for t in tickers
 ]
 
+# Backtested gimme series — categories with proven structural edge.
+# Excludes series with negative P&L in backtesting:
+#   KXCPI (MoM headline), KXPCECORE, KXU3, KXUE (international),
+#   KXTNOTEW, KXJOBLESSCLAIMS (borderline/high variance),
+#   Housing, Fed, Politics, commodities, misc econ.
+GIMME_SERIES: list[str] = [
+    # Inflation (YoY + Core — NOT headline MoM)
+    "KXCPICORE", "KXCPIYOY", "KXCPICOREYOY",
+    # Employment (payrolls + ADP — NOT jobless claims or unemployment rate)
+    "KXPAYROLLS", "KXADP",
+    # GDP
+    "KXGDP",
+    # Equity indices (daily range — NOT up/down)
+    "KXINX", "KXNASDAQ100",
+]
+
 # YES-side equity index series — backtesting shows BUY YES is only
 # profitable on equity index contracts at high prices (>= 70c).
 YES_SIDE_SERIES: list[str] = [
@@ -649,16 +665,16 @@ class ScannerConfig(BaseModel):
         },
     )
     series: list[str] = Field(
-        default_factory=lambda: list(DEFAULT_SERIES),
+        default_factory=lambda: list(GIMME_SERIES),
         json_schema_extra={
             "display_name": "Series Watchlist",
             "description": (
                 "The list of Kalshi series tickers to scan. A 'series' is a group of\n"
                 "related markets (e.g. KXCPI covers all CPI-related contracts).\n"
                 "\n"
-                "By default, the scanner only looks at markets in these series rather\n"
-                "than scanning ALL of Kalshi. This keeps scans fast and focused on\n"
-                "categories where the system has informational edge.\n"
+                "By default, the scanner uses backtested gimme series — categories\n"
+                "with proven structural edge. Use 'gimmes discover <Category>' to\n"
+                "find additional series.\n"
                 "\n"
                 "Use 'gimmes discover <Category>' to find new series tickers.\n"
                 "Categories: Economics, Politics, Financials, etc.\n"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,7 @@ import pytest
 
 from gimmes.config import (
     DEFAULT_SERIES,
+    GIMME_SERIES,
     SERIES_CATEGORIES,
     GimmesConfig,
     Mode,
@@ -205,13 +206,13 @@ class TestLoadConfig:
 class TestDefaultSeries:
     def test_series_defaults_to_curated_list_when_no_db(self, tmp_path):
         config = load_config(db_path=tmp_path / "nonexistent.db")
-        assert config.scanner.series == DEFAULT_SERIES
+        assert config.scanner.series == GIMME_SERIES
 
     def test_series_defaults_to_curated_list_with_empty_db(self, tmp_path):
         db = tmp_path / "test.db"
         _create_config_db(db)
         config = load_config(db_path=db)
-        assert config.scanner.series == DEFAULT_SERIES
+        assert config.scanner.series == GIMME_SERIES
 
     def test_explicit_series_overrides_default(self, tmp_path):
         db = tmp_path / "test.db"


### PR DESCRIPTION
## Summary
- Default scanner series now uses `GIMME_SERIES` (8 backtested profitable series) instead of `DEFAULT_SERIES` (51 series)
- Removes categories with negative backtested P&L: headline CPI MoM, PCE Core, unemployment rate, international UE, treasury notes, jobless claims, housing, Fed, politics, commodities
- Keeps: CPI YoY/Core, payrolls, ADP, GDP, equity indices
- Users can restore any series via `gimmes config set scanner.series`

Closes #508

## Test plan
- [x] 112 config/scanner/wizard tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)