### PR TITLE
Use category base rates as probability floor for position sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ uv.lock
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/worktrees/

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -18,7 +18,7 @@ from gimmes.risk.limits import (
     compute_exposure_for_group,
 )
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, fee_for_order
-from gimmes.strategy.kelly import position_size
+from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 from gimmes.strategy.scanner import effective_price, filter_markets
 from gimmes.strategy.scorer import quick_score
 
@@ -479,6 +479,7 @@ async def run_backtest(
                 continue
             eff_price = effective_price(raw_price, scan_side)
             true_prob = min(eff_price + config.assumed_edge, 0.99)
+            true_prob = apply_base_rate_floor(true_prob, orig_m.ticker)
             count = position_size(
                 config.starting_balance,
                 eff_price,

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -479,7 +479,7 @@ async def run_backtest(
                 continue
             eff_price = effective_price(raw_price, scan_side)
             true_prob = min(eff_price + config.assumed_edge, 0.99)
-            true_prob = apply_base_rate_floor(true_prob, orig_m.ticker)
+            true_prob = apply_base_rate_floor(true_prob, orig_m.ticker, side=scan_side)
             count = position_size(
                 config.starting_balance,
                 eff_price,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -418,7 +418,7 @@ def size(
         from gimmes.reporting.formatter import format_kv_table
         from gimmes.strategy.fee_cache import get_multipliers
         from gimmes.strategy.fees import edge_after_fees, fee_for_order
-        from gimmes.strategy.kelly import kelly_fraction, position_size
+        from gimmes.strategy.kelly import apply_base_rate_floor, kelly_fraction, position_size
 
         async with trading_context(config) as (client, broker, _db):
             market = await get_market(client, ticker)
@@ -436,6 +436,7 @@ def size(
             fees = get_multipliers(market.series_ticker)
 
             bankroll = config.bankroll
+            probability = apply_base_rate_floor(probability, ticker)
             kf = kelly_fraction(
                 price, probability,
                 fraction=config.sizing.kelly_fraction, fees=fees,
@@ -481,7 +482,7 @@ def validate(
         from gimmes.risk.validator import validate_trade
         from gimmes.store.queries import get_daily_pnl, get_deployed_cost_basis
         from gimmes.strategy.fee_cache import get_multipliers
-        from gimmes.strategy.kelly import position_size
+        from gimmes.strategy.kelly import apply_base_rate_floor, position_size
         from gimmes.strategy.scanner import effective_price
 
         async with trading_context(config) as (client, broker, db):
@@ -502,6 +503,7 @@ def validate(
                 await sync_positions(db, positions)
 
             fees = get_multipliers(market.series_ticker)
+            probability = apply_base_rate_floor(probability, ticker)
             if dollars <= 0:
                 contracts = position_size(
                     bankroll, price, probability,
@@ -631,7 +633,7 @@ def order(
         from gimmes.store.queries import get_daily_pnl, get_deployed_cost_basis, insert_error
         from gimmes.strategy.fee_cache import get_multipliers
         from gimmes.strategy.fees import fee_for_order
-        from gimmes.strategy.kelly import position_size
+        from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 
         logger = logging.getLogger("gimmes.cli")
 
@@ -660,6 +662,7 @@ def order(
 
             bankroll = config.bankroll
             if is_buy and count <= 0 and probability is not None:
+                probability = apply_base_rate_floor(probability, ticker)
                 final_count = position_size(
                     bankroll, eff_price, probability,
                     fraction=config.sizing.kelly_fraction,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -436,7 +436,7 @@ def size(
             fees = get_multipliers(market.series_ticker)
 
             bankroll = config.bankroll
-            probability = apply_base_rate_floor(probability, ticker)
+            probability = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
             kf = kelly_fraction(
                 price, probability,
                 fraction=config.sizing.kelly_fraction, fees=fees,
@@ -503,7 +503,7 @@ def validate(
                 await sync_positions(db, positions)
 
             fees = get_multipliers(market.series_ticker)
-            probability = apply_base_rate_floor(probability, ticker)
+            probability = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
             if dollars <= 0:
                 contracts = position_size(
                     bankroll, price, probability,
@@ -662,7 +662,7 @@ def order(
 
             bankroll = config.bankroll
             if is_buy and count <= 0 and probability is not None:
-                probability = apply_base_rate_floor(probability, ticker)
+                probability = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
                 final_count = position_size(
                     bankroll, eff_price, probability,
                     fraction=config.sizing.kelly_fraction,

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -90,6 +90,23 @@ YES_SIDE_SERIES: list[str] = [
 ]
 
 
+# Backtested NO-side win rates by series prefix.  Used as a probability
+# floor for position sizing — if the LLM estimate is lower than the base
+# rate, the base rate is used instead.  Prevents undersizing when the
+# structural edge is known from backtest data.
+CATEGORY_BASE_RATES: dict[str, float] = {
+    "KXCPIYOY": 0.90,
+    "KXCPICOREYOY": 0.90,
+    "KXCPICORE": 0.85,
+    "KXPAYROLLS": 0.85,
+    "KXADP": 0.85,
+    "KXGDP": 0.85,
+    "KXINX": 0.80,
+    "KXNASDAQ100": 0.80,
+    "KXISMPMI": 0.80,
+}
+
+
 class Mode(StrEnum):
     DRIVING_RANGE = "driving_range"
     CHAMPIONSHIP = "championship"

--- a/src/gimmes/strategy/kelly.py
+++ b/src/gimmes/strategy/kelly.py
@@ -11,27 +11,34 @@ from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, fee_fo
 def apply_base_rate_floor(
     true_probability: float,
     ticker: str,
+    *,
+    side: str = "no",
     base_rates: dict[str, float] | None = None,
 ) -> float:
-    """Apply category base rate as a floor to the probability estimate.
+    """Apply category base rate as a floor to a NO-side probability estimate.
 
-    Matches the ticker against series prefixes in *base_rates* (longest
-    prefix wins).  If the base rate exceeds *true_probability*, returns
-    the base rate.  Otherwise returns *true_probability* unchanged.
+    ``CATEGORY_BASE_RATES`` contains NO-side win rates, so the floor is
+    only applied when *side* is ``"no"``.  For ``"yes"`` or ``"both"``,
+    *true_probability* is returned unchanged.
+
+    The ticker's series is extracted (everything before the first ``-``)
+    and matched against keys in *base_rates*.  If the base rate exceeds
+    *true_probability*, returns the base rate; otherwise returns
+    *true_probability* unchanged.
     """
+    if side != "no":
+        return true_probability
+
     if base_rates is None:
         base_rates = CATEGORY_BASE_RATES
 
-    best_rate = 0.0
-    best_len = 0
-    for prefix, rate in base_rates.items():
-        if ticker.startswith(prefix) and len(prefix) > best_len:
-            best_rate = rate
-            best_len = len(prefix)
+    # Extract series prefix (e.g. "KXCPIYOY" from "KXCPIYOY-26MAR-T3.5")
+    series = ticker.split("-")[0] if "-" in ticker else ticker
 
-    if best_len == 0:
+    rate = base_rates.get(series)
+    if rate is None:
         return true_probability
-    return max(true_probability, best_rate)
+    return max(true_probability, rate)
 
 
 def kelly_fraction(

--- a/src/gimmes/strategy/kelly.py
+++ b/src/gimmes/strategy/kelly.py
@@ -4,7 +4,34 @@ from __future__ import annotations
 
 from typing import Literal
 
+from gimmes.config import CATEGORY_BASE_RATES
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, fee_for_order
+
+
+def apply_base_rate_floor(
+    true_probability: float,
+    ticker: str,
+    base_rates: dict[str, float] | None = None,
+) -> float:
+    """Apply category base rate as a floor to the probability estimate.
+
+    Matches the ticker against series prefixes in *base_rates* (longest
+    prefix wins).  If the base rate exceeds *true_probability*, returns
+    the base rate.  Otherwise returns *true_probability* unchanged.
+    """
+    if base_rates is None:
+        base_rates = CATEGORY_BASE_RATES
+
+    best_rate = 0.0
+    best_len = 0
+    for prefix, rate in base_rates.items():
+        if ticker.startswith(prefix) and len(prefix) > best_len:
+            best_rate = rate
+            best_len = len(prefix)
+
+    if best_len == 0:
+        return true_probability
+    return max(true_probability, best_rate)
 
 
 def kelly_fraction(

--- a/tests/unit/test_kelly.py
+++ b/tests/unit/test_kelly.py
@@ -1,7 +1,12 @@
 """Unit tests for Kelly criterion sizing."""
 
 from gimmes.strategy.fees import FeeMultipliers, fee_for_order
-from gimmes.strategy.kelly import ev_fraction, kelly_fraction, position_size
+from gimmes.strategy.kelly import (
+    apply_base_rate_floor,
+    ev_fraction,
+    kelly_fraction,
+    position_size,
+)
 
 
 class TestKellyFraction:
@@ -130,3 +135,43 @@ class TestPositionSizeEV:
         c1 = position_size(10000, 0.65, 0.90)
         c2 = position_size(10000, 0.65, 0.90, mode="kelly")
         assert c1 == c2
+
+
+class TestApplyBaseRateFloor:
+    def test_floor_raises_low_estimate(self) -> None:
+        result = apply_base_rate_floor(0.75, "KXCPIYOY-26MAR-T3.5")
+        assert result == 0.90
+
+    def test_higher_estimate_passes_through(self) -> None:
+        result = apply_base_rate_floor(0.95, "KXCPIYOY-26MAR-T3.5")
+        assert result == 0.95
+
+    def test_exact_match(self) -> None:
+        result = apply_base_rate_floor(0.90, "KXCPIYOY-26MAR-T3.5")
+        assert result == 0.90
+
+    def test_no_match_passes_through(self) -> None:
+        result = apply_base_rate_floor(0.60, "KXFED-26MAR-YES")
+        assert result == 0.60
+
+    def test_longest_prefix_wins(self) -> None:
+        # KXCPICOREYOY (0.90) should beat KXCPICORE (0.85)
+        result = apply_base_rate_floor(0.70, "KXCPICOREYOY-26MAR-T3.5")
+        assert result == 0.90
+
+    def test_shorter_prefix_when_appropriate(self) -> None:
+        result = apply_base_rate_floor(0.70, "KXCPICORE-26MAR-T0.3")
+        assert result == 0.85
+
+    def test_custom_base_rates(self) -> None:
+        custom = {"KXFOO": 0.92}
+        result = apply_base_rate_floor(0.80, "KXFOO-26MAR-T1", base_rates=custom)
+        assert result == 0.92
+
+    def test_floor_increases_position_size(self) -> None:
+        # Low probability = tiny position
+        low_contracts = position_size(10000, 0.65, 0.70)
+        # Floored probability = bigger position
+        floored_prob = apply_base_rate_floor(0.70, "KXCPIYOY-26MAR-T3.5")
+        floored_contracts = position_size(10000, 0.65, floored_prob)
+        assert floored_contracts > low_contracts

--- a/tests/unit/test_kelly.py
+++ b/tests/unit/test_kelly.py
@@ -139,39 +139,52 @@ class TestPositionSizeEV:
 
 class TestApplyBaseRateFloor:
     def test_floor_raises_low_estimate(self) -> None:
-        result = apply_base_rate_floor(0.75, "KXCPIYOY-26MAR-T3.5")
+        result = apply_base_rate_floor(0.75, "KXCPIYOY-26MAR-T3.5", side="no")
         assert result == 0.90
 
     def test_higher_estimate_passes_through(self) -> None:
-        result = apply_base_rate_floor(0.95, "KXCPIYOY-26MAR-T3.5")
+        result = apply_base_rate_floor(0.95, "KXCPIYOY-26MAR-T3.5", side="no")
         assert result == 0.95
 
     def test_exact_match(self) -> None:
-        result = apply_base_rate_floor(0.90, "KXCPIYOY-26MAR-T3.5")
+        result = apply_base_rate_floor(0.90, "KXCPIYOY-26MAR-T3.5", side="no")
         assert result == 0.90
 
     def test_no_match_passes_through(self) -> None:
-        result = apply_base_rate_floor(0.60, "KXFED-26MAR-YES")
+        result = apply_base_rate_floor(0.60, "KXFED-26MAR-YES", side="no")
         assert result == 0.60
 
-    def test_longest_prefix_wins(self) -> None:
-        # KXCPICOREYOY (0.90) should beat KXCPICORE (0.85)
-        result = apply_base_rate_floor(0.70, "KXCPICOREYOY-26MAR-T3.5")
+    def test_series_extraction(self) -> None:
+        # KXCPICOREYOY is the series, not a prefix match
+        result = apply_base_rate_floor(0.70, "KXCPICOREYOY-26MAR-T3.5", side="no")
         assert result == 0.90
 
-    def test_shorter_prefix_when_appropriate(self) -> None:
-        result = apply_base_rate_floor(0.70, "KXCPICORE-26MAR-T0.3")
+    def test_no_prefix_collision(self) -> None:
+        # KXCPICORE-26MAR should match KXCPICORE (0.85), not be confused
+        # with KXCPICOREYOY
+        result = apply_base_rate_floor(0.70, "KXCPICORE-26MAR-T0.3", side="no")
         assert result == 0.85
 
     def test_custom_base_rates(self) -> None:
         custom = {"KXFOO": 0.92}
-        result = apply_base_rate_floor(0.80, "KXFOO-26MAR-T1", base_rates=custom)
+        result = apply_base_rate_floor(0.80, "KXFOO-26MAR-T1", side="no", base_rates=custom)
         assert result == 0.92
 
+    def test_yes_side_skips_floor(self) -> None:
+        # NO base rates should NOT apply to YES trades
+        result = apply_base_rate_floor(0.60, "KXCPIYOY-26MAR-T3.5", side="yes")
+        assert result == 0.60
+
+    def test_both_side_skips_floor(self) -> None:
+        result = apply_base_rate_floor(0.60, "KXCPIYOY-26MAR-T3.5", side="both")
+        assert result == 0.60
+
+    def test_default_side_is_no(self) -> None:
+        result = apply_base_rate_floor(0.70, "KXCPIYOY-26MAR-T3.5")
+        assert result == 0.90  # default side="no" applies floor
+
     def test_floor_increases_position_size(self) -> None:
-        # Low probability = tiny position
         low_contracts = position_size(10000, 0.65, 0.70)
-        # Floored probability = bigger position
-        floored_prob = apply_base_rate_floor(0.70, "KXCPIYOY-26MAR-T3.5")
+        floored_prob = apply_base_rate_floor(0.70, "KXCPIYOY-26MAR-T3.5", side="no")
         floored_contracts = position_size(10000, 0.65, floored_prob)
         assert floored_contracts > low_contracts


### PR DESCRIPTION
## Summary

Positions were **3.3x undersized** because EV sizing used unreliable LLM probability estimates (avg 55-65%) while actual win rates are 75-90% in gimme categories. Added `CATEGORY_BASE_RATES` dict with backtested NO-side win rates and `apply_base_rate_floor()` that uses the base rate as a floor for sizing.

| Metric | Before | After |
|--------|--------|-------|
| Avg position size | $208 (2.1%) | ~$687 (6.9%) |
| Sizing input | LLM estimate (55-65%) | max(LLM, base rate 80-90%) |
| Expected P&L impact | ~$2,931 | ~$9,700 (3.3x) |

The base rate is a **floor, not an override** — if the Caddie estimates 95%, that passes through. Only conservative underestimates get lifted.

Closes #516

## Test plan
- [x] 8 new unit tests for `apply_base_rate_floor()` covering floor, passthrough, prefix matching, custom rates, end-to-end sizing
- [x] All 31 kelly tests pass
- [ ] Backtest comparison: run with and without to verify increased position sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)