### PR TITLE
Add strategy.cm_min_edge_after_fees for auditable CM edge gate

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -260,7 +260,7 @@ For each PROCEED candidate:
    ```bash
    gimmes config get strategy.cm_min_edge_after_fees
    ```
-   Record the value (e.g. 0.05). You MUST cite this exact number in every APPROVE or REJECT decision note for this candidate. If the command fails, REJECT the candidate — you cannot review without the threshold.
+   Record the value and convert to percentage points (e.g. 0.05 = 5pp). You MUST cite the pp value in every APPROVE or REJECT decision note for this candidate. If the command fails, REJECT the candidate — you cannot review without the threshold.
 
 2. **Read the research independently** — form your own view before conferring:
    ```bash
@@ -273,7 +273,7 @@ For each PROCEED candidate:
    ```
    If any of these commands fail, REJECT the candidate — you cannot review without the data.
 
-   **Edge pre-filter.** If the candidate's net edge after fees is already below `cm_min_edge_after_fees`, REJECT immediately without conferring — the candidate cannot clear the CM floor no matter how the conferral goes. Log the REJECT note with the numeric citation and move on. Skip to step 5.
+   **Edge pre-filter.** If the candidate's net edge after fees is already below `cm_min_edge_after_fees`, REJECT immediately without conferring — the candidate cannot clear the CM floor no matter how the conferral goes. Log the REJECT note with the numeric citation and move on. Skip to sub-step 6 (log rejected candidates as skips).
 
 3. **Confer with Caddie using SendMessage.** Probe the research with pointed questions:
    - Is the thesis robust to the most likely contrary scenario?

--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -256,7 +256,13 @@ For each candidate with GimmeScore >= the configured gimme_threshold and recomme
 
 For each PROCEED candidate:
 
-1. **Read the research independently** — form your own view before conferring:
+1. **Read the CM edge floor from config.** Before reviewing, look up the numeric threshold CM must apply:
+   ```bash
+   gimmes config get strategy.cm_min_edge_after_fees
+   ```
+   Record the value (e.g. 0.05). You MUST cite this exact number in every APPROVE or REJECT decision note for this candidate. If the command fails, REJECT the candidate — you cannot review without the threshold.
+
+2. **Read the research independently** — form your own view before conferring:
    ```bash
    gimmes candidates --ticker TICKER --limit 1
    gimmes market-info TICKER
@@ -267,22 +273,31 @@ For each PROCEED candidate:
    ```
    If any of these commands fail, REJECT the candidate — you cannot review without the data.
 
-2. **Confer with Caddie using SendMessage.** Probe the research with pointed questions:
+   **Edge pre-filter.** If the candidate's net edge after fees is already below `cm_min_edge_after_fees`, REJECT immediately without conferring — the candidate cannot clear the CM floor no matter how the conferral goes. Log the REJECT note with the numeric citation and move on. Skip to step 5.
+
+3. **Confer with Caddie using SendMessage.** Probe the research with pointed questions:
    - Is the thesis robust to the most likely contrary scenario?
    - Are the confidence signals genuinely independent, or do they trace back to a common source?
    - Does this candidate correlate with any open positions (same underlying event, same sector, same directional bet)?
    - What is the strongest contrarian case, and why is it wrong?
    - Is the timing right, or could waiting one cycle yield better information?
 
-   Go back and forth as many times as needed. Wait for each Caddie response before asking the next question. When you have enough information to make a judgment call, proceed to step 3.
+   Go back and forth as many times as needed. Wait for each Caddie response before asking the next question. When you have enough information to make a judgment call, proceed to step 4.
 
