### PR TITLE
Default autonomous-loop agents to Sonnet 4.6 with Caddie Master override

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -1,6 +1,7 @@
 ---
 name: Caddie Master
 description: Orchestrates the autonomous trading pipeline — dispatches agents and manages cycle state
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -1,6 +1,7 @@
 ---
 name: Caddie
 description: Deep research and analysis on gimme candidates — produces probability estimates and GimmeScores
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -1,6 +1,7 @@
 ---
 name: Closer
 description: Validates, sizes, and executes trades for approved gimme candidates
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/.claude/agents/groundskeeper.md
+++ b/.claude/agents/groundskeeper.md
@@ -1,6 +1,7 @@
 ---
 name: Groundskeeper
 description: Reviews error logs after each cycle and escalates critical or recurring errors to GitHub issues
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -1,6 +1,7 @@
 ---
 name: Monitor
 description: Surveillance and journalism agent — watches open positions, writes field observations to the journal, and flags positions for Caddie Master review when price or news warrants attention
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/.claude/agents/scorecard.md
+++ b/.claude/agents/scorecard.md
@@ -1,6 +1,7 @@
 ---
 name: Scorecard
 description: Generates performance reports — P&L, win rate, edge accuracy, strategy metrics
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,6 +1,7 @@
 ---
 name: Scout
 description: Scans Kalshi markets for gimme candidates, quick-scores them, and produces a shortlist
