### PR TITLE
Fix UnboundLocalError in validate/size/order from probability shadowing

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -436,24 +436,24 @@ def size(
             fees = get_multipliers(market.series_ticker)
 
             bankroll = config.bankroll
-            probability = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
+            true_prob = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
             kf = kelly_fraction(
-                price, probability,
+                price, true_prob,
                 fraction=config.sizing.kelly_fraction, fees=fees,
             )
             contracts = position_size(
-                bankroll, price, probability,
+                bankroll, price, true_prob,
                 fraction=config.sizing.kelly_fraction,
                 max_position_pct=config.sizing.max_position_pct, fees=fees,
                 mode=config.sizing.mode,
             )
             fee = fee_for_order(contracts, price, is_taker=False, fees=fees)
-            edge = edge_after_fees(price, probability, fees=fees)
+            edge = edge_after_fees(price, true_prob, fees=fees)
             cost = contracts * price + fee
 
             table = format_kv_table(f"Position Sizing: {ticker}", [
                 ("Market Price", f"${price:.2f}"),
-                ("True Probability", f"{probability:.1%}"),
+                ("True Probability", f"{true_prob:.1%}"),
                 ("Edge After Fees", f"{edge:.1%}"),
                 ("Kelly Fraction", f"{kf:.4f}"),
                 ("Bankroll", f"${bankroll:,.2f}"),
@@ -503,10 +503,10 @@ def validate(
                 await sync_positions(db, positions)
 
             fees = get_multipliers(market.series_ticker)
-            probability = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
+            true_prob = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
             if dollars <= 0:
                 contracts = position_size(
-                    bankroll, price, probability,
+                    bankroll, price, true_prob,
                     fraction=config.sizing.kelly_fraction,
                     max_position_pct=config.sizing.max_position_pct, fees=fees,
                     mode=config.sizing.mode,
@@ -557,7 +557,7 @@ def validate(
             event_exp = compute_exposure_for_group(positions, market.event_ticker)
             series_exp = compute_exposure_for_group(positions, market.series_ticker)
             result = validate_trade(
-                market, trade_dollars, probability, bankroll,
+                market, trade_dollars, true_prob, bankroll,
                 total_daily_pnl, len(positions), existing_tickers, config,
                 fees=fees, deployed_cost_basis=deployed, size_up=size_up,
                 existing_cost_basis=existing_cost_basis,
@@ -661,10 +661,11 @@ def order(
             is_taker = config.orders.preferred_order_type != "maker"
 
             bankroll = config.bankroll
+            true_prob = probability
             if is_buy and count <= 0 and probability is not None:
-                probability = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
+                true_prob = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
                 final_count = position_size(
-                    bankroll, eff_price, probability,
+                    bankroll, eff_price, true_prob,
                     fraction=config.sizing.kelly_fraction,
                     max_position_pct=config.sizing.max_position_pct, fees=fees,
                     mode=config.sizing.mode,
@@ -754,8 +755,6 @@ def order(
                             " override.[/red]"
                         )
                         return
-
-                true_prob = probability
 
                 existing_cost_basis = 0.0
                 if size_up:

--- a/tests/unit/test_cli_probability_shadowing.py
+++ b/tests/unit/test_cli_probability_shadowing.py
@@ -16,12 +16,18 @@ mark a name as local and all of them would reintroduce the bug.
 from __future__ import annotations
 
 import symtable
+from functools import cache
 from pathlib import Path
 
 import pytest
 
 CLI_PATH = Path(__file__).resolve().parents[2] / "src" / "gimmes" / "cli.py"
 GUARDED_FUNCTIONS = ("_size", "_validate", "_order")
+
+
+@cache
+def _cli_symtable() -> symtable.SymbolTable:
+    return symtable.symtable(CLI_PATH.read_text(), str(CLI_PATH), "exec")
 
 
 def _find_nested(parent: symtable.SymbolTable, name: str) -> symtable.Function | None:
@@ -36,8 +42,7 @@ def _find_nested(parent: symtable.SymbolTable, name: str) -> symtable.Function |
 
 @pytest.mark.parametrize("func_name", GUARDED_FUNCTIONS)
 def test_probability_parameter_is_not_shadowed(func_name: str) -> None:
-    table = symtable.symtable(CLI_PATH.read_text(), str(CLI_PATH), "exec")
-    func = _find_nested(table, func_name)
+    func = _find_nested(_cli_symtable(), func_name)
     assert func is not None, f"{func_name} not found in cli.py"
 
     try:

--- a/tests/unit/test_cli_probability_shadowing.py
+++ b/tests/unit/test_cli_probability_shadowing.py
@@ -1,0 +1,52 @@
+"""Regression guard for issue #519.
+
+The `size`, `validate`, and `order` CLI commands each define a nested async
+function that calls `apply_base_rate_floor(probability, ...)`. If the result
+is assigned back to `probability`, Python treats `probability` as a local
+throughout the nested function, and reading it on the right-hand side raises
+UnboundLocalError. This test enforces that the reassignment uses a different
+name (e.g., `true_prob`).
+
+Uses Python's `symtable` module so any binding mechanism is caught —
+plain assignment, augmented assignment, annotated assignment, walrus,
+tuple unpacking, `for` target, `with ... as probability`, etc. All of these
+mark a name as local and all of them would reintroduce the bug.
+"""
+
+from __future__ import annotations
+
+import symtable
+from pathlib import Path
+
+import pytest
+
+CLI_PATH = Path(__file__).resolve().parents[2] / "src" / "gimmes" / "cli.py"
+GUARDED_FUNCTIONS = ("_size", "_validate", "_order")
+
+
+def _find_nested(parent: symtable.SymbolTable, name: str) -> symtable.Function | None:
+    for child in parent.get_children():
+        if child.get_name() == name and isinstance(child, symtable.Function):
+            return child
+        found = _find_nested(child, name)
+        if found is not None:
+            return found
+    return None
+
+
+@pytest.mark.parametrize("func_name", GUARDED_FUNCTIONS)
+def test_probability_parameter_is_not_shadowed(func_name: str) -> None:
+    table = symtable.symtable(CLI_PATH.read_text(), str(CLI_PATH), "exec")
+    func = _find_nested(table, func_name)
+    assert func is not None, f"{func_name} not found in cli.py"
+
+    try:
+        symbol = func.lookup("probability")
+    except KeyError:
+        return
+
+    assert not symbol.is_local(), (
+        f"{func_name} binds `probability` as a local, shadowing the outer "
+        f"parameter. This causes UnboundLocalError (issue #519). Rename the "
+        f"local to a distinct name (e.g., `true_prob`)."
+    )


### PR DESCRIPTION
## Summary

The `size`, `validate`, and `order` CLI commands each have a nested async function that called `probability = apply_base_rate_floor(probability, ...)`. Reassigning the outer typer parameter made Python treat `probability` as a local throughout the nested function, so reading it on the right-hand side raised `UnboundLocalError`. The bug blocked all trade validation and has been preventing approved Caddie Master decisions from executing.

- Rename the reassigned local to `true_prob` (matches existing convention in `backtest/engine.py`)
- Drop the now-redundant `true_prob = probability` reassignment later in `_order`
- Add a `symtable`-based regression test that catches any future binding of `probability` inside the three nested functions — covers plain assignment, `+=`, annotated assignment, walrus, tuple unpacking, and `for`/`with` targets

Closes #519

## Test plan

- `uv run pytest tests/unit/` — all 1057 tests pass, including 3 new regression tests
- Verified the new test fails when a shadowing regression is reintroduced (temporarily added `probability += 0.0` and confirmed the test reports `_size` as shadowing)
- `uv run ruff check tests/unit/test_cli_probability_shadowing.py` — clean
- Pre-existing E741 lint errors at cli.py:3880 and 3901 are unrelated, tracked in #524