-3. **Make a deliberate decision** — APPROVE or REJECT:
-   - **APPROVE**: The thesis survives scrutiny, signals are genuinely independent, and the opportunity is not redundant with the existing portfolio.
-   - **REJECT**: The thesis has a hole the Caddie cannot close, signals are not truly independent, the position would over-concentrate the portfolio, or the timing is wrong.
+4. **Make a deliberate decision** — APPROVE or REJECT:
+   - **APPROVE**: The thesis survives scrutiny, signals are genuinely independent, the opportunity is not redundant with the existing portfolio, AND net edge after fees >= `cm_min_edge_after_fees`.
+   - **REJECT** — valid reasons are:
+     - **Thesis hole**: the Caddie cannot close a material gap in the thesis.
+     - **Signal dependence**: confirming signals trace to a common source and are not truly independent.
+     - **Portfolio over-concentration**: the position would exceed event/series exposure limits.
+     - **Timing**: a known catalyst resolving before the next cycle would materially change the edge.
+     - **Edge below CM floor**: net edge after fees < `cm_min_edge_after_fees`. You MUST cite both numbers in the REJECT note (e.g. "edge 3.2pp < cm_min_edge_after_fees 5.0pp"). Read the net edge from `gimmes candidates --ticker TICKER --limit 1`.
+
+   **Audit language rule.** You MUST NOT use subjective edge descriptors — "thin edge", "knife-edge", "marginal edge", "razor-thin", "too close", "coin flip", "insufficient edge" — as a REJECT reason without citing the numeric net edge and `cm_min_edge_after_fees` in the same sentence. Subjective phrases alone are not a sufficient audit trail.
 
    **Cross-threshold consistency (when multiple PROCEED candidates share the same event):** Verify that probability estimates are monotonic — P(metric > low threshold) >= P(metric > high threshold). If probabilities are inconsistent, REJECT ALL candidates from that event and log the inconsistency. When approving multiple thresholds, verify total proposed deployment fits within the event concentration limit (max_event_exposure_pct). Approve only the highest-edge thresholds that fit.
 
-4. **Log the decision BEFORE dispatching Closer** (audit trail):
+5. **Log the decision BEFORE dispatching Closer** (audit trail):
    ```bash
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -292,7 +307,8 @@ For each PROCEED candidate:
    Reasoning: [specific reasoning referencing the Caddie's research and your conferral].
    Thesis robustness: [survived or did not survive scrutiny — cite the key exchange].
    Signal independence: [confirmed independent or not — explain].
-   Portfolio correlation: [none, or describe overlap with existing positions]."
+   Portfolio correlation: [none, or describe overlap with existing positions].
+   Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — pass."
    ```
    For REJECT decisions:
    ```bash
@@ -302,11 +318,12 @@ For each PROCEED candidate:
      --type decision \
      --body "Decision: REJECT for open.
    Reasoning: [specific reasoning — what failed scrutiny].
-   Key concern: [the issue that could not be resolved in conferral]."
+   Key concern: [the issue that could not be resolved in conferral].
+   Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — [pass/fail]."
    ```
    If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with rationale "Decision note failed to write" and move to the next candidate.
 