+model: claude-sonnet-4-6
 tools:
   - Bash
   - Read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case at default 60s pause + 3600s monitor interval) to bound Claude API spend per run; pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning (#543)
+- Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. Override the Caddie Master subprocess globally with `gimmes config set model.default <id>` (e.g. `claude-opus-4-7`); for per-agent overrides (Scout, Caddie, etc.), edit the agent's frontmatter directly because Claude Code's sub-agent dispatch does not accept a runtime override from the parent (#544)
 
 ## [0.6.4] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case at default 60s pause + 3600s monitor interval) to bound Claude API spend per run; pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning (#543)
-- Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. Override the Caddie Master subprocess globally with `gimmes config set model.default <id>` (e.g. `claude-opus-4-7`); for per-agent overrides (Scout, Caddie, etc.), edit the agent's frontmatter directly because Claude Code's sub-agent dispatch does not accept a runtime override from the parent (#544)
+- Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. `gimmes config set model.default <id>` overrides the Caddie Master subprocess only; sub-agents still read their own frontmatter (edit those files for per-agent overrides). (#544)
 
 ## [0.6.4] - 2026-04-21
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3811,8 +3811,10 @@ def _autonomous_loop(
                 "--allowedTools",
                 "Bash,Read,Glob,Grep,Agent,WebSearch,WebFetch",
             ]
-            # Optional runtime model override for the Caddie Master subprocess.
-            # When unset, Claude Code reads the model from agent frontmatter.
+            # Optional runtime model override for the Caddie Master subprocess
+            # only. The six sub-agents (Scout, Caddie, Closer, Monitor,
+            # Groundskeeper, Scorecard) read their own frontmatter when
+            # dispatched, regardless of what is passed here.
             if config.model.default:
                 cmd.extend(["--model", config.model.default])
             try:

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3802,17 +3802,22 @@ def _autonomous_loop(
             env["GIMMES_CYCLE"] = str(cycle)
             env["GIMMES_CYCLE_TYPE"] = cycle_type
             log_path = logs_dir / f"cycle-{cycle:03d}.json"
+            cmd = [
+                claude_path,
+                "--agent", "Caddie Master",
+                "-p", cycle_prompt,
+                "--verbose",
+                "--output-format", "stream-json",
+                "--allowedTools",
+                "Bash,Read,Glob,Grep,Agent,WebSearch,WebFetch",
+            ]
+            # Optional runtime model override for the Caddie Master subprocess.
+            # When unset, Claude Code reads the model from agent frontmatter.
+            if config.model.default:
+                cmd.extend(["--model", config.model.default])
             try:
                 proc = subprocess.Popen(
-                    [
-                        claude_path,
-                        "--agent", "Caddie Master",
-                        "-p", cycle_prompt,
-                        "--verbose",
-                        "--output-format", "stream-json",
-                        "--allowedTools",
-                        "Bash,Read,Glob,Grep,Agent,WebSearch,WebFetch",
-                    ],
+                    cmd,
                     env=env,
                     cwd=project_root,
                     stdout=subprocess.PIPE,

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -885,6 +885,72 @@ class ScoringConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Model selection (autonomous-loop overrides)
+# ---------------------------------------------------------------------------
+
+KNOWN_MODELS: tuple[str, ...] = (
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "claude-haiku-4-5",
+)
+
+
+class ModelConfig(BaseModel):
+    """Runtime model override for the Caddie Master subprocess.
+
+    Default behavior: every autonomous-loop agent reads its own ``model:``
+    field from ``.claude/agents/<name>.md`` (set to ``claude-sonnet-4-6``
+    after #544). The Claude CLI accepts either short aliases (``sonnet``,
+    ``opus``, ``haiku``) or fully-qualified ids (``claude-sonnet-4-6``,
+    ``claude-opus-4-7``); the fully-qualified form is used here to pin
+    versions explicitly.
+
+    Setting ``model.default`` adds ``--model <id>`` to the top-level
+    ``Caddie Master`` subprocess invocation in :func:`_autonomous_loop`,
+    overriding the Caddie Master frontmatter for that run. This affects
+    only the Caddie Master process — the six sub-agents (Scout, Caddie,
+    Closer, Monitor, Groundskeeper, Scorecard) continue to read their own
+    frontmatter, because Claude Code's sub-agent dispatch does not accept
+    a runtime override from the parent. To override a sub-agent at runtime,
+    edit ``.claude/agents/<name>.md`` directly.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "section_name": "Model Selection",
+            "section_description": (
+                "Runtime override for the top-level Caddie Master subprocess.\n"
+                "Per-agent overrides are done by editing\n"
+                ".claude/agents/<name>.md directly."
+            ),
+            "section_order": 8,
+        },
+    )
+
+    default: str | None = Field(
+        default=None,
+        json_schema_extra={
+            "display_name": "Default model override",
+            "description": (
+                "If set, passes --model <id> to the Caddie Master subprocess.\n"
+                "None means honor each agent's frontmatter."
+            ),
+            "choices": [None, *KNOWN_MODELS],
+        },
+    )
+
+    @model_validator(mode="after")
+    def _validate_model_id(self) -> ModelConfig:
+        if self.default is not None and self.default not in KNOWN_MODELS:
+            raise ValueError(
+                f"model.default={self.default!r} not in {KNOWN_MODELS}; "
+                "edit .claude/agents/<name>.md directly for an unlisted model"
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
 # Main config
 # ---------------------------------------------------------------------------
 
@@ -909,6 +975,7 @@ class GimmesConfig(BaseModel):
     orders: OrdersConfig = Field(default_factory=OrdersConfig)
     scanner: ScannerConfig = Field(default_factory=ScannerConfig)
     scoring: ScoringConfig = Field(default_factory=ScoringConfig)
+    model: ModelConfig = Field(default_factory=ModelConfig)
 
     # Database
     db_path: Path = Field(default_factory=lambda: GIMMES_HOME / "gimmes.db")
@@ -997,6 +1064,7 @@ CONFIG_SECTIONS: list[tuple[str, type[BaseModel]]] = [
     ("orders", OrdersConfig),
     ("scanner", ScannerConfig),
     ("scoring", ScoringConfig),
+    ("model", ModelConfig),
 ]
 
 
@@ -1123,4 +1191,5 @@ def load_config(db_path: Path | None = None) -> GimmesConfig:
         orders=OrdersConfig(**overrides.get("orders", {})),
         scanner=ScannerConfig(**overrides.get("scanner", {})),
         scoring=ScoringConfig(**overrides.get("scoring", {})),
+        model=ModelConfig(**overrides.get("model", {})),
     )

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -898,21 +898,16 @@ KNOWN_MODELS: tuple[str, ...] = (
 class ModelConfig(BaseModel):
     """Runtime model override for the Caddie Master subprocess.
 
-    Default behavior: every autonomous-loop agent reads its own ``model:``
-    field from ``.claude/agents/<name>.md`` (set to ``claude-sonnet-4-6``
-    after #544). The Claude CLI accepts either short aliases (``sonnet``,
-    ``opus``, ``haiku``) or fully-qualified ids (``claude-sonnet-4-6``,
-    ``claude-opus-4-7``); the fully-qualified form is used here to pin
-    versions explicitly.
-
-    Setting ``model.default`` adds ``--model <id>`` to the top-level
-    ``Caddie Master`` subprocess invocation in :func:`_autonomous_loop`,
-    overriding the Caddie Master frontmatter for that run. This affects
-    only the Caddie Master process — the six sub-agents (Scout, Caddie,
-    Closer, Monitor, Groundskeeper, Scorecard) continue to read their own
-    frontmatter, because Claude Code's sub-agent dispatch does not accept
-    a runtime override from the parent. To override a sub-agent at runtime,
-    edit ``.claude/agents/<name>.md`` directly.
+    Setting ``model.default`` adds ``--model <id>`` to the Caddie Master
+    subprocess in :func:`_autonomous_loop`. The six sub-agents (Scout,
+    Caddie, Closer, Monitor, Groundskeeper, Scorecard) continue to read
+    their own frontmatter at dispatch time — Claude Code's sub-agent
+    tool does not accept a runtime model override from the parent. To
+    override a sub-agent at runtime, edit ``.claude/agents/<name>.md``
+    directly. To restore Caddie Master to its frontmatter default,
+    run ``gimmes config set model.default claude-sonnet-4-6`` (matches
+    Caddie Master's frontmatter, so the explicit ``--model`` becomes a
+    no-op). Only the ids in :data:`KNOWN_MODELS` are accepted.
     """
 
     model_config = ConfigDict(
@@ -920,8 +915,8 @@ class ModelConfig(BaseModel):
         json_schema_extra={
             "section_name": "Model Selection",
             "section_description": (
-                "Runtime override for the top-level Caddie Master subprocess.\n"
-                "Per-agent overrides are done by editing\n"
+                "Runtime override for the Caddie Master subprocess only.\n"
+                "Sub-agent overrides require editing\n"
                 ".claude/agents/<name>.md directly."
             ),
             "section_order": 8,
@@ -931,12 +926,11 @@ class ModelConfig(BaseModel):
     default: str | None = Field(
         default=None,
         json_schema_extra={
-            "display_name": "Default model override",
+            "display_name": "Caddie Master model override",
             "description": (
-                "If set, passes --model <id> to the Caddie Master subprocess.\n"
-                "None means honor each agent's frontmatter."
+                "Passes --model <id> to the Caddie Master subprocess only."
             ),
-            "choices": [None, *KNOWN_MODELS],
+            "choices": list(KNOWN_MODELS),
         },
     )
 

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -202,6 +202,51 @@ class TestAutonomousLoop:
         output = capsys.readouterr().out
         assert "Unbounded run" not in output
 
+    def test_no_model_flag_when_default_unset(self) -> None:
+        """When config.model.default is None, --model is not passed to claude."""
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        cmd = mock_popen.call_args.args[0]
+        assert "--model" not in cmd
+
+    def test_model_flag_passed_when_default_set(self) -> None:
+        """When config.model.default is set, --model <id> is passed to claude."""
+        from gimmes import cli as gimmes_cli
+        from gimmes.config import ModelConfig
+
+        original_load_config = gimmes_cli.load_config
+
+        def patched_load_config(*args, **kwargs):  # type: ignore[no-untyped-def]
+            cfg = original_load_config(*args, **kwargs)
+            return cfg.model_copy(
+                update={"model": ModelConfig(default="claude-opus-4-7")},
+            )
+
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=patched_load_config),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        cmd = mock_popen.call_args.args[0]
+        assert "--model" in cmd
+        assert cmd[cmd.index("--model") + 1] == "claude-opus-4-7"
+
     def test_passes_correct_claude_args(self) -> None:
         mock_proc = _mock_popen()
         with (
@@ -1593,6 +1638,42 @@ class TestCaddieMasterAgent:
         assert "name: Caddie Master" in content
         assert "tools:" in content
         assert "Agent" in content
+
+
+class TestAutonomousLoopAgentModels:
+    """All 7 autonomous-loop agents pin Sonnet 4.6 in their frontmatter (#544)."""
+
+    AGENTS_DIR = (
+        Path(__file__).resolve().parent.parent.parent / ".claude" / "agents"
+    )
+    EXPECTED_MODEL = "claude-sonnet-4-6"
+
+    @pytest.mark.parametrize(
+        "agent_file",
+        [
+            "caddie-master.md",
+            "scout.md",
+            "caddie.md",
+            "closer.md",
+            "monitor.md",
+            "groundskeeper.md",
+            "scorecard.md",
+        ],
+    )
+    def test_agent_pins_sonnet_4_6(self, agent_file: str) -> None:
+        # Match the frontmatter `model:` field exactly (whitespace-tolerant,
+        # value-anchored). A loose substring check would silently pass on
+        # `model: sonnet-4-6-old` or break on `model:  sonnet-4-6` — neither
+        # is what we want for a value Claude CLI parses.
+        import re
+
+        text = (self.AGENTS_DIR / agent_file).read_text()
+        assert text.startswith("---\n"), f"{agent_file}: missing frontmatter"
+        end = text.index("\n---", 4)
+        frontmatter = text[4:end]
+        match = re.search(r"^model:\s+(\S+)\s*$", frontmatter, re.MULTILINE)
+        assert match is not None, f"{agent_file}: no `model:` field"
+        assert match.group(1) == self.EXPECTED_MODEL
 
 
 class TestCheckCodeStaleness:

--- a/tests/unit/test_config_set.py
+++ b/tests/unit/test_config_set.py
@@ -199,6 +199,53 @@ class TestConfigSet:
         assert "80" in result.output
 
 
+class TestModelConfig:
+    """Tests for the new model.* config keys (#544)."""
+
+    def test_set_model_default_round_trips(self, db_file: Path) -> None:
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(
+                app, ["config", "set", "model.default", "claude-opus-4-7"],
+            )
+        assert result.exit_code == 0
+        assert "claude-opus-4-7" in result.output
+
+        conn = sqlite3.connect(str(db_file))
+        row = conn.execute(
+            "SELECT value FROM config WHERE key = 'model.default'",
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert json.loads(row[0]) == "claude-opus-4-7"
+
+    def test_get_model_default_after_set(self, db_file: Path) -> None:
+        """`config get model.default` returns the value just written."""
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            runner.invoke(
+                app, ["config", "set", "model.default", "claude-opus-4-7"],
+            )
+            result = runner.invoke(app, ["config", "get", "model.default"])
+        assert result.exit_code == 0
+        assert "claude-opus-4-7" in result.output
+
+    def test_set_model_default_rejects_unknown_id(self, db_file: Path) -> None:
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(
+                app, ["config", "set", "model.default", "gpt-5"],
+            )
+        assert result.exit_code == 1
+
+    def test_set_model_default_rejects_empty_string(
+        self, db_file: Path,
+    ) -> None:
+        """Empty string is not a valid model id; validator must reject."""
+        with patch("gimmes.config.GIMMES_HOME", db_file.parent):
+            result = runner.invoke(
+                app, ["config", "set", "model.default", ""],
+            )
+        assert result.exit_code == 1
+
+
 class TestConfigGet:
     def test_get_single_key(self, db_file: Path) -> None:
         conn = sqlite3.connect(str(db_file))

--- a/tests/unit/test_config_wizard.py
+++ b/tests/unit/test_config_wizard.py
@@ -193,6 +193,25 @@ class TestParseInput:
         with pytest.raises(ValueError, match="Must be one of"):
             _parse_input("c", s)
 
+    def test_parse_str_invalid_choice_uses_actual_model_default_setting(self) -> None:
+        """Regression: model.default's choices list must be all-strings.
+
+        Previously included `None` to signal "unset is allowed" — that broke
+        the error formatting in this very function (`', '.join(choices)`
+        TypeErrors on a None element). Pin the contract: deriving the Setting
+        from ModelConfig and feeding an unknown id produces the expected
+        "Must be one of: ..." ValueError, not a TypeError.
+        """
+        from gimmes.config import ModelConfig
+        from gimmes.config_wizard import _field_to_setting
+
+        field_info = ModelConfig.model_fields["default"]
+        setting = _field_to_setting("model", "default", field_info)
+        assert setting is not None, "model.default did not produce a Setting"
+
+        with pytest.raises(ValueError, match="Must be one of"):
+            _parse_input("not-a-real-model-id", setting)
+
     def test_parse_list(self) -> None:
         s = Setting(key="a.b", name="", description="", type="list", default=[])
         result = _parse_input("KXCPI, KXGDP, KXFED", s)


### PR DESCRIPTION
## Summary

Pin `model: claude-sonnet-4-6` in the frontmatter of all 7 autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard). Combined with #543's bounded `--cycles` default, this is the second of three planned cost-control changes to keep the autonomous loop comfortably inside the Anthropic Max plan ($545 is the third). Sonnet 4.6 is competitive with Opus 4.7 on the non-code reasoning the loop actually does (probability estimation, GimmeScore synthesis, light web research) at roughly a tenth of the per-token cost.

Adds a `model.default` config knob that injects `--model <id>` into the Caddie Master subprocess in `_autonomous_loop`. This is the global escape hatch — `gimmes config set model.default claude-opus-4-7` flips the loop back to Opus without editing files.

Closes #544.

## Scope decision: per-agent CLI fields

The original issue spec also asked for per-agent CLI overrides (`gimmes config set model.scout claude-opus-4-7`). I left these out: Claude Code's sub-agent dispatch reads each sub-agent's frontmatter `model:` field at dispatch time and **does not accept a runtime override from the parent process**. Adding `model.scout` / `model.caddie` / etc. as config fields would record state that does not change runtime behavior — misleading UX.

The supported per-agent override path is editing the agent's frontmatter file directly. The CHANGELOG and the `ModelConfig` docstring make this explicit.

If you want the per-agent fields anyway (e.g. for tooling visibility or as a hint propagated via env var that future Claude Code releases might honor), happy to add them as a follow-up.

## What changed

- **`.claude/agents/{caddie-master,scout,caddie,closer,monitor,groundskeeper,scorecard}.md`** — added `model: claude-sonnet-4-6` between `description:` and `tools:`.
- **`src/gimmes/config.py`** — `KNOWN_MODELS` tuple + `ModelConfig` Pydantic submodel (single field `default: str | None` + validator) + `model: ModelConfig` on `GimmesConfig` + `("model", ModelConfig)` in `CONFIG_SECTIONS` + `model=ModelConfig(**overrides.get("model", {}))` in `load_config()`.
- **`src/gimmes/cli.py`** — `_autonomous_loop` extracts the Caddie Master subprocess command list to a `cmd` variable and conditionally appends `["--model", config.model.default]` when set.
- **`CHANGELOG.md`** — entry under `## [Unreleased]` → `### Changed`, including the per-agent caveat.

Fully-qualified model ids (`claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5`) are used everywhere — verified that the short unprefixed forms (`sonnet-4-6`, `opus-4-7`) are NOT accepted by the Claude CLI (returns HTTP 404 against the Anthropic API). The `KNOWN_MODELS` validator in `ModelConfig` enforces this at config-write time.

## Test plan

- [x] `uv run pytest tests/unit/test_autonomous_loop.py::TestAutonomousLoopAgentModels` — 7 parametrized cases, one per agent file, parses frontmatter and asserts `model: claude-sonnet-4-6`.
- [x] `uv run pytest tests/unit/test_autonomous_loop.py::TestAutonomousLoop -k "model_flag"` — 2 cases verifying `--model` appears on Caddie Master `subprocess.Popen` cmd args when `config.model.default` is set, and is absent when unset.
- [x] `uv run pytest tests/unit/test_config_set.py::TestModelConfig` — 4 cases: `set` round-trip, `get` after `set`, rejection of unknown id, rejection of empty string.
- [x] `uv run ruff check` on all changed files — clean.
- [ ] Manual smoke: `gimmes driving_range --cycles 1` runs without 404 against the live Claude CLI (deferred to merge — happy to re-run in CI before merge if there's a runner with the binary).

## Risk level

**Medium** — touches the model identifier passed to every `claude` invocation in the autonomous loop. The frontmatter pin is the load-bearing change; if the chosen id were rejected by Claude Code, every cycle would fail. Mitigation: the `KNOWN_MODELS` validator is anchored to identifiers I've verified accept against the live `claude --help` documentation, and the test suite asserts the canonical id in frontmatter.

## Backward compatibility

- No removed config keys or CLI flags.
- Users with no `model.default` set see no behavior change beyond the frontmatter switch (which is the cost-savings target).
- Users running outside the autonomous loop (`gimmes caddie_shop`, `gimmes pro`, `gimmes starter`) continue to use whatever model their globally-configured Claude defaults to — those agents are intentionally out of scope for this PR.