### PR TITLE
Add side constraint rule to Caddie Master Step 4c

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -266,7 +266,7 @@ For each PROCEED candidate:
    ```bash
    gimmes config get strategy.side
    ```
-   Record the value as `trading_side` (e.g. "no", "yes", or "both"). If this command fails, default to "both" (permissive).
+   Record the value as `trading_side` (e.g. "no", "yes", or "both"). If this command fails, REJECT the candidate — you cannot review without the side constraint.
 
 2. **Read the research independently** — form your own view before conferring:
    ```bash
@@ -298,7 +298,7 @@ For each PROCEED candidate:
      - **Portfolio over-concentration**: the position would exceed event/series exposure limits.
      - **Timing**: a known catalyst resolving before the next cycle would materially change the edge.
      - **Edge below CM floor**: net edge after fees < `cm_min_edge_after_fees`. You MUST cite both numbers in the REJECT note (e.g. "edge 3.2pp < cm_min_edge_after_fees 5.0pp"). Read the net edge from `gimmes candidates --ticker TICKER --limit 1`.
-     - **Side constraint**: when `trading_side` is `"yes"` or `"no"`, REJECT any candidate whose side does not match `trading_side`. The structural edge is side-specific — if the configured side has no edge on a candidate, the correct action is PASS, not switching sides. Only when `trading_side` = `"both"` are both sides permitted. This applies even during extraordinary events.
+     - **Side constraint**: when `trading_side` is `"yes"` or `"no"`, REJECT any candidate whose side does not match `trading_side`. The structural edge is side-specific — if the configured side has no edge on a candidate, REJECT rather than switching sides. Only when `trading_side` = `"both"` are both sides permitted. This applies even during extraordinary events.
 
    **Audit language rule.** You MUST NOT use subjective edge descriptors — "thin edge", "knife-edge", "marginal edge", "razor-thin", "too close", "coin flip", "insufficient edge" — as a REJECT reason without citing the numeric net edge and `cm_min_edge_after_fees` in the same sentence. Subjective phrases alone are not a sufficient audit trail.
 

--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -262,6 +262,12 @@ For each PROCEED candidate:
    ```
    Record the value and convert to percentage points (e.g. 0.05 = 5pp). You MUST cite the pp value in every APPROVE or REJECT decision note for this candidate. If the command fails, REJECT the candidate — you cannot review without the threshold.
 
+   Also read the configured trading side:
+   ```bash
+   gimmes config get strategy.side
+   ```
+   Record the value as `trading_side` (e.g. "no", "yes", or "both"). If this command fails, default to "both" (permissive).
+
 2. **Read the research independently** — form your own view before conferring:
    ```bash
    gimmes candidates --ticker TICKER --limit 1
@@ -292,6 +298,7 @@ For each PROCEED candidate:
      - **Portfolio over-concentration**: the position would exceed event/series exposure limits.
      - **Timing**: a known catalyst resolving before the next cycle would materially change the edge.
      - **Edge below CM floor**: net edge after fees < `cm_min_edge_after_fees`. You MUST cite both numbers in the REJECT note (e.g. "edge 3.2pp < cm_min_edge_after_fees 5.0pp"). Read the net edge from `gimmes candidates --ticker TICKER --limit 1`.
+     - **Side constraint**: when `trading_side` is `"yes"` or `"no"`, REJECT any candidate whose side does not match `trading_side`. The structural edge is side-specific — if the configured side has no edge on a candidate, the correct action is PASS, not switching sides. Only when `trading_side` = `"both"` are both sides permitted. This applies even during extraordinary events.
 
    **Audit language rule.** You MUST NOT use subjective edge descriptors — "thin edge", "knife-edge", "marginal edge", "razor-thin", "too close", "coin flip", "insufficient edge" — as a REJECT reason without citing the numeric net edge and `cm_min_edge_after_fees` in the same sentence. Subjective phrases alone are not a sufficient audit trail.
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -32,6 +32,20 @@ def test_caddie_master_reads_cm_min_edge_after_fees(caddie_master_text: str) -> 
     )
 
 
+def test_caddie_master_reads_strategy_side(caddie_master_text: str) -> None:
+    assert "gimmes config get strategy.side" in caddie_master_text, (
+        "Caddie Master Step 4c must read strategy.side from config "
+        "to enforce the side constraint rule (#540)."
+    )
+
+
+def test_caddie_master_side_constraint_reject_rule(caddie_master_text: str) -> None:
+    assert "Side constraint" in caddie_master_text, (
+        "Step 4c REJECT criteria must include a 'Side constraint' rule "
+        "that rejects candidates mismatched with strategy.side (#540)."
+    )
+
+
 def test_caddie_master_cites_cm_floor_in_reject_criteria(
     caddie_master_text: str,
 ) -> None:


### PR DESCRIPTION
## Summary

CM overrode the configured `strategy.side = "no"` on 2026-04-03 and approved a YES trade on KXCPI-26MAR-T0.8 that lost the entire $410 cost basis — the single biggest loss in the portfolio. The gimme strategy's structural edge exists exclusively on the NO side (backtest: 47/47 trades were NO, 74.5% win rate).

- Step 4c sub-step 1 now also reads `gimmes config get strategy.side` and records `trading_side`
- New REJECT criterion: "Side constraint" — when `trading_side` is "yes" or "no", REJECT any candidate on the opposite side, even during extraordinary events. Only `"both"` permits both sides.

Closes #540

## Test plan

- 2 new static prompt guards: `test_caddie_master_reads_strategy_side`, `test_caddie_master_side_constraint_reject_rule`
- `uv run pytest tests/unit/test_agent_prompts.py` — 8 passed
- `uv run ruff check` — clean