-5. **Log rejected candidates as skips** so the decision is auditable:
+6. **Log rejected candidates as skips** so the decision is auditable:
    ```bash
    gimmes log-trade TICKER --action skip --price 0 --prob P --score S \
      --rationale "Caddie Master review: REJECT — [brief reason]" --agent caddie-master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `strategy.cm_min_edge_after_fees` (default 0.05) — explicit edge floor Caddie Master applies in Step 4c review. CM must cite the numeric threshold in every APPROVE/REJECT decision note; subjective descriptors like "thin edge" or "knife-edge" without a numeric citation are forbidden. Invariant: must be >= `strategy.min_edge_after_fees`. (#527)
+
+### Fixed
+- Driving range crashes on transient Anthropic API 5xx instead of retrying — `is_error: true` result envelopes are now treated as cycle failures and routed through the existing backoff + circuit breaker, recovering from API 5xx, overloads, timeouts, and connection resets (#526)
+- `UnboundLocalError` in `validate`/`size`/`order` CLI commands caused by `probability` variable shadowing in nested async functions (#525)
+
 ## [0.6.1] - 2026-04-11
 
 ### Fixed

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -315,6 +315,28 @@ class StrategyConfig(BaseModel):
             "max_val": 0.50,
         },
     )
+    cm_min_edge_after_fees: float = Field(
+        default=0.05, ge=0.0, le=1.0,
+        json_schema_extra={
+            "display_name": "CM Min Edge After Fees",
+            "description": (
+                "The minimum edge Caddie Master requires before approving a PROCEED\n"
+                "candidate in Step 4c review. CM cites this number when rejecting\n"
+                "on edge magnitude, so reviews are auditable instead of subjective.\n"
+                "\n"
+                "This is a second gate above min_edge_after_fees. It must be >=\n"
+                "strategy.min_edge_after_fees — CM can never be laxer than the\n"
+                "validator. Set equal to min_edge_after_fees to effectively disable\n"
+                "CM's extra edge gate.\n"
+                "\n"
+                "  • 0.05 (default): 5pp floor for CM approval\n"
+                "  • Higher (e.g. 0.08): CM insists on fatter edges than validator\n"
+                "  • = min_edge_after_fees: No extra CM edge gate (validator only)"
+            ),
+            "min_val": 0.0,
+            "max_val": 0.50,
+        },
+    )
     cycle_timeout: int = Field(
         default=2700, gt=0,
         json_schema_extra={
@@ -332,6 +354,21 @@ class StrategyConfig(BaseModel):
             "max_val": 86400,
         },
     )
+
+    @model_validator(mode="after")
+    def _reconcile_cm_floor(self) -> StrategyConfig:
+        cm_explicit = "cm_min_edge_after_fees" in self.model_fields_set
+        if self.cm_min_edge_after_fees < self.min_edge_after_fees:
+            if cm_explicit:
+                raise ValueError(
+                    f"strategy.cm_min_edge_after_fees "
+                    f"({self.cm_min_edge_after_fees:.3f}) must be >= "
+                    f"strategy.min_edge_after_fees "
+                    f"({self.min_edge_after_fees:.3f}) — "
+                    f"Caddie Master cannot be laxer than the validator."
+                )
+            self.cm_min_edge_after_fees = self.min_edge_after_fees
+        return self
 
 
 class SizingConfig(BaseModel):

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -316,7 +316,7 @@ class StrategyConfig(BaseModel):
         },
     )
     cm_min_edge_after_fees: float = Field(
-        default=0.05, ge=0.0, le=1.0,
+        default=0.05, ge=0.0, le=0.50,
         json_schema_extra={
             "display_name": "CM Min Edge After Fees",
             "description": (

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -1,0 +1,58 @@
+"""Static checks on agent prompt files (issue #523).
+
+These guards prevent silent drift in the Caddie Master prompt that
+would reintroduce subjective edge-based rejections untied to config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+AGENTS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "agents"
+CADDIE_MASTER = AGENTS_DIR / "caddie-master.md"
+
+
+@pytest.fixture(scope="module")
+def caddie_master_text() -> str:
+    return CADDIE_MASTER.read_text()
+
+
+def test_caddie_master_reads_cm_min_edge_after_fees(caddie_master_text: str) -> None:
+    assert "gimmes config get strategy.cm_min_edge_after_fees" in caddie_master_text, (
+        "Caddie Master must look up strategy.cm_min_edge_after_fees from config "
+        "at the start of Step 4c review."
+    )
+
+
+def test_caddie_master_cites_cm_floor_in_reject_criteria(
+    caddie_master_text: str,
+) -> None:
+    # Expect the config key to appear in the REJECT criteria list (not just the lookup).
+    assert caddie_master_text.count("cm_min_edge_after_fees") >= 3, (
+        "Expected cm_min_edge_after_fees to appear in config lookup, REJECT "
+        "criteria, and the decision-note template."
+    )
+
+
+def test_caddie_master_forbids_subjective_descriptors(
+    caddie_master_text: str,
+) -> None:
+    import re
+
+    forbidden_phrases = ["thin edge", "knife-edge", "marginal edge", "coin flip"]
+    for phrase in forbidden_phrases:
+        assert phrase in caddie_master_text, (
+            f"Step 4c must mention '{phrase}' as an example of a "
+            f"forbidden subjective descriptor."
+        )
+
+    forbidden_clause = re.search(
+        r"(?is)MUST\s+NOT\s+use.*subjective.*edge.*descriptor",
+        caddie_master_text,
+    )
+    assert forbidden_clause is not None, (
+        "Step 4c must contain a 'MUST NOT use subjective edge descriptors' "
+        "clause (any reasonable wording) so rejections are auditable."
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -209,7 +209,7 @@ class TestCMMinEdgeAfterFees:
     def test_default_is_five_pp(self) -> None:
         assert StrategyConfig().cm_min_edge_after_fees == 0.05
 
-    @pytest.mark.parametrize("value", [-0.01, 1.01, 2.0])
+    @pytest.mark.parametrize("value", [-0.01, 0.51, 1.01])
     def test_bounds_reject_out_of_range(self, value: float) -> None:
         from pydantic import ValidationError
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -203,6 +203,56 @@ class TestLoadConfig:
         assert config.strategy.min_market_price == 0.55  # default
 
 
+class TestCMMinEdgeAfterFees:
+    """Tests for strategy.cm_min_edge_after_fees (issue #523)."""
+
+    def test_default_is_five_pp(self) -> None:
+        assert StrategyConfig().cm_min_edge_after_fees == 0.05
+
+    @pytest.mark.parametrize("value", [-0.01, 1.01, 2.0])
+    def test_bounds_reject_out_of_range(self, value: float) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            StrategyConfig(cm_min_edge_after_fees=value)
+
+    def test_invariant_rejects_explicit_cm_below_validator(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            StrategyConfig(
+                min_edge_after_fees=0.05,
+                cm_min_edge_after_fees=0.01,
+            )
+        assert "must be >= strategy.min_edge_after_fees" in str(exc_info.value)
+
+    def test_cm_auto_bumps_to_validator_when_not_set(self) -> None:
+        # Backward compatibility: users who have raised min_edge_after_fees
+        # above the cm default shouldn't error on upgrade. When cm isn't
+        # explicitly set, it tracks the validator floor.
+        s = StrategyConfig(min_edge_after_fees=0.08)
+        assert s.cm_min_edge_after_fees == 0.08
+
+    def test_invariant_allows_cm_equal_to_validator(self) -> None:
+        s = StrategyConfig(
+            min_edge_after_fees=0.05, cm_min_edge_after_fees=0.05,
+        )
+        assert s.cm_min_edge_after_fees == 0.05
+
+    def test_invariant_allows_cm_above_validator(self) -> None:
+        s = StrategyConfig(
+            min_edge_after_fees=0.03, cm_min_edge_after_fees=0.08,
+        )
+        assert s.cm_min_edge_after_fees == 0.08
+
+    def test_override_via_db(self, tmp_path) -> None:
+        db = tmp_path / "test.db"
+        _create_config_db(db)
+        save_config_value("strategy.cm_min_edge_after_fees", 0.08, db_path=db)
+        config = load_config(db_path=db)
+        assert config.strategy.cm_min_edge_after_fees == 0.08
+
+
 class TestDefaultSeries:
     def test_series_defaults_to_curated_list_when_no_db(self, tmp_path):
         config = load_config(db_path=tmp_path / "nonexistent.db")


### PR DESCRIPTION
## Summary

Caddie Master's Step 4c rejection behavior was effectively a second edge-floor gate (~5pp) living in prompt judgment rather than config. Operators tuning `strategy.min_edge_after_fees` (default 0.05, user override 0.01) saw no effect on CM review, and rejections used subjective language like "thin edge" or "knife-edge" without citing a number.

- New `strategy.cm_min_edge_after_fees` field (default 0.05, `ge=0.0 le=1.0`)
- Invariant: `cm >= validator` so CM can never approve trades the validator will reject. When `cm` isn't explicitly set, it auto-tracks the validator floor so existing users with higher validator floors don't break on upgrade
- Step 4c of `caddie-master.md` now looks up the config value, cites it in every APPROVE/REJECT note, and forbids subjective edge descriptors without a numeric citation
- Early REJECT pre-filter so thin candidates short-circuit before Caddie conferral (saves a round-trip of wasted research)
- Static prompt-text guard (`tests/unit/test_agent_prompts.py`) keeps the citation requirements and forbidden-descriptor clause intact against future prompt edits

Closes #523

## Test plan

- `uv run pytest tests/unit/test_config.py tests/unit/test_agent_prompts.py` — 11 new tests pass (default value, bounds, invariant in both directions, auto-bump on upgrade, DB round-trip, prompt citations)
- `uv run pytest tests/unit/ --ignore=tests/unit/test_autonomous_loop.py` — 975 passed (autonomous_loop file is slow due to real sleep in backoff tests; unchanged by this PR)
- `uv run ruff check` on changed files — clean

## Rollout notes

- Users on defaults: no behavior change (`cm_min_edge_after_fees = 0.05` matches the existing validator default)
- Users with `min_edge_after_fees > 0.05`: `cm_min_edge_after_fees` auto-bumps to match on load; no break
- Users with `min_edge_after_fees < 0.05` (the reporter's case): CM now cites a concrete 5pp floor instead of arbitrary judgment — behavior is the same, but rejections are now auditable