### PR TITLE
Replace time.sleep with chunked _resilient_sleep for system sleep/wake

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3279,6 +3279,24 @@ def _detect_api_error(output: bytes) -> tuple[bool, bool, str]:
     return True, is_transient, detail
 
 
+def _resilient_sleep(seconds: float) -> None:
+    """Sleep that survives macOS system sleep/wake.
+
+    A single ``time.sleep(N)`` can hang indefinitely when the OS suspends
+    the process during lid-close.  This helper sleeps in 60-second chunks
+    and checks ``time.monotonic()`` (which includes suspend time on macOS)
+    between each chunk so the loop resumes promptly after a wake event.
+    """
+    import time as _time
+
+    deadline = _time.monotonic() + seconds
+    while True:
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            break
+        _time.sleep(min(remaining, 60))
+
+
 def _apply_failure_backoff(
     consecutive_failures: int,
     max_consecutive_failures: int,
@@ -3290,8 +3308,6 @@ def _apply_failure_backoff(
     Callers increment ``consecutive_failures`` and print their own
     branch-specific failure message before invoking this helper.
     """
-    import time as _time
-
     if (max_consecutive_failures > 0
             and consecutive_failures >= max_consecutive_failures):
         console.print(
@@ -3304,7 +3320,7 @@ def _apply_failure_backoff(
     console.print(
         f"[dim]Backoff: retrying in {backoff}s...[/dim]"
     )
-    _time.sleep(backoff)
+    _resilient_sleep(backoff)
     return False
 
 
@@ -3818,7 +3834,7 @@ def _autonomous_loop(
                         f" {h}h {m:02d}m until reset."
                         f"[/red bold]"
                     )
-                    time.sleep(rl_pause)
+                    _resilient_sleep(rl_pause)
                     consecutive_failures = 0
                     continue
 
@@ -3888,7 +3904,7 @@ def _autonomous_loop(
                 fresh_secs = seconds_until_next_window()
                 post_sleep = min(fresh_secs, monitor_interval)
             console.print(f"[dim]Next cycle in {post_sleep}s...[/dim]")
-            time.sleep(post_sleep)
+            _resilient_sleep(post_sleep)
     except KeyboardInterrupt:
         if proc is not None and proc.poll() is None:
             _kill_process_group(proc)

--- a/tests/unit/test_resilient_sleep.py
+++ b/tests/unit/test_resilient_sleep.py
@@ -1,0 +1,83 @@
+"""Tests for _resilient_sleep (issue #530).
+
+Verifies that the chunked sleep helper survives macOS system sleep/wake
+by using time.monotonic() to track wall-clock progress.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gimmes.cli import _resilient_sleep
+
+
+class TestResilientSleep:
+
+    def test_short_sleep_calls_once(self) -> None:
+        """A sleep shorter than 60s should call time.sleep once."""
+        with (
+            patch("time.monotonic", side_effect=[0.0, 0.0, 30.0]),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _resilient_sleep(30)
+
+        mock_sleep.assert_called_once_with(30.0)
+
+    def test_long_sleep_chunks_at_60s(self) -> None:
+        """A 150s sleep should chunk into 60+60+30."""
+        # Call sequence: set deadline (0), check remaining (0→sleep 60),
+        # check remaining (60→sleep 60), check remaining (120→sleep 30),
+        # check remaining (150→break)
+        times = [0.0, 0.0, 60.0, 120.0, 150.0]
+        with (
+            patch("time.monotonic", side_effect=times),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _resilient_sleep(150)
+
+        assert mock_sleep.call_count == 3
+        mock_sleep.assert_any_call(60)
+        mock_sleep.assert_any_call(30.0)
+
+    def test_wake_from_sleep_exits_immediately(self) -> None:
+        """Simulates system wake: monotonic jumps past the deadline."""
+        times = [0.0, 0.0, 7200.0]
+        with (
+            patch("time.monotonic", side_effect=times),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _resilient_sleep(3600)
+
+        mock_sleep.assert_called_once_with(60)
+
+    def test_zero_duration_returns_immediately(self) -> None:
+        with (
+            patch("time.monotonic", side_effect=[0.0, 0.0]),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _resilient_sleep(0)
+
+        mock_sleep.assert_not_called()
+
+    def test_negative_duration_returns_immediately(self) -> None:
+        with (
+            patch("time.monotonic", side_effect=[100.0, 100.0]),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _resilient_sleep(-5)
+
+        mock_sleep.assert_not_called()
+
+    def test_sleep_values_never_exceed_60(self) -> None:
+        """Even for very long sleeps, individual chunks cap at 60s."""
+        times = []
+        for i in range(0, 7260, 60):
+            times.extend([float(i), float(i)])
+        with (
+            patch("time.monotonic", side_effect=times),
+            patch("time.sleep") as mock_sleep,
+        ):
+            _resilient_sleep(7200)
+
+        for c in mock_sleep.call_args_list:
+            assert c[0][0] <= 60.0


### PR DESCRIPTION
## Summary

The autonomous loop's `time.sleep()` hangs indefinitely when macOS suspends the process during lid-close. Observed on consecutive days (sessions 58 and 59) — process alive, no children, 3-5h+ idle after what should be a 1h sleep.

- Add `_resilient_sleep(seconds)` that sleeps in 60-second chunks using `time.monotonic()` (includes suspend time on macOS) to detect wall-clock jumps and exit promptly after wake
- Replace all three sleep sites: post-cycle sleep (line 3909), rate-limit pause (line 3839), failure backoff via `_apply_failure_backoff`

Closes #530

## Test plan

- 6 new unit tests (`tests/unit/test_resilient_sleep.py`): short sleep, chunked 150s, wake-from-sleep simulation (monotonic jump past deadline), zero/negative duration, chunk cap at 60s
- `uv run pytest tests/unit/ --ignore=tests/unit/test_autonomous_loop.py` — 981 passed
- `uv run ruff check` — clean (2 pre-existing E741 in unrelated cron handlers, tracked in #524)