### PR TITLE
Rename ambiguous variable 'l' to 'line' in cron handlers

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4002,8 +4002,8 @@ def monitor_cmd(
             existing = ""
 
         lines = [
-            l for l in existing.splitlines()
-            if cron_tag not in l
+            line for line in existing.splitlines()
+            if cron_tag not in line
         ]
         lines.append(cron_line)
         subprocess.run(
@@ -4023,8 +4023,8 @@ def monitor_cmd(
                 console.print("[yellow]No crontab found.[/yellow]")
                 return
             lines = [
-                l for l in result.stdout.splitlines()
-                if cron_tag not in l
+                line for line in result.stdout.splitlines()
+                if cron_tag not in line
             ]
             subprocess.run(
                 ["crontab", "-"],


### PR DESCRIPTION
## Summary

Fixes two ruff E741 violations where list comprehensions in the monitor cron install/uninstall handlers used `l` (visually ambiguous with `1`). Renamed to `line`.

Closes #524

## Test plan

- `uv run ruff check src/gimmes/cli.py --select E741` — 0 errors
- `uv run pytest tests/unit/ --ignore=tests/unit/test_autonomous_loop.py` — 985 passed