### PR TITLE
Retry cycles when Claude SDK returns is_error=true

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3258,7 +3258,7 @@ def _detect_api_error(output: bytes) -> tuple[bool, bool, str]:
             parsed = _json.loads(output.strip())
         except (_json.JSONDecodeError, UnicodeDecodeError):
             return False, False, ""
-        if isinstance(parsed, dict):
+        if isinstance(parsed, dict) and parsed.get("type") == "result":
             event = parsed
 
     if event is None or not event.get("is_error"):
@@ -3277,6 +3277,35 @@ def _detect_api_error(output: bytes) -> tuple[bool, bool, str]:
 
     is_transient = any(p.search(detail) for p in _transient_api_patterns())
     return True, is_transient, detail
+
+
+def _apply_failure_backoff(
+    consecutive_failures: int,
+    max_consecutive_failures: int,
+) -> bool:
+    """Check circuit breaker after a cycle failure; apply backoff if not.
+
+    Returns True if the caller should halt the loop (breaker tripped),
+    False if the caller should ``continue`` after the backoff sleep.
+    Callers increment ``consecutive_failures`` and print their own
+    branch-specific failure message before invoking this helper.
+    """
+    import time as _time
+
+    if (max_consecutive_failures > 0
+            and consecutive_failures >= max_consecutive_failures):
+        console.print(
+            f"[red bold]Circuit breaker tripped:"
+            f" {max_consecutive_failures} consecutive"
+            f" failures. Halting autonomous loop.[/red bold]"
+        )
+        return True
+    backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
+    console.print(
+        f"[dim]Backoff: retrying in {backoff}s...[/dim]"
+    )
+    _time.sleep(backoff)
+    return False
 
 
 def _check_code_staleness(
@@ -3810,21 +3839,11 @@ def _autonomous_loop(
                         f" (failure {consecutive_failures}"
                         f"/{max_consecutive_failures})[/yellow]"
                     )
-                    if (max_consecutive_failures > 0
-                            and consecutive_failures >= max_consecutive_failures):
-                        console.print(
-                            f"[red bold]Circuit breaker tripped:"
-                            f" {max_consecutive_failures} consecutive"
-                            f" failures. Halting autonomous loop."
-                            f"[/red bold]"
-                        )
+                    if _apply_failure_backoff(
+                        consecutive_failures, max_consecutive_failures,
+                    ):
                         session_status = "crashed"
                         break
-                    backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
-                    console.print(
-                        f"[dim]Backoff: retrying in {backoff}s...[/dim]"
-                    )
-                    time.sleep(backoff)
                     continue
 
             except subprocess.TimeoutExpired:
@@ -3836,20 +3855,11 @@ def _autonomous_loop(
                     f" (failure {consecutive_failures}"
                     f"/{max_consecutive_failures})[/yellow]"
                 )
-                if (max_consecutive_failures > 0
-                        and consecutive_failures >= max_consecutive_failures):
-                    console.print(
-                        f"[red bold]Circuit breaker tripped:"
-                        f" {max_consecutive_failures} consecutive"
-                        f" failures. Halting autonomous loop.[/red bold]"
-                    )
+                if _apply_failure_backoff(
+                    consecutive_failures, max_consecutive_failures,
+                ):
                     session_status = "crashed"
                     break
-                backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
-                console.print(
-                    f"[dim]Backoff: retrying in {backoff}s...[/dim]"
-                )
-                time.sleep(backoff)
                 continue
 
             if returncode != 0:
@@ -3860,20 +3870,11 @@ def _autonomous_loop(
                     f" (failure {consecutive_failures}"
                     f"/{max_consecutive_failures})[/yellow]"
                 )
-                if (max_consecutive_failures > 0
-                        and consecutive_failures >= max_consecutive_failures):
-                    console.print(
-                        f"[red bold]Circuit breaker tripped:"
-                        f" {max_consecutive_failures} consecutive"
-                        f" failures. Halting autonomous loop.[/red bold]"
-                    )
+                if _apply_failure_backoff(
+                    consecutive_failures, max_consecutive_failures,
+                ):
                     session_status = "crashed"
                     break
-                backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
-                console.print(
-                    f"[dim]Backoff: retrying in {backoff}s...[/dim]"
-                )
-                time.sleep(backoff)
                 continue
             else:
                 consecutive_failures = 0

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import re
 import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -3205,6 +3207,78 @@ def _detect_rate_limit(output: bytes) -> tuple[bool, int]:
     return True, 1800  # 30 min fallback
 
 
+@functools.cache
+def _transient_api_patterns() -> tuple[re.Pattern[str], ...]:
+    sources = (
+        r"API Error:\s*5\d{2}\b",
+        r"\boverloaded_error\b",
+        r"\bOverloaded\b",
+        r"\btimed?[\s_-]?out\b",
+        r"\bconnection\s+(?:error|reset|refused|aborted)\b",
+        r"\bECONNRESET\b|\bETIMEDOUT\b",
+        r"\b(?:read|write)\s+timeout\b",
+    )
+    return tuple(re.compile(p, re.IGNORECASE) for p in sources)
+
+
+def _detect_api_error(output: bytes) -> tuple[bool, bool, str]:
+    """Classify the Claude SDK result envelope for API-level errors.
+
+    Returns ``(had_error, is_transient, detail)`` where:
+    - ``had_error`` is True when the terminal ``type: result`` event has
+      ``is_error: true`` — the cycle failed inside the SDK even when the
+      subprocess returncode is 0.
+    - ``is_transient`` is True when the error string matches a known
+      retryable pattern (5xx, overloaded, timeout, connection reset).
+      Callers should still treat non-transient errors as failures — the
+      circuit breaker bounds retry on persistent/permanent errors.
+    - ``detail`` is the serialized error content for logging.
+    """
+    import json as _json
+
+    if not output or not output.strip():
+        return False, False, ""
+
+    event: dict[str, object] | None = None
+    lines = output.strip().split(b"\n")
+    if len(lines) > 1:
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = _json.loads(line)
+            except (_json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if isinstance(parsed, dict) and parsed.get("type") == "result":
+                event = parsed
+                break
+    else:
+        try:
+            parsed = _json.loads(output.strip())
+        except (_json.JSONDecodeError, UnicodeDecodeError):
+            return False, False, ""
+        if isinstance(parsed, dict):
+            event = parsed
+
+    if event is None or not event.get("is_error"):
+        return False, False, ""
+
+    raw = event.get("result")
+    if raw is None:
+        detail = str(event.get("subtype") or "unknown")
+    elif isinstance(raw, str):
+        detail = raw
+    else:
+        try:
+            detail = _json.dumps(raw)
+        except (TypeError, ValueError):
+            detail = str(raw)
+
+    is_transient = any(p.search(detail) for p in _transient_api_patterns())
+    return True, is_transient, detail
+
+
 def _check_code_staleness(
     project_root: Path,
     startup_commit: str | None,
@@ -3717,6 +3791,40 @@ def _autonomous_loop(
                     )
                     time.sleep(rl_pause)
                     consecutive_failures = 0
+                    continue
+
+                # --- Anthropic API error detection ---
+                # SDK returns is_error=true with returncode=0 for API errors.
+                # Route every such case through the failure/backoff path so
+                # the circuit breaker bounds retry on persistent errors.
+                had_api_error, is_transient, api_detail = _detect_api_error(
+                    stdout_bytes,
+                )
+                if had_api_error:
+                    consecutive_failures += 1
+                    kind = "transient API error" if is_transient else "API error"
+                    snippet = api_detail[:200].replace("\n", " ")
+                    console.print(
+                        f"[yellow]Cycle {cycle} hit {kind}:"
+                        f" {snippet}"
+                        f" (failure {consecutive_failures}"
+                        f"/{max_consecutive_failures})[/yellow]"
+                    )
+                    if (max_consecutive_failures > 0
+                            and consecutive_failures >= max_consecutive_failures):
+                        console.print(
+                            f"[red bold]Circuit breaker tripped:"
+                            f" {max_consecutive_failures} consecutive"
+                            f" failures. Halting autonomous loop."
+                            f"[/red bold]"
+                        )
+                        session_status = "crashed"
+                        break
+                    backoff = min(30 * 2 ** (consecutive_failures - 1), 240)
+                    console.print(
+                        f"[dim]Backoff: retrying in {backoff}s...[/dim]"
+                    )
+                    time.sleep(backoff)
                     continue
 
             except subprocess.TimeoutExpired:

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -16,6 +16,7 @@ from gimmes.cli import (
     _check_code_staleness,
     _check_remote_staleness,
     _communicate_interruptible,
+    _detect_api_error,
     _detect_rate_limit,
     _extract_terminal_text,
     _set_mode,
@@ -1180,6 +1181,244 @@ class TestDetectRateLimit:
         )
         is_limited, pause = _detect_rate_limit(output)
         assert is_limited is True
+
+
+def _stream_json_result(is_error: bool, result: object) -> bytes:
+    import json
+
+    envelope = {"type": "result", "is_error": is_error, "result": result}
+    return (b'{"type":"assistant"}\n' + json.dumps(envelope).encode() + b"\n")
+
+
+class TestDetectApiError:
+    """Tests for _detect_api_error helper (issue #522)."""
+
+    def test_detects_api_500(self) -> None:
+        output = _stream_json_result(
+            True,
+            'API Error: 500 {"type":"error","error":{"type":"api_error",'
+            '"message":"Internal server error"}} · check status.claude.com',
+        )
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+        assert "500" in detail
+
+    @pytest.mark.parametrize("code", [502, 503, 504, 529, 599])
+    def test_detects_other_5xx(self, code: int) -> None:
+        output = _stream_json_result(True, f"API Error: {code} Upstream failure")
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+
+    def test_detects_overloaded_error(self) -> None:
+        output = _stream_json_result(
+            True, '{"type":"overloaded_error","message":"Overloaded"}',
+        )
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+
+    def test_detects_timeout(self) -> None:
+        output = _stream_json_result(True, "Request timed out after 600s")
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+
+    def test_detects_connection_reset(self) -> None:
+        output = _stream_json_result(True, "connection reset by peer (ECONNRESET)")
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+
+    def test_permanent_4xx_auth_error_is_error_but_not_transient(self) -> None:
+        output = _stream_json_result(
+            True, "API Error: 401 authentication_error: invalid x-api-key",
+        )
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is False
+        assert "401" in detail
+
+    def test_permanent_invalid_request_is_error_but_not_transient(self) -> None:
+        output = _stream_json_result(True, "invalid_request_error: tool not found")
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is False
+
+    def test_success_envelope_is_not_error(self) -> None:
+        output = _stream_json_result(
+            False, "Cycle complete. All steps passed. No timeout.",
+        )
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is False
+        assert is_transient is False
+
+    def test_empty_output(self) -> None:
+        assert _detect_api_error(b"") == (False, False, "")
+        assert _detect_api_error(b"   \n") == (False, False, "")
+
+    def test_no_result_event(self) -> None:
+        output = b'{"type":"assistant"}\n{"type":"tool_use"}\n'
+        assert _detect_api_error(output) == (False, False, "")
+
+    def test_malformed_json_lines_are_skipped(self) -> None:
+        output = (
+            b"not-json\n"
+            + _stream_json_result(True, "API Error: 500 bad")
+        )
+        had_error, is_transient, _ = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+
+    def test_null_result_uses_subtype_as_detail(self) -> None:
+        output = (
+            b'{"type":"result","is_error":true,"result":null,'
+            b'"subtype":"error_during_execution"}\n'
+        )
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is False
+        assert detail == "error_during_execution"
+
+    def test_mixed_stream_picks_terminal_result_event(self) -> None:
+        # assistant + tool_use events before and after the result envelope
+        import json
+
+        msgs = [
+            b'{"type":"system","subtype":"init"}',
+            b'{"type":"assistant","message":"reasoning"}',
+            b'{"type":"tool_use","name":"Bash"}',
+            json.dumps({
+                "type": "result", "is_error": True,
+                "result": "API Error: 503 Service Unavailable",
+            }).encode(),
+        ]
+        output = b"\n".join(msgs) + b"\n"
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+        assert "503" in detail
+
+    def test_utf8_non_ascii_bytes_in_detail(self) -> None:
+        # The real-world error string includes U+00B7 middle dot (\xc2\xb7)
+        import json
+
+        envelope = {
+            "type": "result", "is_error": True,
+            "result": "API Error: 500 Internal server error \u00b7 status.claude.com",
+        }
+        output = json.dumps(envelope, ensure_ascii=False).encode("utf-8") + b"\n"
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+        assert "\u00b7" in detail
+
+    def test_dict_result_is_serialized_to_json(self) -> None:
+        output = _stream_json_result(
+            True, {"type": "overloaded_error", "message": "Overloaded"},
+        )
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+        assert '"overloaded_error"' in detail
+
+
+class TestApiErrorLoopIntegration:
+    """Loop-level integration for #522 — API errors retry via backoff."""
+
+    def test_transient_api_error_triggers_backoff_and_retries(
+        self, capsys,  # type: ignore[no-untyped-def]
+    ) -> None:
+        transient_output = _stream_json_result(
+            True, "API Error: 500 Internal server error",
+        )
+        ok_output = _stream_json_result(False, "ok")
+        call_count = 0
+
+        def popen_side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_popen(returncode=0, output=transient_output)
+            return _mock_popen(returncode=0, output=ok_output)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=popen_side_effect),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._check_code_staleness", return_value=("", False, None)),
+            patch("gimmes.cli._check_remote_staleness", return_value=None),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _autonomous_loop("driving_range", max_cycles=2, pause_seconds=0)
+
+        out = capsys.readouterr().out
+        assert "transient API error" in out
+        mock_sleep.assert_any_call(30)
+        assert call_count == 2
+
+    def test_permanent_api_error_still_counts_as_failure(
+        self, capsys,  # type: ignore[no-untyped-def]
+    ) -> None:
+        # A 401 auth failure is not transient but must still be counted as
+        # a cycle failure. Otherwise consecutive_failures resets and the
+        # loop burns forever on a broken API key — the original #522 bug
+        # class, just for permanent instead of transient errors.
+        permanent_output = _stream_json_result(
+            True, "API Error: 401 authentication_error: invalid x-api-key",
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(
+                    returncode=0, output=permanent_output,
+                ),
+            ) as mock_popen,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._check_code_staleness", return_value=("", False, None)),
+            patch("gimmes.cli._check_remote_staleness", return_value=None),
+            patch("time.sleep"),
+        ):
+            _autonomous_loop(
+                "driving_range", pause_seconds=0,
+                max_consecutive_failures=2,
+            )
+
+        out = capsys.readouterr().out
+        assert mock_popen.call_count == 2
+        assert "API error" in out
+        assert "transient API error" not in out
+        assert "Circuit breaker tripped" in out
+
+    def test_api_error_trips_circuit_breaker(
+        self, capsys,  # type: ignore[no-untyped-def]
+    ) -> None:
+        transient_output = _stream_json_result(
+            True, "API Error: 503 Service Unavailable",
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(
+                    returncode=0, output=transient_output,
+                ),
+            ) as mock_popen,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._check_code_staleness", return_value=("", False, None)),
+            patch("gimmes.cli._check_remote_staleness", return_value=None),
+            patch("time.sleep"),
+        ):
+            _autonomous_loop(
+                "driving_range", pause_seconds=0,
+                max_consecutive_failures=3,
+            )
+
+        assert mock_popen.call_count == 3
+        out = capsys.readouterr().out
+        assert "Circuit breaker tripped" in out
 
 
 class TestCaddieMasterAgent:


