### PR TITLE
Raise monitor staleness threshold from 2h to 3h

### DIFF
--- a/bin/monitor.sh
+++ b/bin/monitor.sh
@@ -15,6 +15,7 @@ LOG_DIR="${GIMMES_HOME}/logs"
 MONITOR_LOG="${LOG_DIR}/monitor.log"
 CONFIG_FILE="${GIMMES_HOME}/monitor.conf"
 NOTIFY_PHONE="+17706162336"
+STALENESS_THRESHOLD="${GIMMES_STALENESS_THRESHOLD:-10800}"
 
 QUIET=false
 [[ "${1:-}" == "--quiet" ]] && QUIET=true
@@ -69,8 +70,8 @@ if [[ -n "$latest_log" ]]; then
         log_age=$(( $(date +%s) - $(stat -c %Y "$latest_log") ))
     fi
     hours_ago=$((log_age / 3600))
-    if [[ "$log_age" -gt 7200 ]]; then
-        issues+=("No cycle in ${hours_ago}h — driving range may have stopped")
+    if [[ "$log_age" -gt "$STALENESS_THRESHOLD" ]]; then
+        issues+=("No cycle in ${hours_ago}h — driving range may have stopped (threshold: $((STALENESS_THRESHOLD/3600))h)")
     fi
 fi
 

--- a/tests/unit/test_monitor_sh.py
+++ b/tests/unit/test_monitor_sh.py
@@ -1,0 +1,91 @@
+"""Tests for bin/monitor.sh staleness threshold (issue #529)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+MONITOR_SH = Path(__file__).parents[2] / "bin" / "monitor.sh"
+
+
+@pytest.fixture()
+def monitor_env(tmp_path: Path) -> dict[str, str]:
+    """Set up a minimal environment for monitor.sh."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".venv" / "bin").mkdir(parents=True)
+    # Stub out gimmes CLI — risk-check and errors succeed silently
+    gimmes_stub = repo / ".venv" / "bin" / "python"
+    gimmes_stub.write_text("#!/bin/sh\nexit 0\n")
+    gimmes_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["GIMMES_HOME"] = str(tmp_path)
+    env["PATH"] = str(repo / ".venv" / "bin") + ":" + env.get("PATH", "")
+    return env
+
+
+class TestStalenessThreshold:
+
+    def test_fresh_cycle_log_passes(self, tmp_path: Path, monitor_env: dict) -> None:
+        """A cycle log created just now should not trigger an alert."""
+        logs = tmp_path / "logs"
+        (logs / "cycle-1.json").write_text("{}")
+
+        result = subprocess.run(
+            ["bash", str(MONITOR_SH), "--quiet"],
+            env=monitor_env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_stale_cycle_log_alerts(self, tmp_path: Path, monitor_env: dict) -> None:
+        """A cycle log older than the threshold should trigger an alert."""
+        logs = tmp_path / "logs"
+        log_file = logs / "cycle-1.json"
+        log_file.write_text("{}")
+        # Set mtime to 4 hours ago (> default 3h threshold)
+        old_time = time.time() - 14400
+        os.utime(log_file, (old_time, old_time))
+
+        result = subprocess.run(
+            ["bash", str(MONITOR_SH), "--quiet"],
+            env=monitor_env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 1
+
+    def test_env_var_overrides_threshold(
+        self, tmp_path: Path, monitor_env: dict,
+    ) -> None:
+        """GIMMES_STALENESS_THRESHOLD env var should override the default."""
+        logs = tmp_path / "logs"
+        log_file = logs / "cycle-1.json"
+        log_file.write_text("{}")
+        # Set mtime to 2 hours ago
+        old_time = time.time() - 7200
+        os.utime(log_file, (old_time, old_time))
+
+        # Default threshold is 3h (10800s) — 2h-old file should pass
+        result = subprocess.run(
+            ["bash", str(MONITOR_SH), "--quiet"],
+            env=monitor_env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, "2h-old file should pass 3h threshold"
+
+        # Override threshold to 1h (3600s) — 2h-old file should alert
+        monitor_env["GIMMES_STALENESS_THRESHOLD"] = "3600"
+        result = subprocess.run(
+            ["bash", str(MONITOR_SH), "--quiet"],
+            env=monitor_env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 1, "2h-old file should fail 1h threshold"
+
+    def test_default_threshold_is_three_hours(self) -> None:
+        """Verify the default value in the script is 10800 (3h)."""
+        content = MONITOR_SH.read_text()
+        assert "GIMMES_STALENESS_THRESHOLD:-10800" in content

--- a/tests/unit/test_monitor_sh.py
+++ b/tests/unit/test_monitor_sh.py
@@ -25,9 +25,11 @@ def monitor_env(tmp_path: Path) -> dict[str, str]:
     gimmes_stub.write_text("#!/bin/sh\nexit 0\n")
     gimmes_stub.chmod(0o755)
 
-    env = os.environ.copy()
-    env["GIMMES_HOME"] = str(tmp_path)
-    env["PATH"] = str(repo / ".venv" / "bin") + ":" + env.get("PATH", "")
+    env = {
+        "GIMMES_HOME": str(tmp_path),
+        "PATH": str(repo / ".venv" / "bin") + ":" + os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", "/tmp"),
+    }
     return env
 
 
@@ -85,7 +87,26 @@ class TestStalenessThreshold:
         )
         assert result.returncode == 1, "2h-old file should fail 1h threshold"
 
-    def test_default_threshold_is_three_hours(self) -> None:
-        """Verify the default value in the script is 10800 (3h)."""
-        content = MONITOR_SH.read_text()
-        assert "GIMMES_STALENESS_THRESHOLD:-10800" in content
+    def test_default_threshold_is_three_hours(
+        self, tmp_path: Path, monitor_env: dict,
+    ) -> None:
+        """With no override, default 3h threshold passes 2h-old but fails 4h-old."""
+        logs = tmp_path / "logs"
+        log_file = logs / "cycle-1.json"
+        log_file.write_text("{}")
+
+        # 2h-old should pass 3h default
+        os.utime(log_file, (time.time() - 7200,) * 2)
+        result = subprocess.run(
+            ["bash", str(MONITOR_SH), "--quiet"],
+            env=monitor_env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, "2h-old file should pass 3h default"
+
+        # 4h-old should fail 3h default
+        os.utime(log_file, (time.time() - 14400,) * 2)
+        result = subprocess.run(
+            ["bash", str(MONITOR_SH), "--quiet"],
+            env=monitor_env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 1, "4h-old file should fail 3h default"


### PR DESCRIPTION
## Summary

The 2h hardcoded staleness threshold in `bin/monitor.sh` fires false iMessage alerts during normal monitor-only cycling outside trade windows. A long cycle (82min Scout timeout) + 1h inter-cycle sleep = 2h22m, exceeding the threshold.

- Raise default from 7200s (2h) to 10800s (3h) — accommodates worst-case cycle + sleep with 38min margin
- Make configurable via `GIMMES_STALENESS_THRESHOLD` env var for tighter setups
- Alert message now shows the threshold for easier debugging

Closes #529

## Test plan

- 4 new tests (`tests/unit/test_monitor_sh.py`): fresh log passes, stale log alerts, env var override, default value check
- `uv run pytest tests/unit/ --ignore=tests/unit/test_autonomous_loop.py` — 985 passed
- `uv run ruff check` — clean