### PR TITLE
Add stream idle timeout to transient API error patterns

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3217,6 +3217,8 @@ def _transient_api_patterns() -> tuple[re.Pattern[str], ...]:
         r"\bconnection\s+(?:error|reset|refused|aborted)\b",
         r"\bECONNRESET\b|\bETIMEDOUT\b",
         r"\b(?:read|write)\s+timeout\b",
+        r"\bstream\s+idle\s+timeout\b",
+        r"\bpartial\s+response\b",
     )
     return tuple(re.compile(p, re.IGNORECASE) for p in sources)
 

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -1271,6 +1271,16 @@ class TestDetectApiError:
         assert had_error is True
         assert is_transient is True
 
+    def test_detects_stream_idle_timeout(self) -> None:
+        output = _stream_json_result(
+            True,
+            "API Error: Stream idle timeout - partial response received",
+        )
+        had_error, is_transient, detail = _detect_api_error(output)
+        assert had_error is True
+        assert is_transient is True
+        assert "Stream idle timeout" in detail
+
     def test_null_result_uses_subtype_as_detail(self) -> None:
         output = (
             b'{"type":"result","is_error":true,"result":null,'


### PR DESCRIPTION
## Summary

Cycle 943 hit `API Error: Stream idle timeout - partial response received` after the Caddie approved 3 gimme candidates. The existing `\btimed?[\s_-]?out\b` pattern already catches "timeout" in this string, but adding explicit patterns for `stream idle timeout` and `partial response` improves specificity and documents the observed error.

Closes #537

## Test plan

- New `test_detects_stream_idle_timeout` verifies the exact observed error string is classified as transient
- `uv run ruff check` — clean