### PR TITLE
Bound autonomous loop with default --cycles 400; warn on unbounded runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case at default 60s pause + 3600s monitor interval) to bound Claude API spend per run; pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning (#543)
+
 ## [0.6.4] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The **Caddie Master** dispatches agents each cycle. During trade windows (around
 
 The [Clubhouse](#the-clubhouse) dashboard auto-launches at `http://127.0.0.1:1919` (or the next available port) — check the printed URL and open your browser to watch live.
 
-Press **Ctrl+C** to stop. Run the command again to resume — the loop reads database state, so it picks up where it left off. Use `--cycles N` to run a fixed number of cycles, `--pause N` to adjust seconds between full cycles, `--monitor-interval N` for seconds between monitor-only checks.
+Press **Ctrl+C** to stop. Run the command again to resume — the loop reads database state, so it picks up where it left off. Use `--cycles N` (alias `--max-cycles N`, default 400 ≈ one trading day) to run a bounded number of cycles, `--pause N` to adjust seconds between full cycles, `--monitor-interval N` for seconds between monitor-only checks. Pass `--cycles 0` for unbounded runs (a startup warning will print).
 
 ---
 
@@ -389,7 +389,7 @@ gimmes driving_range     # Autonomous loop -- paper trading (auto-starts dashboa
 gimmes championship      # Autonomous loop -- real money (auto-starts dashboard)
 ```
 
-All three accept `--cycles N` (0 = unlimited), `--pause N` (seconds between full cycles, default 60), `--monitor-interval N` (seconds between monitor-only cycles outside trade windows, default 3600), and `--no-dashboard`.
+All three accept `--cycles N` (alias `--max-cycles N`; default 400 ≈ one trading day, pass `0` for unbounded with a startup warning), `--pause N` (seconds between full cycles, default 60), `--monitor-interval N` (seconds between monitor-only cycles outside trade windows, default 3600), and `--no-dashboard`.
 
 ---
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -28,6 +28,15 @@ _RECONCILE_HINT = (
     " to sync positions with the broker.[/yellow]"
 )
 
+DEFAULT_AUTONOMOUS_CYCLES = 400
+"""Default `--cycles` value for autonomous-loop commands.
+
+Sized to roughly one saturated trading day at the default 60s in-window
+pause + 3600s monitor interval (~390 in-window cycles + ~17 monitor cycles).
+Pass `--cycles 0` (or `--max-cycles 0`) to opt into unbounded runs; the loop
+prints a startup warning when it does.
+"""
+
 
 def _api_error_detail(e) -> str:  # type: ignore[no-untyped-def]
     """Extract a human-readable message from an httpx.HTTPStatusError."""
@@ -3011,10 +3020,11 @@ def _championship_gate(config: GimmesConfig) -> None:
 @app.command(name="start", rich_help_panel="Autonomous Trading")
 def start(
     cycles: int = typer.Option(
-        400, "--cycles", "--max-cycles", "-n", min=0,
+        DEFAULT_AUTONOMOUS_CYCLES, "--cycles", "--max-cycles", "-n", min=0,
         help=(
-            "Max Claude API cycles before exit (default 400, ~1 trading day;"
-            " 0=unlimited, prints warning)."
+            f"Max Claude API cycles before exit (default"
+            f" {DEFAULT_AUTONOMOUS_CYCLES}, ~1 trading day; 0=unlimited,"
+            " prints warning)."
         ),
     ),
     pause: int = typer.Option(60, "--pause", min=0, help="Seconds between cycles (default 60)"),
@@ -3476,7 +3486,7 @@ def _wrap_stream_json(raw: bytes) -> bytes:
 def _autonomous_loop(
     mode: str,
     *,
-    max_cycles: int = 400,
+    max_cycles: int = DEFAULT_AUTONOMOUS_CYCLES,
     pause_seconds: int = 60,
     monitor_interval: int = 3600,
     no_dashboard: bool = False,
@@ -3581,8 +3591,9 @@ def _autonomous_loop(
     else:
         console.print(
             "[yellow]Warning: Unbounded run -- no Claude API budget will be"
-            " enforced from this flag. Consider --max-cycles or the daily-budget"
-            " guardrail (#545).[/yellow]"
+            " enforced. Pass --max-cycles N to bound the run"
+            f" (e.g. --max-cycles {DEFAULT_AUTONOMOUS_CYCLES} for"
+            " ~1 trading day).[/yellow]"
         )
     console.print("Press Ctrl+C to stop\n")
 
@@ -3933,10 +3944,11 @@ def _autonomous_loop(
 @app.command(name="driving_range", rich_help_panel="Autonomous Trading")
 def driving_range(
     cycles: int = typer.Option(
-        400, "--cycles", "--max-cycles", "-n", min=0,
+        DEFAULT_AUTONOMOUS_CYCLES, "--cycles", "--max-cycles", "-n", min=0,
         help=(
-            "Max Claude API cycles before exit (default 400, ~1 trading day;"
-            " 0=unlimited, prints warning)."
+            f"Max Claude API cycles before exit (default"
+            f" {DEFAULT_AUTONOMOUS_CYCLES}, ~1 trading day; 0=unlimited,"
+            " prints warning)."
         ),
     ),
     pause: int = typer.Option(60, "--pause", min=0, help="Seconds between cycles (default 60)"),
@@ -3957,10 +3969,11 @@ def driving_range(
 @app.command(name="championship", rich_help_panel="Autonomous Trading")
 def championship(
     cycles: int = typer.Option(
-        400, "--cycles", "--max-cycles", "-n", min=0,
+        DEFAULT_AUTONOMOUS_CYCLES, "--cycles", "--max-cycles", "-n", min=0,
         help=(
-            "Max Claude API cycles before exit (default 400, ~1 trading day;"
-            " 0=unlimited, prints warning)."
+            f"Max Claude API cycles before exit (default"
+            f" {DEFAULT_AUTONOMOUS_CYCLES}, ~1 trading day; 0=unlimited,"
+            " prints warning)."
         ),
     ),
     pause: int = typer.Option(60, "--pause", min=0, help="Seconds between cycles (default 60)"),

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3011,7 +3011,11 @@ def _championship_gate(config: GimmesConfig) -> None:
 @app.command(name="start", rich_help_panel="Autonomous Trading")
 def start(
     cycles: int = typer.Option(
-        0, "--cycles", "-n", min=0, help="Max cycles to run (0=unlimited)",
+        400, "--cycles", "--max-cycles", "-n", min=0,
+        help=(
+            "Max Claude API cycles before exit (default 400, ~1 trading day;"
+            " 0=unlimited, prints warning)."
+        ),
     ),
     pause: int = typer.Option(60, "--pause", min=0, help="Seconds between cycles (default 60)"),
     no_dashboard: bool = typer.Option(
@@ -3472,7 +3476,7 @@ def _wrap_stream_json(raw: bytes) -> bytes:
 def _autonomous_loop(
     mode: str,
     *,
-    max_cycles: int = 0,
+    max_cycles: int = 400,
     pause_seconds: int = 60,
     monitor_interval: int = 3600,
     no_dashboard: bool = False,
@@ -3574,6 +3578,12 @@ def _autonomous_loop(
     console.print(f"Monitor interval (outside windows): {monitor_interval}s")
     if max_cycles > 0:
         console.print(f"Max cycles: {max_cycles}")
+    else:
+        console.print(
+            "[yellow]Warning: Unbounded run -- no Claude API budget will be"
+            " enforced from this flag. Consider --max-cycles or the daily-budget"
+            " guardrail (#545).[/yellow]"
+        )
     console.print("Press Ctrl+C to stop\n")
 
     cycle = get_max_global_cycle(config.db_path)
@@ -3923,7 +3933,11 @@ def _autonomous_loop(
 @app.command(name="driving_range", rich_help_panel="Autonomous Trading")
 def driving_range(
     cycles: int = typer.Option(
-        0, "--cycles", "-n", min=0, help="Max cycles to run (0=unlimited)",
+        400, "--cycles", "--max-cycles", "-n", min=0,
+        help=(
+            "Max Claude API cycles before exit (default 400, ~1 trading day;"
+            " 0=unlimited, prints warning)."
+        ),
     ),
     pause: int = typer.Option(60, "--pause", min=0, help="Seconds between cycles (default 60)"),
     monitor_interval: int = typer.Option(
@@ -3943,7 +3957,11 @@ def driving_range(
 @app.command(name="championship", rich_help_panel="Autonomous Trading")
 def championship(
     cycles: int = typer.Option(
-        0, "--cycles", "-n", min=0, help="Max cycles to run (0=unlimited)",
+        400, "--cycles", "--max-cycles", "-n", min=0,
+        help=(
+            "Max Claude API cycles before exit (default 400, ~1 trading day;"
+            " 0=unlimited, prints warning)."
+        ),
     ),
     pause: int = typer.Option(60, "--pause", min=0, help="Seconds between cycles (default 60)"),
     monitor_interval: int = typer.Option(

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -172,6 +172,35 @@ class TestAutonomousLoop:
 
         assert mock_popen.call_count == 3
 
+    def test_warns_when_max_cycles_zero(self, capsys) -> None:  # type: ignore[no-untyped-def]
+        """max_cycles=0 (unbounded) prints a startup warning."""
+        def side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise KeyboardInterrupt
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=side_effect),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=0, pause_seconds=0)
+
+        output = capsys.readouterr().out
+        assert "Unbounded run" in output
+        assert "#545" in output
+        assert "--max-cycles" in output
+
+    def test_no_warning_when_max_cycles_positive(self, capsys) -> None:  # type: ignore[no-untyped-def]
+        """max_cycles>0 (bounded) does not print the unbounded-run warning."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=2, pause_seconds=0)
+
+        output = capsys.readouterr().out
+        assert "Unbounded run" not in output
+
     def test_passes_correct_claude_args(self) -> None:
         mock_proc = _mock_popen()
         with (
@@ -899,6 +928,57 @@ class TestDrivingRangeCommand:
             monitor_interval=3600, no_dashboard=False,
         )
 
+    def test_default_cycles_is_400(self) -> None:
+        """Without --cycles, the new bounded default (400) is passed through."""
+        with (
+            patch("gimmes.cli._set_mode"),
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+        ):
+            result = runner.invoke(app, ["driving_range"])
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "driving_range", max_cycles=400, pause_seconds=60,
+            monitor_interval=3600, no_dashboard=False,
+        )
+
+    def test_max_cycles_alias_works(self) -> None:
+        """The --max-cycles alias is accepted and passes through to max_cycles."""
+        with (
+            patch("gimmes.cli._set_mode"),
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+        ):
+            result = runner.invoke(app, ["driving_range", "--max-cycles", "7"])
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "driving_range", max_cycles=7, pause_seconds=60,
+            monitor_interval=3600, no_dashboard=False,
+        )
+
+    def test_help_documents_new_default_and_alias(self) -> None:
+        """`gimmes driving_range --help` mentions --max-cycles alias and default 400."""
+        result = runner.invoke(app, ["driving_range", "--help"])
+        assert result.exit_code == 0
+        assert "--max-cycles" in result.output
+        assert "400" in result.output
+
+    def test_cycles_and_max_cycles_last_wins(self) -> None:
+        """When both --cycles and --max-cycles are passed, the last value wins."""
+        with (
+            patch("gimmes.cli._set_mode"),
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+        ):
+            result = runner.invoke(
+                app, ["driving_range", "--cycles", "5", "--max-cycles", "9"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "driving_range", max_cycles=9, pause_seconds=60,
+            monitor_interval=3600, no_dashboard=False,
+        )
+
 
 class TestChampionshipCommand:
     def test_command_exists(self) -> None:
@@ -924,6 +1004,36 @@ class TestChampionshipCommand:
 
         mock_loop.assert_called_once_with(
             "championship", max_cycles=1, pause_seconds=60,
+            monitor_interval=3600, no_dashboard=False,
+        )
+
+    def test_default_cycles_is_400(self) -> None:
+        """Without --cycles, the new bounded default (400) is passed through."""
+        with (
+            patch("gimmes.cli._championship_gate"),
+            patch("gimmes.cli._set_mode"),
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+        ):
+            result = runner.invoke(app, ["championship"])
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "championship", max_cycles=400, pause_seconds=60,
+            monitor_interval=3600, no_dashboard=False,
+        )
+
+    def test_max_cycles_alias_works(self) -> None:
+        """The --max-cycles alias is accepted and passes through to max_cycles."""
+        with (
+            patch("gimmes.cli._championship_gate"),
+            patch("gimmes.cli._set_mode"),
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+        ):
+            result = runner.invoke(app, ["championship", "--max-cycles", "7"])
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "championship", max_cycles=7, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
         )
 
@@ -1008,6 +1118,34 @@ class TestStartCommand:
 
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=1, pause_seconds=60,
+            no_dashboard=False,
+        )
+
+    def test_default_cycles_is_400(self) -> None:
+        """Without --cycles, the new bounded default (400) is passed through."""
+        with (
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            result = runner.invoke(app, ["start"])
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "driving_range", max_cycles=400, pause_seconds=60,
+            no_dashboard=False,
+        )
+
+    def test_max_cycles_alias_works(self) -> None:
+        """The --max-cycles alias is accepted and passes through to max_cycles."""
+        with (
+            patch("gimmes.cli._autonomous_loop") as mock_loop,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            result = runner.invoke(app, ["start", "--max-cycles", "7"])
+
+        assert result.exit_code == 0, result.output
+        mock_loop.assert_called_once_with(
+            "driving_range", max_cycles=7, pause_seconds=60,
             no_dashboard=False,
         )
 

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -185,9 +185,10 @@ class TestAutonomousLoop:
             _autonomous_loop("driving_range", max_cycles=0, pause_seconds=0)
 
         output = capsys.readouterr().out
-        assert "Unbounded run" in output
-        assert "#545" in output
-        assert "--max-cycles" in output
+        # Flatten rich's terminal-width line wrapping before substring checks.
+        flat = " ".join(output.split())
+        assert "Unbounded run" in flat
+        assert "Pass --max-cycles" in flat
 
     def test_no_warning_when_max_cycles_positive(self, capsys) -> None:  # type: ignore[no-untyped-def]
         """max_cycles>0 (bounded) does not print the unbounded-run warning."""
@@ -961,7 +962,7 @@ class TestDrivingRangeCommand:
         result = runner.invoke(app, ["driving_range", "--help"])
         assert result.exit_code == 0
         assert "--max-cycles" in result.output
-        assert "400" in result.output
+        assert "[default: 400]" in result.output
 
     def test_cycles_and_max_cycles_last_wins(self) -> None:
         """When both --cycles and --max-cycles are passed, the last value wins."""
@@ -1036,6 +1037,13 @@ class TestChampionshipCommand:
             "championship", max_cycles=7, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
         )
+
+    def test_help_documents_new_default_and_alias(self) -> None:
+        """`gimmes championship --help` mentions --max-cycles alias and default 400."""
+        result = runner.invoke(app, ["championship", "--help"])
+        assert result.exit_code == 0
+        assert "--max-cycles" in result.output
+        assert "[default: 400]" in result.output
 
 
 class TestSwitchCommand:
@@ -1148,6 +1156,13 @@ class TestStartCommand:
             "driving_range", max_cycles=7, pause_seconds=60,
             no_dashboard=False,
         )
+
+    def test_help_documents_new_default_and_alias(self) -> None:
+        """`gimmes start --help` mentions --max-cycles alias and default 400."""
+        result = runner.invoke(app, ["start", "--help"])
+        assert result.exit_code == 0
+        assert "--max-cycles" in result.output
+        assert "[default: 400]" in result.output
 
     def test_start_championship_requires_confirmation(self, monkeypatch) -> None:
         monkeypatch.setenv("GIMMES_MODE", "championship")


### PR DESCRIPTION
## Summary

The autonomous trading loop previously defaulted `--cycles` to `0` (unlimited) on the `start`, `driving_range`, and `championship` commands. Because each cycle spawns a fresh Opus session via `claude --agent`, a single unbounded run was enough to burn through the Anthropic Max plan cap silently — verified empirically (sessions per day: 13–17 manual → 58–103 once the loop was started → 0 after the cap kicked in).

This change:

- Sets the `--cycles` default to `400` on all three commands (~1 saturated trading day at 60s pause + 1h monitor interval).
- Adds `--max-cycles` as an alias for `--cycles` so the bound is named more clearly.
- Prints a yellow startup warning when `--cycles 0` is explicitly passed, suggesting `--max-cycles` or the daily-budget guardrail tracked in #545.
- Flips the function-level default in `_autonomous_loop` to match.

Closes #543.

## What changed

- `src/gimmes/cli.py` — three `typer.Option` defaults flipped, `--max-cycles` alias added, function default flipped, `else` branch added to the existing `Max cycles:` startup print.
- `tests/unit/test_autonomous_loop.py` — added 11 tests:
  - `TestAutonomousLoop`: `test_warns_when_max_cycles_zero`, `test_no_warning_when_max_cycles_positive`.
  - `TestStartCommand`, `TestDrivingRangeCommand`, `TestChampionshipCommand`: `test_default_cycles_is_400`, `test_max_cycles_alias_works` (each).
  - `TestDrivingRangeCommand`: `test_help_documents_new_default_and_alias`, `test_cycles_and_max_cycles_last_wins`.
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Changed`.

## Test plan

- [x] `uv run pytest tests/unit/test_autonomous_loop.py -k "default_cycles_is_400 or max_cycles_alias or warns_when_max_cycles_zero or no_warning_when_max_cycles or help_documents_new_default or cycles_and_max_cycles_last_wins or respects_max_cycles"` — 11 passed in 0.18s.
- [x] `uv run pytest tests/unit/test_autonomous_loop.py` — 124 passed, 1 pre-existing failure (`test_transient_api_error_triggers_backoff_and_retries`) verified on `main` and tracked separately as #547.
- [x] `uv run ruff check src/gimmes/cli.py tests/unit/test_autonomous_loop.py` — clean.

## Backward compatibility

`--cycles 0` continues to work; previous unlimited-mode users see only the new warning. `--max-cycles` is added as an alias, not a replacement. No removed options.