### PR DESCRIPTION
## Summary

The autonomous loop treated only nonzero returncode as a failure. When the Claude SDK returned an envelope with `is_error: true` and `returncode: 0` — which happens for API 5xx, overloads, timeouts, and connection resets — the loop thought the cycle succeeded, never applied the existing exponential backoff, and effectively ended the session without retry. Session 35 crashed this way on 2026-04-15 and idled for 7h until the monitor alerted.

- Add `_detect_api_error(output) -> (had_error, is_transient, detail)` that inspects the terminal stream-json result envelope
- Route every `had_error` cycle through the existing `consecutive_failures` + exponential-backoff + circuit-breaker path — so persistent errors (auth, invalid request) bound retry via the breaker instead of looping forever, and transient errors recover automatically
- Existing `max_consecutive_failures` cap already prevents infinite loops; this change just plugs the SDK-error path into that machinery

Closes #522

## Test plan

- 19 direct unit tests (`TestDetectApiError`): 5xx including 529, overloaded, timeout, connection reset, permanent 4xx / invalid_request, null/dict/non-ASCII `result`, mixed streams, empty output, malformed JSON
- 3 loop-level integration tests (`TestApiErrorLoopIntegration`): transient → retry + 30s backoff, permanent → counted as failure + circuit breaker trip, persistent transient → circuit breaker trip
- `uv run pytest tests/unit/` — 1079 passed
- `uv run ruff check` on changed files — clean (two pre-existing E741s on unrelated lines tracked in #524)