### PR TITLE
Add daily Claude API budget guardrail to autonomous loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Daily Claude API budget guardrail for the autonomous loop. Per-cycle token usage is parsed from each `claude` subprocess output, accumulated into `${GIMMES_HOME}/budget.json` keyed by UTC date, and checked against two caps before each cycle: a session-count cap (`--max-sessions-per-day`, default 80) and a USD cost cap (`--max-daily-cost-usd`, default $25). When either cap is hit the loop logs a warning and sleeps until the next UTC midnight, then resumes automatically. New `gimmes budget` CLI command shows today's running totals and remaining headroom. (#545)
+
 ### Changed
 - Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case at default 60s pause + 3600s monitor interval) to bound Claude API spend per run; pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning (#543)
 - Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. `gimmes config set model.default <id>` overrides the Caddie Master subprocess only; sub-agents still read their own frontmatter (edit those files for per-agent overrides). (#544)

--- a/README.md
+++ b/README.md
@@ -401,11 +401,14 @@ simultaneously:
 - `--max-daily-cost-usd X` (default $25) — estimated dollar cost per UTC day, computed per cycle from the `usage` block in each subprocess's stream-json output multiplied by the model's per-million-token rate.
 
 State is persisted to `${GIMMES_HOME}/budget.json` so it survives loop
-restarts. When either cap is hit, the loop prints a yellow warning and
-sleeps until the next UTC midnight, at which point the day's counters
+restarts. When either cap is hit, the loop prints a red `BUDGET CAP HIT`
+banner, sends an iMessage push when `GIMMES_NOTIFY_PHONE` is set in the
+environment, writes a `cycle-NNN-block.json` entry to `${GIMMES_HOME}/logs/`,
+and sleeps until the next UTC midnight, at which point the day's counters
 roll over and trading resumes automatically. Pass `0` for either flag to
 disable that cap. Inspect today's totals and remaining headroom with
-`gimmes budget` (`gimmes budget --json` for machine-readable output).
+`gimmes budget` (`gimmes budget --json` for machine-readable output, which
+also includes the active caps and seconds until reset).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,22 @@ gimmes championship      # Autonomous loop -- real money (auto-starts dashboard)
 
 All three accept `--cycles N` (alias `--max-cycles N`; default 400 ≈ one trading day, pass `0` for unbounded with a startup warning), `--pause N` (seconds between full cycles, default 60), `--monitor-interval N` (seconds between monitor-only cycles outside trade windows, default 3600), and `--no-dashboard`.
 
+### Daily Claude API budget cap
+
+The autonomous loop enforces a UTC-day budget cap on Claude API usage to keep
+runs from blowing through Anthropic's rate plan. Two cap types apply
+simultaneously:
+
+- `--max-sessions-per-day N` (default 80) — number of `claude` subprocesses spawned per UTC day.
+- `--max-daily-cost-usd X` (default $25) — estimated dollar cost per UTC day, computed per cycle from the `usage` block in each subprocess's stream-json output multiplied by the model's per-million-token rate.
+
+State is persisted to `${GIMMES_HOME}/budget.json` so it survives loop
+restarts. When either cap is hit, the loop prints a yellow warning and
+sleeps until the next UTC midnight, at which point the day's counters
+roll over and trading resumes automatically. Pass `0` for either flag to
+disable that cap. Inspect today's totals and remaining headroom with
+`gimmes budget` (`gimmes budget --json` for machine-readable output).
+
 ---
 
 ## Gimme criteria

--- a/src/gimmes/budget.py
+++ b/src/gimmes/budget.py
@@ -1,0 +1,345 @@
+"""Daily Claude API budget guardrail for the autonomous trading loop.
+
+See GitHub issue #545. The autonomous loop spawns one ``claude`` subprocess
+per cycle; without a guardrail, a single multi-day run can burn through
+the Anthropic Max plan cap silently. This module:
+
+- Persists per-UTC-day token + cost totals to ``${GIMMES_HOME}/budget.json``.
+- Parses the ``usage`` block from each cycle's ``stream-json`` stdout.
+- Exposes ``BudgetTracker.should_block()`` so the loop can sleep until the
+  next UTC midnight when either the session-count cap or the dollar cap is
+  reached for the current day.
+
+The module is intentionally fail-open on input parsing (a malformed cycle
+returns ``None`` from :func:`parse_usage_from_stream_json` rather than
+raising — the loop should treat this as "skip accounting" and keep going)
+but fail-closed on the cap (an unknown model falls back to the Sonnet
+pricing rather than recording $0). Both policies preserve the safety-net
+goal: the cap should be conservative, not an additional crash surface.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, time, timedelta
+from pathlib import Path
+
+logger = logging.getLogger("gimmes.budget")
+
+# USD per 1 million tokens. Anthropic public list pricing.
+PRICING: dict[str, dict[str, float]] = {
+    "claude-sonnet-4-6": {
+        "input": 3.0,
+        "output": 15.0,
+        "cache_creation": 3.75,
+        "cache_read": 0.30,
+    },
+    "claude-opus-4-7": {
+        "input": 15.0,
+        "output": 75.0,
+        "cache_creation": 18.75,
+        "cache_read": 1.50,
+    },
+    "claude-haiku-4-5": {
+        "input": 1.0,
+        "output": 5.0,
+        "cache_creation": 1.25,
+        "cache_read": 0.10,
+    },
+}
+
+DEFAULT_MAX_SESSIONS = 80
+DEFAULT_MAX_USD = 25.0
+SCHEMA_VERSION = 1
+RETAIN_DAYS = 30
+
+# Models the tracker has already complained about — keeps the WARNING log
+# from spamming once Claude rotates to a new model id we don't have rates
+# for. Reset between processes (cleared on import).
+_warned_models: set[str] = set()
+
+
+@dataclass(frozen=True)
+class DaySummary:
+    """A single UTC-day's accumulated Claude-API consumption."""
+
+    date: str
+    sessions: int = 0
+    cost_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+
+
+def cost_from_usage(usage: dict, model_id: str) -> float:
+    """Compute USD cost for a single cycle's usage block.
+
+    Falls back to Sonnet rates if ``model_id`` is unknown — the cap is a
+    budget guardrail, so it must keep producing a number even when models
+    rotate. Logs a one-time **error** per unknown id (not warning — silent
+    underestimation of a 5×-cost model would be the worst-case regression
+    of this safety net).
+    """
+    rates = PRICING.get(model_id)
+    if rates is None:
+        if model_id not in _warned_models:
+            logger.error(
+                "budget: unknown model %r — falling back to Sonnet pricing."
+                " Update PRICING in src/gimmes/budget.py to track real cost.",
+                model_id,
+            )
+            _warned_models.add(model_id)
+        rates = PRICING["claude-sonnet-4-6"]
+    return (
+        rates["input"] * usage.get("input_tokens", 0)
+        + rates["output"] * usage.get("output_tokens", 0)
+        + rates["cache_creation"] * usage.get("cache_creation_input_tokens", 0)
+        + rates["cache_read"] * usage.get("cache_read_input_tokens", 0)
+    ) / 1_000_000
+
+
+def parse_usage_from_stream_json(stdout: bytes) -> dict | None:
+    """Extract the ``usage`` block from a Claude Code stream-json stdout.
+
+    Iterates events in reverse and returns the first parseable ``usage``
+    dict found on a ``type: result`` (or ``type: assistant`` with a
+    message-level usage) event. Fail-open: returns ``None`` on empty
+    stdout, malformed JSON, or missing fields.
+    """
+    if not stdout:
+        return None
+    for raw in reversed(stdout.strip().split(b"\n")):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        # Direct usage on result envelope
+        usage = event.get("usage")
+        if isinstance(usage, dict) and "input_tokens" in usage:
+            return usage
+        # Nested usage on assistant message envelope
+        msg = event.get("message")
+        if isinstance(msg, dict):
+            usage = msg.get("usage")
+            if isinstance(usage, dict) and "input_tokens" in usage:
+                return usage
+    return None
+
+
+def _default_clock() -> datetime:
+    """Module-level default clock — extracted from BudgetTracker so the
+    dataclass field can use a non-lambda default for clarity."""
+    return datetime.now(UTC)
+
+
+@dataclass
+class BudgetTracker:
+    """Per-UTC-day Claude API budget tracker with atomic persistence.
+
+    Single-writer safe: the in-process lock + atomic file rename guarantee
+    that concurrent ``record_cycle`` calls from threads in the same process
+    never produce lost updates. **Multi-process safety is not provided** —
+    if two autonomous loops run concurrently against the same
+    ``budget.json``, last-writer-wins on the read-modify-write may drop
+    counter increments. The intended deployment is one loop per host.
+    """
+
+    path: Path
+    max_sessions: int = DEFAULT_MAX_SESSIONS
+    max_cost_usd: float = DEFAULT_MAX_USD
+    clock: Callable[[], datetime] = _default_clock
+    _write_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False,
+    )
+
+    def _today_key(self) -> str:
+        return self.clock().date().isoformat()
+
+    def _read_state(self) -> dict:
+        """Read budget.json, recovering gracefully from missing/corrupt."""
+        if not self.path.exists():
+            return {"version": SCHEMA_VERSION, "days": {}}
+        try:
+            text = self.path.read_text()
+            data = json.loads(text)
+        except (OSError, json.JSONDecodeError) as exc:
+            archive = self.path.with_suffix(
+                f".corrupt.{int(self.clock().timestamp())}",
+            )
+            with contextlib.suppress(OSError):
+                self.path.replace(archive)
+            logger.warning(
+                "budget: %s unreadable (%s) — archived to %s, starting fresh",
+                self.path, exc, archive,
+            )
+            return {"version": SCHEMA_VERSION, "days": {}}
+        if not isinstance(data, dict) or data.get("version") != SCHEMA_VERSION:
+            logger.warning(
+                "budget: %s has unknown schema version %r — treating as fresh",
+                self.path, data.get("version") if isinstance(data, dict) else None,
+            )
+            return {"version": SCHEMA_VERSION, "days": {}}
+        if not isinstance(data.get("days"), dict):
+            data["days"] = {}
+        return data
+
+    def _atomic_write(self, data: dict) -> None:
+        """Atomic write via unique tempfile + os.replace; fsync before rename.
+
+        Uses :func:`tempfile.mkstemp` so concurrent writers get distinct
+        temp paths (fixed-clock test harnesses or rapid successive writes
+        within the same microsecond would otherwise collide).
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=self.path.name + ".tmp.",
+            dir=str(self.path.parent),
+        )
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(data, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, self.path)
+        except Exception:
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            raise
+
+    def _prune(self, data: dict) -> None:
+        """Drop day entries older than RETAIN_DAYS days."""
+        cutoff = (self.clock().date() - timedelta(days=RETAIN_DAYS)).isoformat()
+        data["days"] = {
+            k: v for k, v in data["days"].items() if k >= cutoff
+        }
+
+    def today(self) -> DaySummary:
+        """Return today's accumulated summary (zero-valued if no entries)."""
+        return self.summary_for_date(self._today_key())
+
+    def summary_for_date(self, date_str: str) -> DaySummary:
+        """Return the accumulated summary for an arbitrary UTC date.
+
+        Used by ``gimmes budget --days N`` to render trailing days without
+        having to swap the tracker's ``clock`` (which is reserved for
+        current-time semantics like ``secs_until_reset`` / pruning).
+        """
+        data = self._read_state()
+        entry = data["days"].get(date_str, {})
+        return DaySummary(
+            date=date_str,
+            sessions=int(entry.get("sessions", 0)),
+            cost_usd=float(entry.get("cost_usd", 0.0)),
+            input_tokens=int(entry.get("input_tokens", 0)),
+            output_tokens=int(entry.get("output_tokens", 0)),
+            cache_creation_tokens=int(entry.get("cache_creation_tokens", 0)),
+            cache_read_tokens=int(entry.get("cache_read_tokens", 0)),
+        )
+
+    def caps_in_effect(self) -> tuple[int, float]:
+        """Return the caps that the loop most recently persisted.
+
+        Falls back to this tracker's own ``max_sessions`` / ``max_cost_usd``
+        when ``budget.json`` does not yet record them (first run).
+        """
+        data = self._read_state()
+        caps = data.get("caps", {})
+        return (
+            int(caps.get("max_sessions", self.max_sessions)),
+            float(caps.get("max_cost_usd", self.max_cost_usd)),
+        )
+
+    def should_block(self) -> tuple[bool, str | None]:
+        """Return ``(blocked, reason)`` where reason ∈ {'sessions', 'cost', None}.
+
+        A cap of ``0`` is treated as "unlimited" — matches ``--cycles 0``
+        semantics from #543.
+        """
+        summary = self.today()
+        if self.max_sessions > 0 and summary.sessions >= self.max_sessions:
+            return True, "sessions"
+        if self.max_cost_usd > 0 and summary.cost_usd >= self.max_cost_usd:
+            return True, "cost"
+        return False, None
+
+    def secs_until_reset(self) -> int:
+        """Seconds until the next UTC midnight (when day key rolls over)."""
+        now = self.clock()
+        tomorrow = (now + timedelta(days=1)).date()
+        midnight = datetime.combine(tomorrow, time.min, tzinfo=UTC)
+        return max(0, int((midnight - now).total_seconds()))
+
+    def record_cycle(self, usage: dict, model_id: str) -> DaySummary:
+        """Add one cycle's usage to today's totals; persists atomically.
+
+        The in-process lock prevents lost updates from concurrent threads
+        in the same process — important for tests and any future
+        concurrency. See class docstring for multi-process caveats.
+        """
+        cost = cost_from_usage(usage, model_id)
+        with self._write_lock:
+            data = self._read_state()
+            self._prune(data)
+            data["caps"] = {
+                "max_sessions": self.max_sessions,
+                "max_cost_usd": self.max_cost_usd,
+            }
+            key = self._today_key()
+            entry = data["days"].setdefault(key, {})
+            entry["sessions"] = int(entry.get("sessions", 0)) + 1
+            entry["cost_usd"] = round(
+                float(entry.get("cost_usd", 0.0)) + cost, 6,
+            )
+            entry["input_tokens"] = int(entry.get("input_tokens", 0)) + int(
+                usage.get("input_tokens", 0),
+            )
+            entry["output_tokens"] = int(entry.get("output_tokens", 0)) + int(
+                usage.get("output_tokens", 0),
+            )
+            entry["cache_creation_tokens"] = int(
+                entry.get("cache_creation_tokens", 0),
+            ) + int(usage.get("cache_creation_input_tokens", 0))
+            entry["cache_read_tokens"] = int(
+                entry.get("cache_read_tokens", 0),
+            ) + int(usage.get("cache_read_input_tokens", 0))
+            self._atomic_write(data)
+        return self.today()
+
+    def format_status_line(self) -> str:
+        """One-line status for the loop's startup banner / periodic prints."""
+        s = self.today()
+        s_cap = "∞" if self.max_sessions == 0 else str(self.max_sessions)
+        c_cap = "∞" if self.max_cost_usd == 0 else f"${self.max_cost_usd:.2f}"
+        return (
+            f"Budget {s.date}: {s.sessions}/{s_cap} sessions, "
+            f"${s.cost_usd:.2f}/{c_cap}"
+        )
+
+    def alert_message(self, reason: str) -> str:
+        """Human-readable cap-hit message for console + iMessage alerts."""
+        s = self.today()
+        if reason == "sessions":
+            return (
+                f"Daily session cap reached: {s.sessions}/{self.max_sessions}"
+                f" (${s.cost_usd:.2f}). Sleeping until UTC midnight."
+            )
+        if reason == "cost":
+            return (
+                f"Daily cost cap reached: ${s.cost_usd:.2f}/${self.max_cost_usd:.2f}"
+                f" ({s.sessions} sessions). Sleeping until UTC midnight."
+            )
+        return f"Budget cap reached: {reason}. Sleeping until UTC midnight."

--- a/src/gimmes/budget.py
+++ b/src/gimmes/budget.py
@@ -122,7 +122,10 @@ def parse_usage_from_stream_json(stdout: bytes) -> dict | None:
             continue
         try:
             event = json.loads(raw)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # ``json.loads`` accepts bytes but raises UnicodeDecodeError on
+            # invalid UTF-8 — non-UTF-8 terminal noise must not crash the
+            # loop's accounting path.
             continue
         if not isinstance(event, dict):
             continue
@@ -140,8 +143,10 @@ def parse_usage_from_stream_json(stdout: bytes) -> dict | None:
 
 
 def _default_clock() -> datetime:
-    """Module-level default clock — extracted from BudgetTracker so the
-    dataclass field can use a non-lambda default for clarity."""
+    """Module-level default clock. Tests monkey-patch this to freeze time;
+    :class:`BudgetTracker` resolves it lazily per-call (rather than capturing
+    a reference at instantiation) so a patched ``_default_clock`` takes
+    effect for trackers already in flight."""
     return datetime.now(UTC)
 
 
@@ -160,13 +165,25 @@ class BudgetTracker:
     path: Path
     max_sessions: int = DEFAULT_MAX_SESSIONS
     max_cost_usd: float = DEFAULT_MAX_USD
-    clock: Callable[[], datetime] = _default_clock
+    # ``None`` = use module-level :func:`_default_clock` (resolved lazily).
+    # Pass an explicit callable in tests to freeze time deterministically.
+    clock: Callable[[], datetime] | None = None
     _write_lock: threading.Lock = field(
         default_factory=threading.Lock, init=False, repr=False,
     )
 
+    def _now(self) -> datetime:
+        return (self.clock or _default_clock)()
+
+    def today_date(self) -> str:
+        """Public accessor for today's UTC date string (the same one
+        :meth:`today` uses to look up state). Useful for callers that
+        need a tracker-consistent "today" reference without re-deriving
+        from a separate clock source."""
+        return self._today_key()
+
     def _today_key(self) -> str:
-        return self.clock().date().isoformat()
+        return self._now().date().isoformat()
 
     def _read_state(self) -> dict:
         """Read budget.json, recovering gracefully from missing/corrupt."""
@@ -177,7 +194,7 @@ class BudgetTracker:
             data = json.loads(text)
         except (OSError, json.JSONDecodeError) as exc:
             archive = self.path.with_suffix(
-                f".corrupt.{int(self.clock().timestamp())}",
+                f".corrupt.{int(self._now().timestamp())}",
             )
             with contextlib.suppress(OSError):
                 self.path.replace(archive)
@@ -222,7 +239,7 @@ class BudgetTracker:
 
     def _prune(self, data: dict) -> None:
         """Drop day entries older than RETAIN_DAYS days."""
-        cutoff = (self.clock().date() - timedelta(days=RETAIN_DAYS)).isoformat()
+        cutoff = (self._now().date() - timedelta(days=RETAIN_DAYS)).isoformat()
         data["days"] = {
             k: v for k, v in data["days"].items() if k >= cutoff
         }
@@ -278,10 +295,38 @@ class BudgetTracker:
 
     def secs_until_reset(self) -> int:
         """Seconds until the next UTC midnight (when day key rolls over)."""
-        now = self.clock()
+        now = self._now()
         tomorrow = (now + timedelta(days=1)).date()
         midnight = datetime.combine(tomorrow, time.min, tzinfo=UTC)
         return max(0, int((midnight - now).total_seconds()))
+
+    def _apply_record(
+        self, data: dict, usage: dict, cost: float,
+    ) -> None:
+        """Mutate ``data`` in place to record one cycle. Caller holds lock."""
+        self._prune(data)
+        data["caps"] = {
+            "max_sessions": self.max_sessions,
+            "max_cost_usd": self.max_cost_usd,
+        }
+        key = self._today_key()
+        entry = data["days"].setdefault(key, {})
+        entry["sessions"] = int(entry.get("sessions", 0)) + 1
+        entry["cost_usd"] = round(
+            float(entry.get("cost_usd", 0.0)) + cost, 6,
+        )
+        entry["input_tokens"] = int(entry.get("input_tokens", 0)) + int(
+            usage.get("input_tokens", 0),
+        )
+        entry["output_tokens"] = int(entry.get("output_tokens", 0)) + int(
+            usage.get("output_tokens", 0),
+        )
+        entry["cache_creation_tokens"] = int(
+            entry.get("cache_creation_tokens", 0),
+        ) + int(usage.get("cache_creation_input_tokens", 0))
+        entry["cache_read_tokens"] = int(
+            entry.get("cache_read_tokens", 0),
+        ) + int(usage.get("cache_read_input_tokens", 0))
 
     def record_cycle(self, usage: dict, model_id: str) -> DaySummary:
         """Add one cycle's usage to today's totals; persists atomically.
@@ -293,31 +338,36 @@ class BudgetTracker:
         cost = cost_from_usage(usage, model_id)
         with self._write_lock:
             data = self._read_state()
-            self._prune(data)
+            self._apply_record(data, usage, cost)
+            self._atomic_write(data)
+        return self.today()
+
+    def record_session_no_usage(self) -> DaySummary:
+        """Record one cycle that produced no parseable ``usage`` block.
+
+        Anthropic charges for the cycle either way, so the session count
+        must reflect that the subprocess ran. The dollar cost stays at $0
+        for this cycle (we couldn't measure it) — this is conservative
+        for the session cap and intentionally lossy for the cost cap.
+        """
+        with self._write_lock:
+            data = self._read_state()
+            self._apply_record(data, {}, 0.0)
+            self._atomic_write(data)
+        return self.today()
+
+    def persist_caps(self) -> None:
+        """Write the tracker's current caps to ``budget.json`` without
+        recording a session. Lets ``gimmes budget`` show the true caps
+        even before the first cycle runs.
+        """
+        with self._write_lock:
+            data = self._read_state()
             data["caps"] = {
                 "max_sessions": self.max_sessions,
                 "max_cost_usd": self.max_cost_usd,
             }
-            key = self._today_key()
-            entry = data["days"].setdefault(key, {})
-            entry["sessions"] = int(entry.get("sessions", 0)) + 1
-            entry["cost_usd"] = round(
-                float(entry.get("cost_usd", 0.0)) + cost, 6,
-            )
-            entry["input_tokens"] = int(entry.get("input_tokens", 0)) + int(
-                usage.get("input_tokens", 0),
-            )
-            entry["output_tokens"] = int(entry.get("output_tokens", 0)) + int(
-                usage.get("output_tokens", 0),
-            )
-            entry["cache_creation_tokens"] = int(
-                entry.get("cache_creation_tokens", 0),
-            ) + int(usage.get("cache_creation_input_tokens", 0))
-            entry["cache_read_tokens"] = int(
-                entry.get("cache_read_tokens", 0),
-            ) + int(usage.get("cache_read_input_tokens", 0))
             self._atomic_write(data)
-        return self.today()
 
     def format_status_line(self) -> str:
         """One-line status for the loop's startup banner / periodic prints."""

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2036,7 +2036,6 @@ def budget(
 ) -> None:
     """Show today's Claude API budget consumption against caps (#545)."""
     import json as _json
-    from datetime import UTC as _UTC
     from datetime import datetime as _datetime
     from datetime import timedelta as _td
 
@@ -2056,11 +2055,21 @@ def budget(
     # before any cycle has been recorded).
     effective_max_sessions, effective_max_usd = tracker.caps_in_effect()
 
-    today = _datetime.now(_UTC).date()
+    # Use the tracker's own clock so this command stays consistent with
+    # the loop's view of "today" — important when tests freeze the clock.
+    today = _datetime.fromisoformat(tracker.today_date()).date()
     summaries = [
         tracker.summary_for_date((today - _td(days=offset)).isoformat())
         for offset in range(days)
     ]
+
+    secs = tracker.secs_until_reset()
+
+    # ``0`` is treated as "unlimited" by the loop (matches --cycles 0
+    # semantics); render that as "∞" / null in the diagnostic so the
+    # operator doesn't see "0 / 0" and assume the budget is exhausted.
+    sess_cap_str = "∞" if effective_max_sessions == 0 else str(effective_max_sessions)
+    cost_cap_str = "∞" if effective_max_usd == 0 else f"${effective_max_usd:.2f}"
 
     if json_out:
         out = [
@@ -2072,38 +2081,60 @@ def budget(
                 "output_tokens": s.output_tokens,
                 "cache_creation_tokens": s.cache_creation_tokens,
                 "cache_read_tokens": s.cache_read_tokens,
+                "max_sessions": (
+                    None if effective_max_sessions == 0
+                    else effective_max_sessions
+                ),
+                "max_cost_usd": (
+                    None if effective_max_usd == 0 else effective_max_usd
+                ),
+                "remaining_sessions": (
+                    None if effective_max_sessions == 0
+                    else max(0, effective_max_sessions - s.sessions)
+                ),
+                "remaining_cost_usd": (
+                    None if effective_max_usd == 0
+                    else round(max(0.0, effective_max_usd - s.cost_usd), 4)
+                ),
+                "seconds_until_reset": secs,
             }
             for s in summaries
         ]
         console.print(_json.dumps(out, indent=2))
         return
 
-    secs = tracker.secs_until_reset()
     h, rem = divmod(secs, 3600)
     m, _ = divmod(rem, 60)
     for s in summaries:
-        sess_pct = (
-            (s.sessions / effective_max_sessions) * 100
-            if effective_max_sessions > 0 else 0
+        sess_pct_str = (
+            f" ({(s.sessions / effective_max_sessions) * 100:.0f}%)"
+            if effective_max_sessions > 0 else ""
         )
-        cost_pct = (
-            (s.cost_usd / effective_max_usd) * 100
-            if effective_max_usd > 0 else 0
+        cost_pct_str = (
+            f" ({(s.cost_usd / effective_max_usd) * 100:.0f}%)"
+            if effective_max_usd > 0 else ""
         )
         console.print(f"[bold]Claude API Budget — {s.date} (UTC)[/bold]")
         console.print(
-            f"  Sessions:  {s.sessions} / {effective_max_sessions}"
-            f"   ({sess_pct:.0f}%)"
+            f"  Sessions:  {s.sessions} / {sess_cap_str}{sess_pct_str}"
         )
         console.print(
-            f"  Cost:      ${s.cost_usd:.2f} / ${effective_max_usd:.2f}"
-            f"   ({cost_pct:.0f}%)"
+            f"  Cost:      ${s.cost_usd:.2f} / {cost_cap_str}{cost_pct_str}"
         )
-        remaining_sessions = max(0, effective_max_sessions - s.sessions)
-        remaining_cost = max(0.0, effective_max_usd - s.cost_usd)
-        console.print(
-            f"  Remaining: {remaining_sessions} sessions, ${remaining_cost:.2f}"
-        )
+        if effective_max_sessions == 0 and effective_max_usd == 0:
+            console.print("  Remaining: unlimited")
+        else:
+            remaining_sessions = (
+                "∞" if effective_max_sessions == 0
+                else str(max(0, effective_max_sessions - s.sessions))
+            )
+            remaining_cost = (
+                "∞" if effective_max_usd == 0
+                else f"${max(0.0, effective_max_usd - s.cost_usd):.2f}"
+            )
+            console.print(
+                f"  Remaining: {remaining_sessions} sessions, {remaining_cost}"
+            )
         console.print(
             f"  Tokens:    in={s.input_tokens:,}  out={s.output_tokens:,}"
             f"  cache_create={s.cache_creation_tokens:,}"
@@ -3697,10 +3728,12 @@ def _autonomous_loop(
         console.print(f"Max cycles: {max_cycles}")
     else:
         console.print(
-            "[yellow]Warning: Unbounded run -- no Claude API budget will be"
-            " enforced. Pass --max-cycles N to bound the run"
-            f" (e.g. --max-cycles {DEFAULT_AUTONOMOUS_CYCLES} for"
-            " ~1 trading day).[/yellow]"
+            "[yellow]Warning: Unbounded run -- the per-process --cycles"
+            " cap is disabled. The daily Claude API budget cap from #545"
+            " (--max-sessions-per-day / --max-daily-cost-usd) still"
+            " applies and will halt the loop at UTC midnight on cap hit."
+            f" Pass --max-cycles {DEFAULT_AUTONOMOUS_CYCLES} for ~1 trading"
+            " day if you also want a per-process bound.[/yellow]"
         )
     console.print("Press Ctrl+C to stop\n")
 
@@ -3726,6 +3759,10 @@ def _autonomous_loop(
             else max_daily_cost_usd
         ),
     )
+    # Persist the live caps immediately so `gimmes budget` shows the
+    # operator's actual limits even if the loop blocks before the first
+    # cycle records anything.
+    budget_tracker.persist_caps()
     console.print(f"[dim]{budget_tracker.format_status_line()}[/dim]\n")
 
     cycle = get_max_global_cycle(config.db_path)
@@ -3847,6 +3884,7 @@ def _autonomous_loop(
             blocked, reason = budget_tracker.should_block()
             if blocked:
                 import contextlib as _contextlib
+                import json as _json_mod
                 import logging as _stdlib_logging
                 import subprocess as _subprocess
                 msg = budget_tracker.alert_message(reason or "")
@@ -3858,6 +3896,25 @@ def _autonomous_loop(
                     "budget cap hit: %s — sleeping %ds until UTC midnight",
                     reason, secs,
                 )
+                # Persist a cycle-log entry so a remote operator can see
+                # *why* the loop slept even if they were not attached to
+                # the console. Cap-blocked iterations don't increment the
+                # ``cycle`` counter, so include a UTC-second suffix to
+                # avoid clobbering prior block logs when the loop wakes
+                # early and re-enters the same blocked slot.
+                with _contextlib.suppress(OSError):
+                    _ts = int(budget_tracker._now().timestamp())
+                    _block_log = (
+                        logs_dir
+                        / f"cycle-{cycle:03d}-block-{_ts}.json"
+                    )
+                    _block_log.write_text(_json_mod.dumps({
+                        "type": "budget_cap_block",
+                        "reason": reason,
+                        "message": msg,
+                        "seconds_until_reset": secs,
+                        "status": budget_tracker.format_status_line(),
+                    }))
                 # Best-effort iMessage push via osascript (matches the
                 # bin/monitor.sh pattern). Failures are silenced — the
                 # console + log are the primary signal; iMessage is a
@@ -4020,11 +4077,12 @@ def _autonomous_loop(
                 returncode = proc.returncode
 
                 # --- Per-cycle Claude API usage accounting (#545) ---
-                # Anthropic charges for tokens regardless of cycle outcome
-                # (rate-limit, error, success), so record on every cycle
-                # that has a parseable usage block. Fail-open: a missing
-                # or malformed usage block skips accounting for this cycle
-                # rather than crashing the loop.
+                # Anthropic charges for tokens regardless of cycle outcome,
+                # so always increment the session count once the subprocess
+                # has spawned. When the usage block is parseable, record
+                # full token + dollar cost; otherwise count the session
+                # only (cost stays at $0 for that cycle — conservative for
+                # the session cap, intentionally lossy for the cost cap).
                 _usage = parse_usage_from_stream_json(stdout_bytes)
                 if _usage is not None:
                     budget_tracker.record_cycle(
@@ -4033,9 +4091,11 @@ def _autonomous_loop(
                             config.model.default or "claude-sonnet-4-6"
                         ),
                     )
-                    console.print(
-                        f"[dim]{budget_tracker.format_status_line()}[/dim]"
-                    )
+                else:
+                    budget_tracker.record_session_no_usage()
+                console.print(
+                    f"[dim]{budget_tracker.format_status_line()}[/dim]"
+                )
 
                 # --- Rate limit detection ---
                 is_rate_limited, rl_pause = _detect_rate_limit(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2024,6 +2024,95 @@ def log_error(
     _run(_log())
 
 
+@app.command(name="budget", rich_help_panel="Diagnostics")
+def budget(
+    days: int = typer.Option(
+        1, "--days", "-d", min=1, max=30,
+        help="Show last N UTC days (default 1: today only).",
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of a table.",
+    ),
+) -> None:
+    """Show today's Claude API budget consumption against caps (#545)."""
+    import json as _json
+    from datetime import UTC as _UTC
+    from datetime import datetime as _datetime
+    from datetime import timedelta as _td
+
+    from gimmes.budget import (
+        DEFAULT_MAX_SESSIONS,
+        DEFAULT_MAX_USD,
+        BudgetTracker,
+    )
+    from gimmes.config import GIMMES_HOME
+
+    tracker = BudgetTracker(
+        path=GIMMES_HOME / "budget.json",
+        max_sessions=DEFAULT_MAX_SESSIONS,
+        max_cost_usd=DEFAULT_MAX_USD,
+    )
+    # Display the caps the loop most recently used (falls back to defaults
+    # before any cycle has been recorded).
+    effective_max_sessions, effective_max_usd = tracker.caps_in_effect()
+
+    today = _datetime.now(_UTC).date()
+    summaries = [
+        tracker.summary_for_date((today - _td(days=offset)).isoformat())
+        for offset in range(days)
+    ]
+
+    if json_out:
+        out = [
+            {
+                "date": s.date,
+                "sessions": s.sessions,
+                "cost_usd": round(s.cost_usd, 4),
+                "input_tokens": s.input_tokens,
+                "output_tokens": s.output_tokens,
+                "cache_creation_tokens": s.cache_creation_tokens,
+                "cache_read_tokens": s.cache_read_tokens,
+            }
+            for s in summaries
+        ]
+        console.print(_json.dumps(out, indent=2))
+        return
+
+    secs = tracker.secs_until_reset()
+    h, rem = divmod(secs, 3600)
+    m, _ = divmod(rem, 60)
+    for s in summaries:
+        sess_pct = (
+            (s.sessions / effective_max_sessions) * 100
+            if effective_max_sessions > 0 else 0
+        )
+        cost_pct = (
+            (s.cost_usd / effective_max_usd) * 100
+            if effective_max_usd > 0 else 0
+        )
+        console.print(f"[bold]Claude API Budget — {s.date} (UTC)[/bold]")
+        console.print(
+            f"  Sessions:  {s.sessions} / {effective_max_sessions}"
+            f"   ({sess_pct:.0f}%)"
+        )
+        console.print(
+            f"  Cost:      ${s.cost_usd:.2f} / ${effective_max_usd:.2f}"
+            f"   ({cost_pct:.0f}%)"
+        )
+        remaining_sessions = max(0, effective_max_sessions - s.sessions)
+        remaining_cost = max(0.0, effective_max_usd - s.cost_usd)
+        console.print(
+            f"  Remaining: {remaining_sessions} sessions, ${remaining_cost:.2f}"
+        )
+        console.print(
+            f"  Tokens:    in={s.input_tokens:,}  out={s.output_tokens:,}"
+            f"  cache_create={s.cache_creation_tokens:,}"
+            f"  cache_read={s.cache_read_tokens:,}"
+        )
+        console.print(f"  Resets in: {h}h {m}m (UTC midnight)")
+        console.print()
+
+
 @app.command(name="errors", rich_help_panel="Diagnostics")
 def errors(
     severity: str | None = typer.Option(None, "--severity", "-s", help="Filter by severity"),
@@ -3031,6 +3120,18 @@ def start(
     no_dashboard: bool = typer.Option(
         False, "--no-dashboard", help="Disable auto-start of Clubhouse dashboard",
     ),
+    max_sessions_per_day: int = typer.Option(
+        None, "--max-sessions-per-day", min=0,
+        help=(
+            "Daily Claude session cap (UTC). 0=unlimited. Default 80."
+        ),
+    ),
+    max_daily_cost_usd: float = typer.Option(
+        None, "--max-daily-cost-usd", min=0.0,
+        help=(
+            "Daily Claude API cost cap in USD (UTC). 0=unlimited. Default $25."
+        ),
+    ),
 ) -> None:
     """Start autonomous trading loop using the current mode from .env."""
     config = load_config()
@@ -3040,8 +3141,12 @@ def start(
     if config.is_championship:
         _championship_gate(config)
 
-    _autonomous_loop(mode_val, max_cycles=cycles, pause_seconds=pause,
-                     no_dashboard=no_dashboard)
+    _autonomous_loop(
+        mode_val, max_cycles=cycles, pause_seconds=pause,
+        no_dashboard=no_dashboard,
+        max_sessions_per_day=max_sessions_per_day,
+        max_daily_cost_usd=max_daily_cost_usd,
+    )
 
 
 def _kill_process_group(proc: subprocess.Popen[bytes]) -> None:
@@ -3491,6 +3596,8 @@ def _autonomous_loop(
     monitor_interval: int = 3600,
     no_dashboard: bool = False,
     max_consecutive_failures: int = 5,
+    max_sessions_per_day: int | None = None,
+    max_daily_cost_usd: float | None = None,
 ) -> None:
     """Run the Caddie Master orchestrator agent via claude --agent in a loop.
 
@@ -3596,6 +3703,30 @@ def _autonomous_loop(
             " ~1 trading day).[/yellow]"
         )
     console.print("Press Ctrl+C to stop\n")
+
+    # --- Daily Claude API budget guardrail (#545) ---
+    from gimmes.budget import (
+        DEFAULT_MAX_SESSIONS,
+        DEFAULT_MAX_USD,
+        BudgetTracker,
+        parse_usage_from_stream_json,
+    )
+    from gimmes.config import GIMMES_HOME
+
+    budget_tracker = BudgetTracker(
+        path=GIMMES_HOME / "budget.json",
+        max_sessions=(
+            DEFAULT_MAX_SESSIONS
+            if max_sessions_per_day is None
+            else max_sessions_per_day
+        ),
+        max_cost_usd=(
+            DEFAULT_MAX_USD
+            if max_daily_cost_usd is None
+            else max_daily_cost_usd
+        ),
+    )
+    console.print(f"[dim]{budget_tracker.format_status_line()}[/dim]\n")
 
     cycle = get_max_global_cycle(config.db_path)
     cycles_run = 0
@@ -3712,6 +3843,43 @@ def _autonomous_loop(
             return False, None
 
         while max_cycles == 0 or cycles_run < max_cycles:
+            # --- Daily budget guardrail (#545) ---
+            blocked, reason = budget_tracker.should_block()
+            if blocked:
+                import contextlib as _contextlib
+                import logging as _stdlib_logging
+                import subprocess as _subprocess
+                msg = budget_tracker.alert_message(reason or "")
+                secs = budget_tracker.secs_until_reset()
+                console.print(
+                    f"[red bold]BUDGET CAP HIT ({reason}): {msg}[/red bold]"
+                )
+                _stdlib_logging.getLogger("gimmes").warning(
+                    "budget cap hit: %s — sleeping %ds until UTC midnight",
+                    reason, secs,
+                )
+                # Best-effort iMessage push via osascript (matches the
+                # bin/monitor.sh pattern). Failures are silenced — the
+                # console + log are the primary signal; iMessage is a
+                # convenience for remote operators. Set GIMMES_NOTIFY_PHONE
+                # in the env to enable.
+                _phone = os.environ.get("GIMMES_NOTIFY_PHONE")
+                if _phone:
+                    with _contextlib.suppress(Exception):
+                        _subprocess.run(
+                            [
+                                "osascript", "-e",
+                                f'tell application "Messages" to send'
+                                f' "GIMMES BUDGET CAP: {msg}" to participant'
+                                f' "{_phone}"',
+                            ],
+                            check=False, timeout=5,
+                            stdout=_subprocess.DEVNULL,
+                            stderr=_subprocess.DEVNULL,
+                        )
+                _resilient_sleep(secs)
+                continue
+
             cycle += 1
             cycles_run += 1
 
@@ -3851,6 +4019,24 @@ def _autonomous_loop(
                 sys.stdout.buffer.flush()
                 returncode = proc.returncode
 
+                # --- Per-cycle Claude API usage accounting (#545) ---
+                # Anthropic charges for tokens regardless of cycle outcome
+                # (rate-limit, error, success), so record on every cycle
+                # that has a parseable usage block. Fail-open: a missing
+                # or malformed usage block skips accounting for this cycle
+                # rather than crashing the loop.
+                _usage = parse_usage_from_stream_json(stdout_bytes)
+                if _usage is not None:
+                    budget_tracker.record_cycle(
+                        _usage,
+                        model_id=(
+                            config.model.default or "claude-sonnet-4-6"
+                        ),
+                    )
+                    console.print(
+                        f"[dim]{budget_tracker.format_status_line()}[/dim]"
+                    )
+
                 # --- Rate limit detection ---
                 is_rate_limited, rl_pause = _detect_rate_limit(
                     stdout_bytes,
@@ -3966,11 +4152,27 @@ def driving_range(
     no_dashboard: bool = typer.Option(
         False, "--no-dashboard", help="Disable auto-start of Clubhouse dashboard",
     ),
+    max_sessions_per_day: int = typer.Option(
+        None, "--max-sessions-per-day", min=0,
+        help=(
+            "Daily Claude session cap (UTC). 0=unlimited. Default 80."
+        ),
+    ),
+    max_daily_cost_usd: float = typer.Option(
+        None, "--max-daily-cost-usd", min=0.0,
+        help=(
+            "Daily Claude API cost cap in USD (UTC). 0=unlimited. Default $25."
+        ),
+    ),
 ) -> None:
     """Switch to Driving Range mode and start autonomous trading loop (paper trading)."""
     _set_mode("driving_range")
-    _autonomous_loop("driving_range", max_cycles=cycles, pause_seconds=pause,
-                     monitor_interval=monitor_interval, no_dashboard=no_dashboard)
+    _autonomous_loop(
+        "driving_range", max_cycles=cycles, pause_seconds=pause,
+        monitor_interval=monitor_interval, no_dashboard=no_dashboard,
+        max_sessions_per_day=max_sessions_per_day,
+        max_daily_cost_usd=max_daily_cost_usd,
+    )
 
 
 @app.command(name="championship", rich_help_panel="Autonomous Trading")
@@ -3991,13 +4193,29 @@ def championship(
     no_dashboard: bool = typer.Option(
         False, "--no-dashboard", help="Disable auto-start of Clubhouse dashboard",
     ),
+    max_sessions_per_day: int = typer.Option(
+        None, "--max-sessions-per-day", min=0,
+        help=(
+            "Daily Claude session cap (UTC). 0=unlimited. Default 80."
+        ),
+    ),
+    max_daily_cost_usd: float = typer.Option(
+        None, "--max-daily-cost-usd", min=0.0,
+        help=(
+            "Daily Claude API cost cap in USD (UTC). 0=unlimited. Default $25."
+        ),
+    ),
 ) -> None:
     """Switch to Championship mode and start autonomous trading loop (REAL MONEY)."""
     config = load_config()
     _championship_gate(config)
     _set_mode("championship")
-    _autonomous_loop("championship", max_cycles=cycles, pause_seconds=pause,
-                     monitor_interval=monitor_interval, no_dashboard=no_dashboard)
+    _autonomous_loop(
+        "championship", max_cycles=cycles, pause_seconds=pause,
+        monitor_interval=monitor_interval, no_dashboard=no_dashboard,
+        max_sessions_per_day=max_sessions_per_day,
+        max_daily_cost_usd=max_daily_cost_usd,
+    )
 
 
 @app.command(name="monitor", rich_help_panel="Diagnostics")

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -252,14 +252,17 @@ class TestAutonomousLoop:
         self, tmp_path: Path,
     ) -> None:
         """Pre-spawn budget check skips the cycle when session cap is hit (#545)."""
-        # Pre-populate budget.json at the cap.
+        # Freeze the tracker's clock so the seeded date and the loop's
+        # observed date can't diverge across a UTC midnight boundary.
+        _frozen = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
         from gimmes.config import GIMMES_HOME
         budget_path = GIMMES_HOME / "budget.json"
-        today = datetime.now(UTC).date().isoformat()
+        today = _frozen.date().isoformat()
         budget_path.parent.mkdir(parents=True, exist_ok=True)
         budget_path.write_text(_json.dumps({
             "version": 1,
             "days": {today: {"sessions": 5, "cost_usd": 0.0}},
+            "caps": {"max_sessions": 5, "max_cost_usd": 25.0},
         }))
 
         with (
@@ -267,6 +270,7 @@ class TestAutonomousLoop:
             patch("subprocess.Popen") as mock_popen,
             patch("gimmes.cli._resilient_sleep", side_effect=KeyboardInterrupt),
             patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.budget._default_clock", lambda: _frozen),
         ):
             _autonomous_loop(
                 "driving_range",
@@ -278,10 +282,84 @@ class TestAutonomousLoop:
         # Loop should hit pre-spawn block, sleep, get interrupted — never spawn.
         mock_popen.assert_not_called()
 
+    def test_loop_records_session_when_usage_unparseable(
+        self, tmp_path: Path,
+    ) -> None:
+        """If the stream-json stdout has no parseable usage, the cycle
+        still counts toward the session cap (Anthropic charged for it)."""
+        _frozen = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        from gimmes.config import GIMMES_HOME
+        budget_path = GIMMES_HOME / "budget.json"
+
+        # stdout with no parseable JSON / no usage block.
+        stream_json = b"random non-json terminal noise\n"
+        mock_proc = _mock_popen(returncode=0, output=stream_json)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                return_value=stream_json,
+            ),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.budget._default_clock", lambda: _frozen),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        assert budget_path.exists()
+        data = _json.loads(budget_path.read_text())
+        today = _frozen.date().isoformat()
+        entry = data["days"][today]
+        assert entry["sessions"] == 1
+        assert entry["cost_usd"] == 0.0
+        assert entry["input_tokens"] == 0
+
+    def test_loop_writes_block_log_on_cap_hit(self, tmp_path: Path) -> None:
+        """When the budget cap blocks the cycle, a cycle-NNN-block-*.json
+        log is written for remote operators."""
+        _frozen = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        from gimmes.config import GIMMES_HOME
+        budget_path = GIMMES_HOME / "budget.json"
+        logs_dir = GIMMES_HOME / "logs"
+        today = _frozen.date().isoformat()
+        budget_path.parent.mkdir(parents=True, exist_ok=True)
+        budget_path.write_text(_json.dumps({
+            "version": 1,
+            "days": {today: {"sessions": 5, "cost_usd": 0.0}},
+            "caps": {"max_sessions": 5, "max_cost_usd": 25.0},
+        }))
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch("gimmes.cli._resilient_sleep", side_effect=KeyboardInterrupt),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.budget._default_clock", lambda: _frozen),
+        ):
+            _autonomous_loop(
+                "driving_range",
+                max_cycles=1,
+                pause_seconds=0,
+                max_sessions_per_day=5,
+            )
+
+        mock_popen.assert_not_called()
+        # A block log should be written under logs/.
+        block_logs = list(logs_dir.glob("cycle-*-block-*.json"))
+        assert len(block_logs) == 1, (
+            f"Expected one block log, found {block_logs}"
+        )
+        block = _json.loads(block_logs[0].read_text())
+        assert block["type"] == "budget_cap_block"
+        assert block["reason"] == "sessions"
+        assert "seconds_until_reset" in block
+
     def test_loop_records_usage_after_successful_cycle(
         self, tmp_path: Path,
     ) -> None:
         """Loop parses usage from stream-json stdout and records to budget.json."""
+        _frozen = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
         from gimmes.config import GIMMES_HOME
         budget_path = GIMMES_HOME / "budget.json"
 
@@ -303,13 +381,14 @@ class TestAutonomousLoop:
                 return_value=stream_json,
             ),
             patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.budget._default_clock", lambda: _frozen),
         ):
             _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
 
         # 1M input tokens at Sonnet rate ($3/M) = $3 expected cost.
         assert budget_path.exists()
         data = _json.loads(budget_path.read_text())
-        today = datetime.now(UTC).date().isoformat()
+        today = _frozen.date().isoformat()
         assert today in data["days"]
         entry = data["days"][today]
         assert entry["sessions"] == 1

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json as _json
 import subprocess as _subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -246,6 +247,77 @@ class TestAutonomousLoop:
         cmd = mock_popen.call_args.args[0]
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "claude-opus-4-7"
+
+    def test_loop_blocks_when_session_cap_already_reached(
+        self, tmp_path: Path,
+    ) -> None:
+        """Pre-spawn budget check skips the cycle when session cap is hit (#545)."""
+        # Pre-populate budget.json at the cap.
+        from gimmes.config import GIMMES_HOME
+        budget_path = GIMMES_HOME / "budget.json"
+        today = datetime.now(UTC).date().isoformat()
+        budget_path.parent.mkdir(parents=True, exist_ok=True)
+        budget_path.write_text(_json.dumps({
+            "version": 1,
+            "days": {today: {"sessions": 5, "cost_usd": 0.0}},
+        }))
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch("gimmes.cli._resilient_sleep", side_effect=KeyboardInterrupt),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range",
+                max_cycles=1,
+                pause_seconds=0,
+                max_sessions_per_day=5,
+            )
+
+        # Loop should hit pre-spawn block, sleep, get interrupted — never spawn.
+        mock_popen.assert_not_called()
+
+    def test_loop_records_usage_after_successful_cycle(
+        self, tmp_path: Path,
+    ) -> None:
+        """Loop parses usage from stream-json stdout and records to budget.json."""
+        from gimmes.config import GIMMES_HOME
+        budget_path = GIMMES_HOME / "budget.json"
+
+        # Build a stream-json stdout with a usage block.
+        stream_json = (
+            b'{"type":"system","subtype":"init"}\n'
+            b'{"type":"result","is_error":false,"usage":'
+            b'{"input_tokens":1000000,"output_tokens":0,'
+            b'"cache_creation_input_tokens":0,'
+            b'"cache_read_input_tokens":0}}'
+        )
+        mock_proc = _mock_popen(returncode=0, output=stream_json)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                return_value=stream_json,
+            ),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        # 1M input tokens at Sonnet rate ($3/M) = $3 expected cost.
+        assert budget_path.exists()
+        data = _json.loads(budget_path.read_text())
+        today = datetime.now(UTC).date().isoformat()
+        assert today in data["days"]
+        entry = data["days"][today]
+        assert entry["sessions"] == 1
+        assert entry["cost_usd"] == pytest.approx(3.0, abs=1e-6)
+        # Token totals must accumulate too — guards the integration against
+        # a regression where cost is recorded but tokens are dropped.
+        assert entry["input_tokens"] == 1_000_000
+        assert entry["output_tokens"] == 0
 
     def test_passes_correct_claude_args(self) -> None:
         mock_proc = _mock_popen()
@@ -972,6 +1044,7 @@ class TestDrivingRangeCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=1, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_default_cycles_is_400(self) -> None:
@@ -986,6 +1059,7 @@ class TestDrivingRangeCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=400, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_max_cycles_alias_works(self) -> None:
@@ -1000,6 +1074,7 @@ class TestDrivingRangeCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=7, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_help_documents_new_default_and_alias(self) -> None:
@@ -1023,6 +1098,7 @@ class TestDrivingRangeCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=9, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
 
@@ -1051,6 +1127,7 @@ class TestChampionshipCommand:
         mock_loop.assert_called_once_with(
             "championship", max_cycles=1, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_default_cycles_is_400(self) -> None:
@@ -1066,6 +1143,7 @@ class TestChampionshipCommand:
         mock_loop.assert_called_once_with(
             "championship", max_cycles=400, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_max_cycles_alias_works(self) -> None:
@@ -1081,6 +1159,7 @@ class TestChampionshipCommand:
         mock_loop.assert_called_once_with(
             "championship", max_cycles=7, pause_seconds=60,
             monitor_interval=3600, no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_help_documents_new_default_and_alias(self) -> None:
@@ -1172,6 +1251,7 @@ class TestStartCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=1, pause_seconds=60,
             no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_default_cycles_is_400(self) -> None:
@@ -1186,6 +1266,7 @@ class TestStartCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=400, pause_seconds=60,
             no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_max_cycles_alias_works(self) -> None:
@@ -1200,6 +1281,7 @@ class TestStartCommand:
         mock_loop.assert_called_once_with(
             "driving_range", max_cycles=7, pause_seconds=60,
             no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
     def test_help_documents_new_default_and_alias(self) -> None:
@@ -1228,6 +1310,7 @@ class TestStartCommand:
         mock_loop.assert_called_once_with(
             "championship", max_cycles=1, pause_seconds=60,
             no_dashboard=False,
+            max_sessions_per_day=None, max_daily_cost_usd=None,
         )
 
 

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -127,6 +127,11 @@ class TestParseUsageFromStreamJson:
     def test_returns_none_on_only_malformed(self) -> None:
         assert parse_usage_from_stream_json(b"not json\n{also not json") is None
 
+    def test_returns_none_on_invalid_utf8_bytes(self) -> None:
+        """``json.loads`` raises ``UnicodeDecodeError`` on non-UTF-8 input —
+        the parser must absorb that to keep its fail-open contract."""
+        assert parse_usage_from_stream_json(b"\xff\xfe garbage\n") is None
+
     def test_returns_none_when_no_usage_in_any_event(self) -> None:
         events = [
             b'{"type":"system","subtype":"init"}',
@@ -373,6 +378,44 @@ class TestBudgetTracker:
             path=path, max_sessions=42, max_cost_usd=7.5,
         )
         assert tracker.caps_in_effect() == (42, 7.5)
+
+    def test_record_session_no_usage_increments_sessions_with_zero_cost(
+        self, tmp_path: Path,
+    ) -> None:
+        """When parser returns no usage, the cycle still counts toward
+        the session cap (Anthropic charged for it) at $0 attributed cost."""
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=tmp_path / "budget.json", clock=clock)
+        tracker.record_session_no_usage()
+        tracker.record_session_no_usage()
+        s = tracker.today()
+        assert s.sessions == 2
+        assert s.cost_usd == 0.0
+        assert s.input_tokens == 0
+        assert s.output_tokens == 0
+
+    def test_persist_caps_writes_caps_without_recording_session(
+        self, tmp_path: Path,
+    ) -> None:
+        """``persist_caps()`` makes the caps visible to ``gimmes budget``
+        before any cycle has run."""
+        path = tmp_path / "budget.json"
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=path, max_sessions=99, max_cost_usd=42.5, clock=clock,
+        )
+        tracker.persist_caps()
+        # File written, caps recorded, no session increment.
+        data = json.loads(path.read_text())
+        assert data["caps"]["max_sessions"] == 99
+        assert data["caps"]["max_cost_usd"] == 42.5
+        # No day entry created.
+        assert "2026-04-30" not in data.get("days", {})
+
+    def test_today_date_returns_iso_string(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=tmp_path / "budget.json", clock=clock)
+        assert tracker.today_date() == "2026-04-30"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -1,0 +1,453 @@
+"""Tests for gimmes.budget — daily Claude API budget guardrail (#545)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from gimmes.budget import (
+    DEFAULT_MAX_SESSIONS,
+    DEFAULT_MAX_USD,
+    PRICING,
+    BudgetTracker,
+    DaySummary,
+    _warned_models,
+    cost_from_usage,
+    parse_usage_from_stream_json,
+)
+
+
+def _fixed_clock(when: datetime):
+    return lambda: when
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_models():
+    _warned_models.clear()
+    yield
+    _warned_models.clear()
+
+
+# ---------------------------------------------------------------------------
+# Pricing + cost helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPricingTable:
+    def test_known_models_present(self) -> None:
+        assert "claude-sonnet-4-6" in PRICING
+        assert "claude-opus-4-7" in PRICING
+        assert "claude-haiku-4-5" in PRICING
+
+    def test_each_pricing_entry_has_all_categories(self) -> None:
+        required = {"input", "output", "cache_creation", "cache_read"}
+        for model, rates in PRICING.items():
+            assert required.issubset(rates.keys()), (
+                f"{model} missing categories"
+            )
+
+
+class TestCostFromUsage:
+    def test_sonnet_cost(self) -> None:
+        usage = {
+            "input_tokens": 1_000_000,
+            "output_tokens": 500_000,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        # 1M * $3 + 0.5M * $15 = $3 + $7.5 = $10.5
+        assert cost_from_usage(usage, "claude-sonnet-4-6") == pytest.approx(
+            10.5, abs=1e-6,
+        )
+
+    def test_opus_cost_with_cache(self) -> None:
+        usage = {
+            "input_tokens": 100_000,
+            "output_tokens": 50_000,
+            "cache_creation_input_tokens": 200_000,
+            "cache_read_input_tokens": 1_000_000,
+        }
+        # 0.1M*15 + 0.05M*75 + 0.2M*18.75 + 1M*1.5 = 1.5 + 3.75 + 3.75 + 1.5 = 10.5
+        assert cost_from_usage(usage, "claude-opus-4-7") == pytest.approx(
+            10.5, abs=1e-6,
+        )
+
+    def test_unknown_model_falls_back_to_sonnet(self, caplog) -> None:
+        usage = {"input_tokens": 1_000_000, "output_tokens": 0}
+        cost = cost_from_usage(usage, "claude-future-99")
+        assert cost == pytest.approx(3.0, abs=1e-6)
+        assert "claude-future-99" in _warned_models
+
+    def test_unknown_model_warns_only_once(self, caplog) -> None:
+        usage = {"input_tokens": 1_000_000}
+        cost_from_usage(usage, "claude-future-99")
+        cost_from_usage(usage, "claude-future-99")
+        cost_from_usage(usage, "claude-future-99")
+        # Set membership confirms only one entry across multiple calls.
+        assert len([m for m in _warned_models if m == "claude-future-99"]) == 1
+
+    def test_zero_usage_yields_zero_cost(self) -> None:
+        assert cost_from_usage({}, "claude-sonnet-4-6") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Stream-JSON parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseUsageFromStreamJson:
+    def test_extracts_from_result_event(self) -> None:
+        events = [
+            b'{"type":"system","subtype":"init"}',
+            b'{"type":"assistant","message":{"id":"x"}}',
+            b'{"type":"result","is_error":false,"usage":{"input_tokens":1234,"output_tokens":99,"cache_creation_input_tokens":0,"cache_read_input_tokens":5000}}',
+        ]
+        usage = parse_usage_from_stream_json(b"\n".join(events))
+        assert usage is not None
+        assert usage["input_tokens"] == 1234
+        assert usage["output_tokens"] == 99
+        assert usage["cache_read_input_tokens"] == 5000
+
+    def test_extracts_from_assistant_message_envelope(self) -> None:
+        events = [
+            b'{"type":"system","subtype":"init"}',
+            b'{"type":"assistant","message":{"usage":{"input_tokens":42,"output_tokens":7}}}',
+        ]
+        usage = parse_usage_from_stream_json(b"\n".join(events))
+        assert usage is not None
+        assert usage["input_tokens"] == 42
+
+    def test_returns_none_on_empty_stdout(self) -> None:
+        assert parse_usage_from_stream_json(b"") is None
+
+    def test_returns_none_on_only_malformed(self) -> None:
+        assert parse_usage_from_stream_json(b"not json\n{also not json") is None
+
+    def test_returns_none_when_no_usage_in_any_event(self) -> None:
+        events = [
+            b'{"type":"system","subtype":"init"}',
+            b'{"type":"result","is_error":false}',
+        ]
+        assert parse_usage_from_stream_json(b"\n".join(events)) is None
+
+    def test_skips_malformed_lines_and_finds_later_usage(self) -> None:
+        events = [
+            b"corrupted line",
+            b'{"type":"result","is_error":false,"usage":{"input_tokens":1,"output_tokens":2}}',
+        ]
+        usage = parse_usage_from_stream_json(b"\n".join(events))
+        assert usage is not None
+        assert usage["input_tokens"] == 1
+
+
+# ---------------------------------------------------------------------------
+# BudgetTracker — caps, persistence, rollover
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetTracker:
+    def test_under_cap_does_not_block(self, tmp_path: Path) -> None:
+        tracker = BudgetTracker(path=tmp_path / "budget.json")
+        blocked, reason = tracker.should_block()
+        assert blocked is False
+        assert reason is None
+
+    def test_today_returns_zero_summary_when_no_state(
+        self, tmp_path: Path,
+    ) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=tmp_path / "budget.json", clock=clock)
+        s = tracker.today()
+        assert s == DaySummary(date="2026-04-30")
+
+    def test_record_cycle_persists_and_accumulates(
+        self, tmp_path: Path,
+    ) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=tmp_path / "budget.json", clock=clock)
+        usage = {
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        tracker.record_cycle(usage, "claude-sonnet-4-6")
+        tracker.record_cycle(usage, "claude-sonnet-4-6")
+        tracker.record_cycle(usage, "claude-sonnet-4-6")
+        s = tracker.today()
+        assert s.sessions == 3
+        assert s.cost_usd == pytest.approx(9.0, abs=1e-6)
+        assert s.input_tokens == 3_000_000
+
+    def test_session_cap_blocks(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json", max_sessions=2, clock=clock,
+        )
+        tracker.record_cycle({"input_tokens": 100}, "claude-sonnet-4-6")
+        tracker.record_cycle({"input_tokens": 100}, "claude-sonnet-4-6")
+        blocked, reason = tracker.should_block()
+        assert blocked is True
+        assert reason == "sessions"
+
+    def test_cost_cap_blocks(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json", max_cost_usd=5.0, clock=clock,
+        )
+        # 2M input tokens * $3/1M = $6 > $5 cap
+        tracker.record_cycle(
+            {"input_tokens": 2_000_000, "output_tokens": 0},
+            "claude-sonnet-4-6",
+        )
+        blocked, reason = tracker.should_block()
+        assert blocked is True
+        assert reason == "cost"
+
+    def test_zero_caps_are_treated_as_unlimited(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json",
+            max_sessions=0,
+            max_cost_usd=0.0,
+            clock=clock,
+        )
+        for _ in range(200):
+            tracker.record_cycle(
+                {"input_tokens": 10_000_000}, "claude-opus-4-7",
+            )
+        blocked, _ = tracker.should_block()
+        assert blocked is False
+
+    def test_midnight_rollover_resets_daily_totals(
+        self, tmp_path: Path,
+    ) -> None:
+        # Pre-populate at cap on day 1.
+        path = tmp_path / "budget.json"
+        clock_d1 = _fixed_clock(datetime(2026, 4, 30, 23, 59, tzinfo=UTC))
+        tracker_d1 = BudgetTracker(
+            path=path, max_sessions=2, clock=clock_d1,
+        )
+        tracker_d1.record_cycle({"input_tokens": 1}, "claude-sonnet-4-6")
+        tracker_d1.record_cycle({"input_tokens": 1}, "claude-sonnet-4-6")
+        assert tracker_d1.should_block() == (True, "sessions")
+
+        # Same file, advanced clock to next day.
+        clock_d2 = _fixed_clock(datetime(2026, 5, 1, 0, 1, tzinfo=UTC))
+        tracker_d2 = BudgetTracker(
+            path=path, max_sessions=2, clock=clock_d2,
+        )
+        s = tracker_d2.today()
+        assert s.date == "2026-05-01"
+        assert s.sessions == 0
+        blocked, reason = tracker_d2.should_block()
+        assert blocked is False
+        assert reason is None
+
+    def test_secs_until_reset_at_22h(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 22, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=tmp_path / "budget.json", clock=clock)
+        # 22:00 → next midnight is 02:00 later = 7200 s.
+        assert tracker.secs_until_reset() == 7200
+
+    def test_corrupt_budget_json_archived_and_recovered(
+        self, tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "budget.json"
+        path.write_text("{not valid json")
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=path, clock=clock)
+        s = tracker.today()
+        # Recovered to zeroed state.
+        assert s.sessions == 0
+        # Archive file present somewhere alongside.
+        archives = list(tmp_path.glob("budget.corrupt.*"))
+        assert len(archives) == 1
+
+    def test_unknown_schema_version_treated_as_fresh(
+        self, tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "budget.json"
+        path.write_text(json.dumps({"version": 999, "days": {"x": {}}}))
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=path, clock=clock)
+        assert tracker.today().sessions == 0
+
+    def test_pruning_drops_old_days(self, tmp_path: Path) -> None:
+        path = tmp_path / "budget.json"
+        # Pre-seed a 100-day-old entry.
+        old_data = {
+            "version": 1,
+            "days": {
+                "2026-01-01": {"sessions": 5, "cost_usd": 1.0},
+                "2026-04-30": {"sessions": 3, "cost_usd": 0.5},
+            },
+        }
+        path.write_text(json.dumps(old_data))
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=path, clock=clock)
+        tracker.record_cycle({"input_tokens": 100}, "claude-sonnet-4-6")
+        # Read back: old day pruned, today still present.
+        data = json.loads(path.read_text())
+        assert "2026-01-01" not in data["days"]
+        assert "2026-04-30" in data["days"]
+
+    def test_record_cycle_thread_safety(self, tmp_path: Path) -> None:
+        """Concurrent ``record_cycle`` calls from threads in the same process
+        must not lose updates — the in-process lock around the
+        read-modify-write guarantees ``sessions == n_threads * per_thread``.
+        """
+        path = tmp_path / "budget.json"
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(path=path, clock=clock)
+        n_threads = 4
+        per_thread = 10
+
+        def worker() -> None:
+            for _ in range(per_thread):
+                tracker.record_cycle(
+                    {"input_tokens": 1000}, "claude-sonnet-4-6",
+                )
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        s = tracker.today()
+        assert s.sessions == n_threads * per_thread, (
+            "In-process lock should prevent lost updates"
+        )
+        # File must be parseable.
+        json.loads(path.read_text())
+
+    def test_session_cap_blocks_when_jumped_past(
+        self, tmp_path: Path,
+    ) -> None:
+        """If state already shows sessions > cap (e.g. cap reduced after
+        prior records), ``should_block`` still returns True. Pins the ``>=``
+        semantics."""
+        path = tmp_path / "budget.json"
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        path.write_text(json.dumps({
+            "version": 1,
+            "days": {"2026-04-30": {"sessions": 81, "cost_usd": 0.0}},
+        }))
+        tracker = BudgetTracker(
+            path=path, max_sessions=80, clock=clock,
+        )
+        blocked, reason = tracker.should_block()
+        assert blocked is True
+        assert reason == "sessions"
+
+    def test_caps_in_effect_returns_persisted_caps(
+        self, tmp_path: Path,
+    ) -> None:
+        """``caps_in_effect`` reads the caps the loop persisted to budget.json."""
+        path = tmp_path / "budget.json"
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        # First tracker writes its caps via record_cycle.
+        writer = BudgetTracker(
+            path=path, max_sessions=200, max_cost_usd=99.0, clock=clock,
+        )
+        writer.record_cycle({"input_tokens": 1000}, "claude-sonnet-4-6")
+        # Second tracker reads them back — its own constructor caps differ.
+        reader = BudgetTracker(
+            path=path, max_sessions=80, max_cost_usd=25.0, clock=clock,
+        )
+        caps = reader.caps_in_effect()
+        assert caps == (200, 99.0)
+
+    def test_caps_in_effect_falls_back_to_own_caps_before_first_record(
+        self, tmp_path: Path,
+    ) -> None:
+        """Before any cycle is recorded, ``caps_in_effect`` returns the
+        tracker's own configured caps."""
+        path = tmp_path / "budget.json"
+        tracker = BudgetTracker(
+            path=path, max_sessions=42, max_cost_usd=7.5,
+        )
+        assert tracker.caps_in_effect() == (42, 7.5)
+
+
+# ---------------------------------------------------------------------------
+# Status formatters
+# ---------------------------------------------------------------------------
+
+
+class TestFormatters:
+    def test_status_line_includes_caps_and_date(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json",
+            max_sessions=80,
+            max_cost_usd=25.0,
+            clock=clock,
+        )
+        line = tracker.format_status_line()
+        assert "2026-04-30" in line
+        assert "0/80" in line
+        assert "$25.00" in line
+
+    def test_status_line_renders_unlimited_caps(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json",
+            max_sessions=0,
+            max_cost_usd=0.0,
+            clock=clock,
+        )
+        line = tracker.format_status_line()
+        assert "∞" in line
+
+    def test_alert_message_session_reason(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json",
+            max_sessions=2,
+            clock=clock,
+        )
+        tracker.record_cycle({"input_tokens": 1}, "claude-sonnet-4-6")
+        tracker.record_cycle({"input_tokens": 1}, "claude-sonnet-4-6")
+        msg = tracker.alert_message("sessions")
+        assert "session cap" in msg
+        assert "2/2" in msg
+
+    def test_alert_message_cost_reason(self, tmp_path: Path) -> None:
+        clock = _fixed_clock(datetime(2026, 4, 30, 12, 0, tzinfo=UTC))
+        tracker = BudgetTracker(
+            path=tmp_path / "budget.json",
+            max_cost_usd=5.0,
+            clock=clock,
+        )
+        tracker.record_cycle(
+            {"input_tokens": 2_000_000}, "claude-sonnet-4-6",
+        )
+        msg = tracker.alert_message("cost")
+        assert "cost cap" in msg
+        assert "$5.00" in msg
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_default_session_cap_is_80(self) -> None:
+        assert DEFAULT_MAX_SESSIONS == 80
+
+    def test_default_cost_cap_is_25_usd(self) -> None:
+        assert DEFAULT_MAX_USD == 25.0
+
+    def test_tracker_uses_defaults_when_unspecified(
+        self, tmp_path: Path,
+    ) -> None:
+        tracker = BudgetTracker(path=tmp_path / "budget.json")
+        assert tracker.max_sessions == DEFAULT_MAX_SESSIONS
+        assert tracker.max_cost_usd == DEFAULT_MAX_USD

--- a/tests/unit/test_cli_budget.py
+++ b/tests/unit/test_cli_budget.py
@@ -1,0 +1,122 @@
+"""Tests for the `gimmes budget` CLI command (#545)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def gimmes_home(tmp_path: Path) -> Path:
+    """Provide an isolated GIMMES_HOME and pre-create the dir."""
+    home = tmp_path / ".gimmes"
+    home.mkdir()
+    return home
+
+
+def _seed_budget(home: Path, days: dict, caps: dict | None = None) -> None:
+    """Write a budget.json fixture into the given GIMMES_HOME."""
+    payload = {"version": 1, "days": days}
+    if caps is not None:
+        payload["caps"] = caps
+    (home / "budget.json").write_text(json.dumps(payload))
+
+
+class TestBudgetCommand:
+    def test_zero_state_today(self, gimmes_home: Path) -> None:
+        """With no budget.json, the command prints zero totals at default caps."""
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget"])
+
+        assert result.exit_code == 0, result.output
+        assert "Claude API Budget" in result.output
+        assert "Sessions:  0 / 80" in result.output
+        assert "Cost:      $0.00 / $25.00" in result.output
+        assert "Resets in:" in result.output
+
+    def test_populated_state_reflects_seeded_totals(
+        self, gimmes_home: Path,
+    ) -> None:
+        """A pre-seeded budget.json shows the recorded totals."""
+        from datetime import UTC, datetime
+        today = datetime.now(UTC).date().isoformat()
+        _seed_budget(
+            gimmes_home,
+            days={today: {
+                "sessions": 12,
+                "cost_usd": 7.5,
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_tokens": 0,
+                "cache_read_tokens": 200,
+            }},
+            caps={"max_sessions": 80, "max_cost_usd": 25.0},
+        )
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget"])
+
+        assert result.exit_code == 0, result.output
+        assert "Sessions:  12 / 80" in result.output
+        assert "Cost:      $7.50 / $25.00" in result.output
+
+    def test_uses_caps_persisted_in_budget_json(
+        self, gimmes_home: Path,
+    ) -> None:
+        """When the loop persisted custom caps, the diagnostic uses them."""
+        from datetime import UTC, datetime
+        today = datetime.now(UTC).date().isoformat()
+        _seed_budget(
+            gimmes_home,
+            days={today: {"sessions": 25, "cost_usd": 30.0}},
+            caps={"max_sessions": 200, "max_cost_usd": 75.0},
+        )
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget"])
+
+        assert result.exit_code == 0
+        assert "25 / 200" in result.output
+        assert "$30.00 / $75.00" in result.output
+
+    def test_json_output_is_parseable_list(self, gimmes_home: Path) -> None:
+        """`--json` emits a JSON list of day summaries."""
+        from datetime import UTC, datetime
+        today = datetime.now(UTC).date().isoformat()
+        _seed_budget(
+            gimmes_home,
+            days={today: {"sessions": 3, "cost_usd": 1.2345}},
+        )
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["date"] == today
+        assert parsed[0]["sessions"] == 3
+        # Cost is rounded to 4 decimals per the CLI contract.
+        assert parsed[0]["cost_usd"] == 1.2345
+
+    def test_days_flag_returns_n_summaries(
+        self, gimmes_home: Path,
+    ) -> None:
+        """`--days 3` produces 3 entries (today + 2 prior days)."""
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget", "--days", "3", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert len(parsed) == 3

--- a/tests/unit/test_cli_budget.py
+++ b/tests/unit/test_cli_budget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -12,6 +13,22 @@ from typer.testing import CliRunner
 from gimmes.cli import app
 
 runner = CliRunner()
+
+# Frozen clock keeps the seeded date and the CLI-observed date in lockstep
+# even if the test happens to run across a UTC midnight boundary.
+_FROZEN_NOW = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+_FROZEN_TODAY = _FROZEN_NOW.date().isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _freeze_clock(monkeypatch):
+    """Freeze the BudgetTracker's clock to keep the seeded date and the
+    CLI-observed date in lockstep regardless of when the suite runs.
+    The tracker resolves ``_default_clock`` lazily per-call, so this
+    patch takes effect for any tracker constructed afterwards.
+    """
+    monkeypatch.setattr("gimmes.budget._default_clock", lambda: _FROZEN_NOW)
+    yield
 
 
 @pytest.fixture()
@@ -47,8 +64,7 @@ class TestBudgetCommand:
         self, gimmes_home: Path,
     ) -> None:
         """A pre-seeded budget.json shows the recorded totals."""
-        from datetime import UTC, datetime
-        today = datetime.now(UTC).date().isoformat()
+        today = _FROZEN_TODAY
         _seed_budget(
             gimmes_home,
             days={today: {
@@ -73,8 +89,7 @@ class TestBudgetCommand:
         self, gimmes_home: Path,
     ) -> None:
         """When the loop persisted custom caps, the diagnostic uses them."""
-        from datetime import UTC, datetime
-        today = datetime.now(UTC).date().isoformat()
+        today = _FROZEN_TODAY
         _seed_budget(
             gimmes_home,
             days={today: {"sessions": 25, "cost_usd": 30.0}},
@@ -90,8 +105,7 @@ class TestBudgetCommand:
 
     def test_json_output_is_parseable_list(self, gimmes_home: Path) -> None:
         """`--json` emits a JSON list of day summaries."""
-        from datetime import UTC, datetime
-        today = datetime.now(UTC).date().isoformat()
+        today = _FROZEN_TODAY
         _seed_budget(
             gimmes_home,
             days={today: {"sessions": 3, "cost_usd": 1.2345}},
@@ -120,3 +134,66 @@ class TestBudgetCommand:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert len(parsed) == 3
+
+    def test_zero_caps_render_as_unlimited(self, gimmes_home: Path) -> None:
+        """`0` caps in budget.json render as ``∞`` (matches the loop's
+        ``0=unlimited`` semantics — the user shouldn't see ``0/0`` and
+        think the budget is exhausted)."""
+        _seed_budget(
+            gimmes_home,
+            days={_FROZEN_TODAY: {"sessions": 5, "cost_usd": 1.0}},
+            caps={"max_sessions": 0, "max_cost_usd": 0.0},
+        )
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget"])
+
+        assert result.exit_code == 0, result.output
+        assert "∞" in result.output or "unlimited" in result.output.lower()
+        assert "0 / 0" not in result.output
+
+    def test_json_includes_caps_remaining_and_reset(
+        self, gimmes_home: Path,
+    ) -> None:
+        """The `--json` schema includes the caps + remaining headroom +
+        reset-seconds so automation can act on cap proximity."""
+        _seed_budget(
+            gimmes_home,
+            days={_FROZEN_TODAY: {"sessions": 10, "cost_usd": 5.0}},
+            caps={"max_sessions": 80, "max_cost_usd": 25.0},
+        )
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        entry = parsed[0]
+        assert entry["max_sessions"] == 80
+        assert entry["max_cost_usd"] == 25.0
+        assert entry["remaining_sessions"] == 70
+        assert entry["remaining_cost_usd"] == 20.0
+        assert "seconds_until_reset" in entry
+        assert isinstance(entry["seconds_until_reset"], int)
+
+    def test_json_under_unlimited_caps_shows_null(
+        self, gimmes_home: Path,
+    ) -> None:
+        """Under `0` caps, the JSON cap fields are null (machine-friendly
+        equivalent of the human-readable ``∞``)."""
+        _seed_budget(
+            gimmes_home,
+            days={_FROZEN_TODAY: {"sessions": 1, "cost_usd": 0.5}},
+            caps={"max_sessions": 0, "max_cost_usd": 0.0},
+        )
+        with patch("gimmes.config.GIMMES_HOME", gimmes_home), \
+             patch("gimmes.cli.GIMMES_HOME", gimmes_home, create=True):
+            result = runner.invoke(app, ["budget", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        entry = parsed[0]
+        assert entry["max_sessions"] is None
+        assert entry["max_cost_usd"] is None
+        assert entry["remaining_sessions"] is None
+        assert entry["remaining_cost_usd"] is None


### PR DESCRIPTION
## Summary

The autonomous trading loop spawns one `claude` subprocess per cycle. Without a budget guardrail, a single multi-day run had been blowing through the Anthropic Max plan cap silently (Apr 29: 103 cycles, cap hit; Apr 30: throttled; May 1–4: zero cycles). #543 (cycles cap) and #544 (Sonnet default) were upstream mitigations; this PR is the explicit safety net the issue title calls for.

Closes #545.

## What changed

**New `src/gimmes/budget.py`:**

- `BudgetTracker` — persists per-UTC-day session counts and dollar costs to `${GIMMES_HOME}/budget.json` via atomic tempfile + `os.replace` writes. Caps in effect are persisted alongside totals so `gimmes budget` shows real numbers.
- `cost_from_usage(usage, model_id)` — multiplies parsed token usage by per-model rates (Sonnet/Opus/Haiku, fully-qualified ids matching #544's frontmatter). Unknown models fall back to Sonnet rates with an **ERROR** log (not warning — silent under-costing of a 5×-cost model is the worst-case regression).
- `parse_usage_from_stream_json(stdout)` — fail-open: malformed/missing cycles return `None`, skipping accounting rather than crashing the loop.
- In-process `threading.Lock` around `record_cycle` prevents lost updates from concurrent threads. Multi-process safety is explicitly out of scope (one loop per host).
- `summary_for_date(date_str)` and `caps_in_effect()` give the diagnostic CLI a clean read-only view without abusing the `clock` injection.

**Loop integration in `_autonomous_loop`:**

- **Pre-spawn block:** `should_block()` check before the subprocess fires. Cap hit → red banner, WARNING log, iMessage push via `osascript` (when `GIMMES_NOTIFY_PHONE` is set, mirroring `bin/monitor.sh`), and `_resilient_sleep` until the next UTC midnight. `cycles_run` is *not* incremented so cap-blocked iterations don't burn #543's `--cycles` budget.
- **Post-success record:** parse `usage` from the captured stream-json stdout and call `record_cycle`. Tokens are recorded for rate-limited and API-error cycles too — Anthropic charges for them.

**CLI:**

- New `--max-sessions-per-day N` (default 80) and `--max-daily-cost-usd X` (default $25) flags on `start`, `driving_range`, `championship`. `0` = unlimited (matches `--cycles 0` semantics from #543).
- New `gimmes budget` command — today's totals, persisted caps, remaining headroom, time until next UTC midnight. `--days N` for trailing days; `--json` for machine output.

## Scope decisions (called out)

- **`monitor.conf` integration deferred** — CLI flags + safe defaults give 100% of the safety value; reading `monitor.conf` from the loop would mean two parsers for the same file. Acceptance criterion #1's "or config-file value if present" is satisfied in spirit by safe defaults.
- **`--reset-on cap` vs `--exit-on cap` configurability deferred** — hard-stop with midnight resume is the conservative default (the loop self-heals; "exit" requires manual restart that a sleeping operator may miss).
- **Auto-issue creation on cap-hit deferred** — console + iMessage covers operator notification; auto-filing GitHub issues is nice-to-have.
- **`by_model` breakdown dropped from v1** — Anthropic billing is unified across models, the cap is a dollar cap, and per-model accounting adds schema complexity (migration concerns when models rotate). Lazily computable from per-cycle log files if/when needed.

## Test plan

- `uv run pytest tests/unit/test_budget.py` — **35 tests** covering pricing, cost calculation, parser fail-open, cap enforcement, midnight rollover, atomic write, corrupt-file recovery, schema-version handling, pruning, thread safety with exact counter assertion, jumped-past cap, persisted caps round-trip.
- `uv run pytest tests/unit/test_cli_budget.py` — **5 tests** for the new CLI: zero state, populated state, custom caps from budget.json, JSON output, `--days N`.
- `uv run pytest tests/unit/test_autonomous_loop.py -k "loop_blocks_when_session_cap or loop_records_usage"` — **2 integration tests** pinning the pre-spawn block (no `subprocess.Popen` call when cap reached) and the post-success record (sessions, cost, *and* tokens accumulated).
- `uv run ruff check src/gimmes/budget.py src/gimmes/cli.py tests/unit/test_budget.py tests/unit/test_cli_budget.py tests/unit/test_autonomous_loop.py` — clean.
- All 7 prior `assert_called_once_with(_autonomous_loop, ...)` assertions in `test_autonomous_loop.py` updated to include the new `max_sessions_per_day=None, max_daily_cost_usd=None` kwargs.

## Backward compatibility

- No removed config keys, CLI flags, or function signatures (only additions).
- Defaults activate the cap immediately on upgrade; pass `--max-sessions-per-day 0 --max-daily-cost-usd 0` to opt out (CHANGELOG documents this).
- No database migration needed — the new state lives in `${GIMMES_HOME}/budget.json`, separate from `gimmes.db`.

## Risk level

**Medium** — touches the autonomous loop's main control flow. The pre-spawn block is the load-bearing change; if `should_block()` ever returned `True` spuriously, the loop would sleep when it shouldn't. Mitigation: `should_block` is read-only with a single >= comparison; the integration test pins both the True and False paths.

## Pricing-table maintenance

The `PRICING` dict in `src/gimmes/budget.py` is pinned to Anthropic's published list rates. Re-validate against `anthropic.com/pricing` when Anthropic announces plan changes; the unknown-model fallback logs an ERROR so a model-id rotation surfaces immediately even if the table is stale.