### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-06
+
 ### Added
-- Daily Claude API budget guardrail for the autonomous loop. Per-cycle token usage is parsed from each `claude` subprocess output, accumulated into `${GIMMES_HOME}/budget.json` keyed by UTC date, and checked against two caps before each cycle: a session-count cap (`--max-sessions-per-day`, default 80) and a USD cost cap (`--max-daily-cost-usd`, default $25). When either cap is hit the loop logs a warning and sleeps until the next UTC midnight, then resumes automatically. New `gimmes budget` CLI command shows today's running totals and remaining headroom. (#545)
+- Daily Claude API budget guardrail for the autonomous loop. Two caps apply per UTC day: `--max-sessions-per-day N` (default 80) and `--max-daily-cost-usd X` (default $25). On cap hit the loop logs a warning, sends an iMessage push (when `GIMMES_NOTIFY_PHONE` is set), and sleeps until the next UTC midnight, then resumes automatically. Pass `0` for either flag to disable that cap. State is persisted to `${GIMMES_HOME}/budget.json`; new `gimmes budget` CLI command (with `--days N` and `--json`) shows running totals and remaining headroom. (#550)
 
 ### Changed
-- Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case at default 60s pause + 3600s monitor interval) to bound Claude API spend per run; pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning (#543)
-- Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. `gimmes config set model.default <id>` overrides the Caddie Master subprocess only; sub-agents still read their own frontmatter (edit those files for per-agent overrides). (#544)
+- Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case) to bound Claude API spend per run. Pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning. (#548)
+- Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. To override only the Caddie Master subprocess at runtime: `gimmes config set model.default claude-opus-4-7`. Sub-agents continue to read their own frontmatter (edit those files for per-agent overrides). (#549)
+
+### Fixed
+- Caddie Master Step 4c now reads `strategy.side` from config and rejects any candidate whose side does not match the configured side. The structural edge is side-specific; CM was previously overriding the configured side during extraordinary events, which caused the KXCPI-26MAR-T0.8 YES trade loss. (#541)
 
 ## [0.6.4] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ gimmes position-notes TICKER    # Position journal entries
 ### Diagnostics
 ```bash
 gimmes errors            # View error logs (--severity, --category, --unresolved)
+gimmes budget            # Show today's Claude API budget (--days N, --json)
 ```
 
 ### Strategy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gimmes"
-version = "0.6.4"
+version = "0.7.0"
 description = "Autonomous Claude Code agent system for trading Kalshi prediction markets"
 readme = "README.md"
 license = "MIT"

--- a/src/gimmes/__init__.py
+++ b/src/gimmes/__init__.py
@@ -1,3 +1,3 @@
 """GIMMES — We only play the gimmes."""
 
-__version__ = "0.6.4"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Release v0.7.0

### Added
- Daily Claude API budget guardrail for the autonomous loop. Two caps apply per UTC day: `--max-sessions-per-day N` (default 80) and `--max-daily-cost-usd X` (default $25). On cap hit the loop logs a warning, sends an iMessage push (when `GIMMES_NOTIFY_PHONE` is set), and sleeps until the next UTC midnight, then resumes automatically. Pass `0` for either flag to disable that cap. State is persisted to `${GIMMES_HOME}/budget.json`; new `gimmes budget` CLI command (with `--days N` and `--json`) shows running totals and remaining headroom. (#550)

### Changed
- Autonomous loop commands (`start`, `driving_range`, `championship`) now default `--cycles` to 400 (~1 trading day worst-case) to bound Claude API spend per run. Pass `--cycles 0` (or the new `--max-cycles 0` alias) for the previous unbounded behavior, which now logs a startup warning. (#548)
- Autonomous-loop agents (Caddie Master, Scout, Caddie, Closer, Monitor, Groundskeeper, Scorecard) now pin `model: claude-sonnet-4-6` in their `.claude/agents/*.md` frontmatter, dropping per-cycle Claude API cost ~10× from Opus. To override only the Caddie Master subprocess at runtime: `gimmes config set model.default claude-opus-4-7`. Sub-agents continue to read their own frontmatter (edit those files for per-agent overrides). (#549)

### Fixed
- Caddie Master Step 4c now reads `strategy.side` from config and rejects any candidate whose side does not match the configured side. The structural edge is side-specific; CM was previously overriding the configured side during extraordinary events, which caused the KXCPI-26MAR-T0.8 YES trade loss. (#541)

---

## Why minor (0.7.0) rather than patch

Three coordinated default-behavior changes (#548, #549, #550) plus a brand-new top-level CLI command (`gimmes budget`). Pre-1.0 strict patch convention would call this 0.6.5; the magnitude of observable defaults flipping for an existing operator (cycle ceiling, model swap, daily cap that can pause the loop until UTC midnight) makes minor more honest about the upgrade impact. Each change has an explicit opt-out documented in the entries above.

## Upgrade notes

- **Existing scripts that ran `gimmes driving_range` expecting unbounded cycles** will now exit at 400. Pass `--cycles 0` to restore.
- **Existing runs that depended on Opus** will now use Sonnet 4.6. Run `gimmes config set model.default claude-opus-4-7` to flip the Caddie Master subprocess back; edit `.claude/agents/<name>.md` for sub-agents.
- **Existing unbounded runs** will now hit the daily budget caps (80 sessions / $25 USD per UTC day) and sleep until midnight. Pass `--max-sessions-per-day 0 --max-daily-cost-usd 0` to disable both caps. New `gimmes budget` command shows running totals.

## Verification

- `pyproject.toml` and `src/gimmes/__init__.py` both bumped to `0.7.0`.
- `git log v0.6.4..HEAD --no-merges` matches the four PR references (#541, #548, #549, #550).
- Pre-PR review pipeline (code-reviewer, silent-failure-hunter, pr-test-analyzer) clean.