### PR TITLE
Phase 0 of #546: cycle-staleness audit module + May 7 deliverable

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2077,8 +2077,11 @@ def audit_cycles(
     )
     md = render_markdown(summaries=summaries, target_date=parsed_date)
     if output == "-":
-        # markup=False so Rich doesn't interpret bracketed Markdown text
-        # (e.g. `[start_time, end_time]`) as style tags and corrupt stdout.
+        # Defensive: pass the rendered Markdown through Rich verbatim.
+        # Today's report doesn't emit `[bracketed]` segments that Rich
+        # would interpret as style tags, but if a future field ever does
+        # (e.g. an embedded `[start_time, end_time]` literal), markup=False
+        # + highlight=False keep stdout faithful.
         console.print(md, markup=False, highlight=False)
     else:
         out_path = Path(output)

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2024,6 +2024,67 @@ def log_error(
     _run(_log())
 
 
+@app.command(name="audit-cycles", rich_help_panel="Diagnostics")
+def audit_cycles(
+    target_date: str = typer.Option(
+        ...,
+        "--date",
+        help=(
+            "UTC date to audit (YYYY-MM-DD). Cycles are bucketed by their "
+            "start_time converted to America/New_York."
+        ),
+    ),
+    output: str = typer.Option(
+        "-",
+        "--output",
+        "-o",
+        help=(
+            "Path to write the Markdown report. Use '-' for stdout (default)."
+        ),
+    ),
+) -> None:
+    """Audit a day's autonomous-loop cycle logs and produce a Markdown report.
+
+    Phase 0 of #546. Parses every ``${GIMMES_HOME}/logs/cycle-NNNN.json``
+    that started on the target date (in EDT), extracts Scout / Caddie / trade
+    extracts, cross-checks trade counts against the ``trades`` SQLite table,
+    and renders a deterministic Markdown report.
+    """
+    from datetime import date as _date
+
+    from gimmes.config import GIMMES_HOME
+    from gimmes.reporting.cycle_audit import audit_date, render_markdown
+
+    try:
+        parsed_date = _date.fromisoformat(target_date)
+    except ValueError as exc:
+        console.print(f"[red]Invalid --date value: {exc}[/red]")
+        raise typer.Exit(1)
+
+    log_dir = GIMMES_HOME / "logs"
+    db_path = GIMMES_HOME / "gimmes.db"
+    if not log_dir.is_dir():
+        console.print(f"[red]No logs directory at {log_dir}[/red]")
+        raise typer.Exit(1)
+
+    summaries = audit_date(
+        log_dir=log_dir,
+        db_path=db_path if db_path.exists() else None,
+        target_date=parsed_date,
+    )
+    md = render_markdown(summaries=summaries, target_date=parsed_date)
+    if output == "-":
+        console.print(md)
+    else:
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(md)
+        console.print(
+            f"[green]Audit written to {out_path}[/green] "
+            f"({len(summaries)} cycles)."
+        )
+
+
 @app.command(name="budget", rich_help_panel="Diagnostics")
 def budget(
     days: int = typer.Option(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2030,8 +2030,10 @@ def audit_cycles(
         ...,
         "--date",
         help=(
-            "UTC date to audit (YYYY-MM-DD). Cycles are bucketed by their "
-            "start_time converted to America/New_York."
+            "UTC date to audit (YYYY-MM-DD). Cycles are selected by UTC "
+            "day-of-start with a 12-hour pre-buffer for cycles that "
+            "spilled in from the prior evening; the hour-of-window "
+            "aggregate in the rendered report converts to America/New_York."
         ),
     ),
     output: str = typer.Option(
@@ -2046,9 +2048,10 @@ def audit_cycles(
     """Audit a day's autonomous-loop cycle logs and produce a Markdown report.
 
     Phase 0 of #546. Parses every ``${GIMMES_HOME}/logs/cycle-NNNN.json``
-    that started on the target date (in EDT), extracts Scout / Caddie / trade
-    extracts, cross-checks trade counts against the ``trades`` SQLite table,
-    and renders a deterministic Markdown report.
+    whose UTC start_time falls on (or pre-buffer-spills into) the target
+    UTC date, extracts Scout / Caddie / trade extracts, cross-checks trade
+    counts against the ``trades`` SQLite table, and renders a deterministic
+    Markdown report. The hour aggregate is bucketed in EDT for readability.
     """
     from datetime import date as _date
 
@@ -2074,7 +2077,9 @@ def audit_cycles(
     )
     md = render_markdown(summaries=summaries, target_date=parsed_date)
     if output == "-":
-        console.print(md)
+        # markup=False so Rich doesn't interpret bracketed Markdown text
+        # (e.g. `[start_time, end_time]`) as style tags and corrupt stdout.
+        console.print(md, markup=False, highlight=False)
     else:
         out_path = Path(output)
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/gimmes/reporting/cycle_audit.py
+++ b/src/gimmes/reporting/cycle_audit.py
@@ -424,11 +424,16 @@ def render_markdown(
             "No cycles found for this date.\n"
         )
 
-    # Defensive in-place sort to make the contract independent of caller.
+    # Defensive sort to make the contract independent of caller-supplied
+    # order. Matches ``audit_date``'s ordering: cycles without a
+    # ``start_time`` (block logs) sort before timestamped cycles via
+    # ``datetime.min`` fallback. Block logs already share their parent's
+    # ``cycle_id``, so the secondary sort keeps each block paired with
+    # its parent in the table.
     summaries = sorted(
         summaries,
         key=lambda s: (
-            s.start_time or datetime.max.replace(tzinfo=UTC),
+            s.start_time or datetime.min.replace(tzinfo=UTC),
             s.cycle_id,
         ),
     )
@@ -471,7 +476,13 @@ def render_markdown(
     if not overnight_cycles and not pre_release_cycles:
         verdict = "INCONCLUSIVE"
         verdict_reason = "No cycles ran in either bucket."
-    elif overnight_trades == 0 and pre_release_trades == 0:
+    def _cycles(n: int) -> str:
+        return "cycle" if n == 1 else "cycles"
+
+    def _trades(n: int) -> str:
+        return "trade" if n == 1 else "trades"
+
+    if overnight_trades == 0 and pre_release_trades == 0:
         verdict = "INCONCLUSIVE"
         verdict_reason = (
             f"Zero trades in both buckets ({len(overnight_cycles)} overnight, "
@@ -480,36 +491,38 @@ def render_markdown(
     elif overnight_trades == 0 and pre_release_trades > 0:
         verdict = "ACCEPTED (one-day data)"
         verdict_reason = (
-            f"{len(overnight_cycles)} overnight cycles produced 0 trades; "
-            f"{pre_release_trades} trades came from {len(pre_release_cycles)} "
-            "pre-release cycles."
+            f"{len(overnight_cycles)} overnight {_cycles(len(overnight_cycles))} "
+            f"produced 0 trades; {pre_release_trades} "
+            f"{_trades(pre_release_trades)} came from "
+            f"{len(pre_release_cycles)} pre-release "
+            f"{_cycles(len(pre_release_cycles))}."
         )
     elif overnight_trades > 0 and not pre_release_cycles:
         verdict = "REJECTED for overnight bucket; pre-release uninformed"
         verdict_reason = (
-            f"{len(overnight_cycles)} overnight cycles produced "
-            f"{overnight_trades} trades — overnight is NOT alpha-empty as "
-            "H5 predicted. No cycles ran in the 5–9 AM ET pre-release "
-            "bucket (e.g. cap-blocked, no scheduled window, or system "
-            "down) so the comparison side is missing."
+            f"{len(overnight_cycles)} overnight {_cycles(len(overnight_cycles))} "
+            f"produced {overnight_trades} {_trades(overnight_trades)} — "
+            "overnight is NOT alpha-empty as H5 predicted. No cycles ran "
+            "in the 5–9 AM ET pre-release bucket (e.g. cap-blocked, no "
+            "scheduled window, or system down) so the comparison side is "
+            "missing."
         )
     elif overnight_trades > 0 and pre_release_trades == 0 and pre_release_cycles:
         verdict = "REJECTED (one-day data)"
-        on_word = "cycle" if len(overnight_cycles) == 1 else "cycles"
-        on_trade = "trade" if overnight_trades == 1 else "trades"
-        pr_word = "cycle" if len(pre_release_cycles) == 1 else "cycles"
         verdict_reason = (
-            f"{len(overnight_cycles)} overnight {on_word} produced "
-            f"{overnight_trades} {on_trade}; {len(pre_release_cycles)} "
-            f"pre-release {pr_word} produced 0 trades. "
+            f"{len(overnight_cycles)} overnight {_cycles(len(overnight_cycles))} "
+            f"produced {overnight_trades} {_trades(overnight_trades)}; "
+            f"{len(pre_release_cycles)} pre-release "
+            f"{_cycles(len(pre_release_cycles))} produced 0 trades. "
             "H5's prediction is inverted on this date."
         )
     else:
         verdict = "PARTIALLY REJECTED (one-day data)"
         verdict_reason = (
-            f"Overnight {len(overnight_cycles)} cycles → "
-            f"{overnight_trades} trades; pre-release "
-            f"{len(pre_release_cycles)} cycles → {pre_release_trades} trades. "
+            f"Overnight {len(overnight_cycles)} {_cycles(len(overnight_cycles))} "
+            f"→ {overnight_trades} {_trades(overnight_trades)}; pre-release "
+            f"{len(pre_release_cycles)} {_cycles(len(pre_release_cycles))} "
+            f"→ {pre_release_trades} {_trades(pre_release_trades)}. "
             "Both buckets produced signal."
         )
 

--- a/src/gimmes/reporting/cycle_audit.py
+++ b/src/gimmes/reporting/cycle_audit.py
@@ -145,8 +145,15 @@ def parse_cycle_log(
     in_trade_window_fn=None,
 ) -> CycleSummary:
     """Parse a single ``cycle-NNNN.json`` (or ``cycle-NNNN-block-*.json``)
-    log file. Fail-open: regex misses produce ``None`` cells with a warning,
-    not exceptions. Only structural failures (e.g. unreadable file) raise.
+    log file.
+
+    Fully fail-open: regex misses, malformed JSON, missing fields, stray
+    non-dict elements in the events list, and DB query failures all
+    produce a :class:`CycleSummary` with ``None`` extraction cells and
+    descriptive entries in :attr:`CycleSummary.parse_warnings`. The
+    function does not raise for any of these conditions, so callers do
+    not need to wrap invocations in ``try``/``except``. (Programming
+    errors — e.g. wrong argument type — still raise normally.)
     """
     cycle_id = _cycle_id_from_path(path)
     warnings: list[str] = []
@@ -330,22 +337,23 @@ def audit_date(
 ) -> list[CycleSummary]:
     """Audit cycle logs associated with ``target_date``'s trade window.
 
-    A cycle is included if any of:
+    A cycle is included if either:
 
-    - its UTC ``start_time.date()`` equals ``target_date``, OR
-    - its UTC ``start_time`` falls within ``pre_buffer_hours`` before
-      ``target_date 00:00 UTC`` (captures cycles that started late on the
-      prior evening and whose trade-window work / placed orders landed
-      on ``target_date``), OR
-    - its ``end_time`` lands on or after ``target_date 00:00 UTC`` (cycles
-      that span the boundary).
+    - its UTC ``start_time`` falls within
+      ``[target_date 00:00, target_date+1 00:00)`` UTC, OR
+    - its UTC ``start_time`` falls within
+      ``[target_date 00:00 - pre_buffer_hours, target_date 00:00)`` UTC
+      **AND** its UTC ``end_time`` lands on or after ``target_date 00:00``
+      (i.e. the cycle started late on the prior evening but its work
+      spilled into the target day).
 
-    The default ``pre_buffer_hours=12`` aligns with the longest gimmes
-    trade window (Wed 6:30 PM ET → Thu 8:30 AM ET, ~14 h, but the half
-    spilling backwards from any UTC date is at most 12 h).
+    The default ``pre_buffer_hours=12`` is conservative for gimmes' longest
+    trade window (Wed 6:30 PM ET → Thu 8:30 AM ET) — a cycle that opens at
+    18:30 ET = 22:30 UTC EST / 23:30 UTC EDT lands within 12 h of UTC
+    midnight, so 12 h covers every realistic spillover.
 
     Block-log siblings are paired with their parent cycle if the parent
-    falls in the audit set.
+    falls in the audit set; orphan blocks are silently dropped.
     """
     from datetime import timedelta as _td
 
@@ -403,14 +411,27 @@ def render_markdown(
     deferred_phase1_issue: int = 553,
     deferred_phase23_issue: int = 554,
 ) -> str:
-    """Render a deterministic Markdown report. Re-running with the same
-    summaries must produce byte-identical output (sort + fixed format)."""
+    """Render a deterministic Markdown report.
+
+    Sorts ``summaries`` by ``(start_time, cycle_id)`` internally so the
+    output is byte-identical regardless of caller-supplied order; cycles
+    without a ``start_time`` (block logs) sort after timestamped cycles.
+    """
     if not summaries:
         return (
             f"# {target_date.isoformat()} Cycle-Staleness Audit "
             f"(Phase 0 of #{parent_issue})\n\n"
             "No cycles found for this date.\n"
         )
+
+    # Defensive in-place sort to make the contract independent of caller.
+    summaries = sorted(
+        summaries,
+        key=lambda s: (
+            s.start_time or datetime.max.replace(tzinfo=UTC),
+            s.cycle_id,
+        ),
+    )
 
     full_cycles = [s for s in summaries if s.cycle_type == "full"]
     monitor_cycles = [s for s in summaries if s.cycle_type == "monitor"]
@@ -474,10 +495,14 @@ def render_markdown(
         )
     elif overnight_trades > 0 and pre_release_trades == 0 and pre_release_cycles:
         verdict = "REJECTED (one-day data)"
+        on_word = "cycle" if len(overnight_cycles) == 1 else "cycles"
+        on_trade = "trade" if overnight_trades == 1 else "trades"
+        pr_word = "cycle" if len(pre_release_cycles) == 1 else "cycles"
         verdict_reason = (
-            f"{len(overnight_cycles)} overnight cycles produced "
-            f"{overnight_trades} trades; {len(pre_release_cycles)} pre-release "
-            "cycles produced 0 trades. H5's prediction is inverted on this date."
+            f"{len(overnight_cycles)} overnight {on_word} produced "
+            f"{overnight_trades} {on_trade}; {len(pre_release_cycles)} "
+            f"pre-release {pr_word} produced 0 trades. "
+            "H5's prediction is inverted on this date."
         )
     else:
         verdict = "PARTIALLY REJECTED (one-day data)"
@@ -517,8 +542,8 @@ def render_markdown(
     )
     lines.append(
         "- Trade ground truth: read-only SQL on the `trades` table, "
-        "windowed to each cycle's `[start_time, end_time]` and excluding "
-        "`skip`/`cooldown`/`cap_blocked` bookkeeping rows."
+        "windowed to each cycle's start/end timestamps and excluding "
+        "Scout/Caddie `skip` bookkeeping rows."
     )
     lines.append(
         "- Hour-of-window bucketing converts each cycle's start time to "

--- a/src/gimmes/reporting/cycle_audit.py
+++ b/src/gimmes/reporting/cycle_audit.py
@@ -1,0 +1,608 @@
+"""Per-cycle audit of autonomous-loop ``cycle-NNNN.json`` logs.
+
+Phase 0 of GitHub issue #546: extract Scout shortlist size, Caddie
+threshold passes, and trade placements from each cycle log, cross-check
+trades against the SQLite ``trades`` table, and render a Markdown report.
+
+The audit is intentionally read-only and never modifies the live
+``${GIMMES_HOME}/gimmes.db`` — it opens the database with
+``mode=ro`` so a running loop is not perturbed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger("gimmes.cycle_audit")
+
+ET = ZoneInfo("America/New_York")
+
+# Scout shortlist: try variants in order; first match wins.
+_SCOUT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"Scout\s+returned\s+(\d+)\s+candidates?", re.IGNORECASE),
+    re.compile(
+        r"Scout\s+(?:shortlisted|surfaced|found)\s+(\d+)\s+(?:markets?|candidates?|tickers?)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"shortlist(?:\s+size)?\s*[:=]\s*(\d+)", re.IGNORECASE),
+)
+
+_CADDIE_DISPATCH_RE = re.compile(
+    r"Dispatching\s+Caddie|Step\s*4[a-z]?\s*[:.\-—]\s*Caddie",
+    re.IGNORECASE,
+)
+
+# Caddie pass: count PROCEED tokens. Combined with REJECT for sanity.
+_PROCEED_RE = re.compile(r"\bPROCEED\b")
+_REJECT_RE = re.compile(r"\bREJECT(?:ED)?\b")
+
+# Closer trade-placement text markers (cross-check; DB is source of truth).
+_TRADE_TEXT_RE = re.compile(
+    r"Order\s+(?:submitted|placed|filled)|Closer.*?placed",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class CycleSummary:
+    """One audited cycle's salient extracts."""
+
+    cycle_id: int
+    log_path: Path
+    start_time: datetime | None
+    end_time: datetime | None
+    duration_seconds: float | None
+    scout_shortlist_size: int | None
+    caddie_dispatches: int | None
+    caddie_threshold_passes: int | None
+    trades_placed_db: int
+    trades_placed_text: int | None
+    cycle_type: str  # "full" | "monitor" | "errored" | "block"
+    in_trade_window: bool
+    parse_warnings: list[str] = field(default_factory=list)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        # Handle the trailing 'Z' some Claude Code events emit.
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
+    except (ValueError, TypeError):
+        return None
+
+
+def _iter_assistant_text(events: list[dict]) -> Iterable[str]:
+    for ev in events:
+        if ev.get("type") != "assistant":
+            continue
+        msg = ev.get("message")
+        if not isinstance(msg, dict):
+            continue
+        for c in msg.get("content", []) or []:
+            if isinstance(c, dict) and c.get("type") == "text":
+                t = c.get("text")
+                if isinstance(t, str):
+                    yield t
+
+
+def _extract_scout_size(text_blocks: list[str]) -> tuple[int | None, str | None]:
+    """Try each Scout pattern; return (size, warning) where warning notes
+    multi-match cases."""
+    matches: list[int] = []
+    for pat in _SCOUT_PATTERNS:
+        for block in text_blocks:
+            for m in pat.finditer(block):
+                matches.append(int(m.group(1)))
+        if matches:
+            # First pattern that hits wins; later patterns are fallbacks.
+            break
+    if not matches:
+        return None, None
+    if len(matches) > 1:
+        return matches[-1], f"multiple Scout matches: {matches}"
+    return matches[0], None
+
+
+def _extract_caddie_passes(text_blocks: list[str]) -> int:
+    proceed = 0
+    for block in text_blocks:
+        proceed += len(_PROCEED_RE.findall(block))
+    return proceed
+
+
+def _extract_caddie_dispatches(text_blocks: list[str]) -> int:
+    n = 0
+    for block in text_blocks:
+        n += len(_CADDIE_DISPATCH_RE.findall(block))
+    return n
+
+
+def _extract_text_trade_count(text_blocks: list[str]) -> int:
+    n = 0
+    for block in text_blocks:
+        n += len(_TRADE_TEXT_RE.findall(block))
+    return n
+
+
+def parse_cycle_log(
+    path: Path,
+    *,
+    db_path: Path | None = None,
+    in_trade_window_fn=None,
+) -> CycleSummary:
+    """Parse a single ``cycle-NNNN.json`` (or ``cycle-NNNN-block-*.json``)
+    log file. Fail-open: regex misses produce ``None`` cells with a warning,
+    not exceptions. Only structural failures (e.g. unreadable file) raise.
+    """
+    cycle_id = _cycle_id_from_path(path)
+    warnings: list[str] = []
+
+    if "-block-" in path.name:
+        # Cap-block log: minimal JSON, never had a subprocess. Mark it.
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            warnings.append(f"unreadable block log: {exc}")
+            payload = {}
+        return CycleSummary(
+            cycle_id=cycle_id,
+            log_path=path,
+            start_time=None,
+            end_time=None,
+            duration_seconds=None,
+            scout_shortlist_size=None,
+            caddie_dispatches=None,
+            caddie_threshold_passes=None,
+            trades_placed_db=0,
+            trades_placed_text=None,
+            cycle_type="block",
+            in_trade_window=False,
+            parse_warnings=warnings + [f"reason={payload.get('reason')}"],
+        )
+
+    try:
+        events = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        warnings.append(f"unreadable: {exc}")
+        return CycleSummary(
+            cycle_id=cycle_id,
+            log_path=path,
+            start_time=None,
+            end_time=None,
+            duration_seconds=None,
+            scout_shortlist_size=None,
+            caddie_dispatches=None,
+            caddie_threshold_passes=None,
+            trades_placed_db=0,
+            trades_placed_text=None,
+            cycle_type="errored",
+            in_trade_window=False,
+            parse_warnings=warnings,
+        )
+
+    if not isinstance(events, list):
+        warnings.append("log root is not a list")
+        events = []
+    # Filter out any non-dict elements before iterating — a malformed log
+    # with a stray string/int in the events list must not raise here.
+    events = [e for e in events if isinstance(e, dict)]
+
+    # Timestamps: first and last with a non-empty value.
+    first_ts = next(
+        (_parse_iso(e.get("timestamp")) for e in events if e.get("timestamp")),
+        None,
+    )
+    last_ts = next(
+        (_parse_iso(e.get("timestamp")) for e in reversed(events) if e.get("timestamp")),
+        None,
+    )
+    duration = (
+        (last_ts - first_ts).total_seconds()
+        if first_ts and last_ts and last_ts >= first_ts
+        else None
+    )
+
+    # Cycle type: result event's is_error flag, or absence of assistant content.
+    result_event = next((e for e in reversed(events) if e.get("type") == "result"), {})
+    is_error = bool(result_event.get("is_error"))
+    text_blocks = list(_iter_assistant_text(events))
+    has_text = any(b.strip() for b in text_blocks)
+
+    cycle_type: str
+    if is_error:
+        cycle_type = "errored"
+    elif not has_text:
+        cycle_type = "monitor"  # no assistant output ≈ monitor-only or no-op
+    else:
+        cycle_type = "full"
+
+    scout_size, scout_warn = _extract_scout_size(text_blocks)
+    if scout_warn:
+        warnings.append(scout_warn)
+    caddie_dispatches = _extract_caddie_dispatches(text_blocks) or None
+    caddie_passes = _extract_caddie_passes(text_blocks) if has_text else None
+    trades_text = _extract_text_trade_count(text_blocks) if has_text else None
+
+    # Cross-check trades against the DB. Bubble any DB error into the
+    # cycle's warnings so a swallowed sqlite failure (locked DB, missing
+    # table, schema drift) is visible in the rendered report and doesn't
+    # silently flip the H5 verdict.
+    if db_path and first_ts and last_ts:
+        trades_db, db_warning = _query_trades_in_window_with_warning(
+            db_path, first_ts, last_ts,
+        )
+        if db_warning:
+            warnings.append(db_warning)
+    else:
+        trades_db = 0
+
+    if trades_text is not None and trades_db != trades_text:
+        warnings.append(
+            f"text/db trade count mismatch: text={trades_text} db={trades_db}"
+        )
+
+    in_window = (
+        bool(in_trade_window_fn(first_ts)[0])
+        if in_trade_window_fn and first_ts
+        else False
+    )
+
+    return CycleSummary(
+        cycle_id=cycle_id,
+        log_path=path,
+        start_time=first_ts,
+        end_time=last_ts,
+        duration_seconds=duration,
+        scout_shortlist_size=scout_size,
+        caddie_dispatches=caddie_dispatches,
+        caddie_threshold_passes=caddie_passes,
+        trades_placed_db=trades_db,
+        trades_placed_text=trades_text,
+        cycle_type=cycle_type,
+        in_trade_window=in_window,
+        parse_warnings=warnings,
+    )
+
+
+def _cycle_id_from_path(path: Path) -> int:
+    """Extract the integer cycle id from ``cycle-NNNN.json`` /
+    ``cycle-NNNN-block-*.json`` filenames; return -1 on parse failure."""
+    m = re.match(r"cycle-(\d+)", path.stem)
+    return int(m.group(1)) if m else -1
+
+
+def query_trades_in_window(
+    db_path: Path, start: datetime, end: datetime,
+) -> int:
+    """Read-only count of ``trades`` rows whose ``timestamp`` falls in
+    ``[start, end]`` and whose ``action`` represents an actual order
+    placement (excludes Scout/Caddie ``skip`` rows). Errors are swallowed
+    and return 0 — callers that need to surface DB problems should use
+    :func:`_query_trades_in_window_with_warning` instead."""
+    count, _ = _query_trades_in_window_with_warning(db_path, start, end)
+    return count
+
+
+def _query_trades_in_window_with_warning(
+    db_path: Path, start: datetime, end: datetime,
+) -> tuple[int, str | None]:
+    """Same as :func:`query_trades_in_window` but returns a warning string
+    on error so the audit report can surface the failure inline."""
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as conn:
+            cur = conn.execute(
+                """
+                SELECT COUNT(*) FROM trades
+                WHERE timestamp >= ? AND timestamp <= ?
+                  AND action != 'skip'
+                """,
+                (start.isoformat(), end.isoformat()),
+            )
+            return int(cur.fetchone()[0]), None
+    except sqlite3.Error as exc:
+        msg = f"trades-DB query failed: {exc}"
+        logger.warning("audit: %s", msg)
+        return 0, msg
+
+
+def audit_date(
+    log_dir: Path,
+    db_path: Path | None,
+    target_date: date,
+    *,
+    in_trade_window_fn=None,
+    pre_buffer_hours: int = 12,
+) -> list[CycleSummary]:
+    """Audit cycle logs associated with ``target_date``'s trade window.
+
+    A cycle is included if any of:
+
+    - its UTC ``start_time.date()`` equals ``target_date``, OR
+    - its UTC ``start_time`` falls within ``pre_buffer_hours`` before
+      ``target_date 00:00 UTC`` (captures cycles that started late on the
+      prior evening and whose trade-window work / placed orders landed
+      on ``target_date``), OR
+    - its ``end_time`` lands on or after ``target_date 00:00 UTC`` (cycles
+      that span the boundary).
+
+    The default ``pre_buffer_hours=12`` aligns with the longest gimmes
+    trade window (Wed 6:30 PM ET → Thu 8:30 AM ET, ~14 h, but the half
+    spilling backwards from any UTC date is at most 12 h).
+
+    Block-log siblings are paired with their parent cycle if the parent
+    falls in the audit set.
+    """
+    from datetime import timedelta as _td
+
+    day_start = datetime.combine(target_date, datetime.min.time(), tzinfo=UTC)
+    day_end = day_start + _td(days=1)
+    pre_window_start = day_start - _td(hours=pre_buffer_hours)
+
+    summaries: list[CycleSummary] = []
+    for log_path in sorted(log_dir.glob("cycle-*.json")):
+        try:
+            summary = parse_cycle_log(
+                log_path,
+                db_path=db_path,
+                in_trade_window_fn=in_trade_window_fn,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("audit: failed to parse %s: %s", log_path, exc)
+            continue
+        if summary.start_time is None and summary.cycle_type != "block":
+            # No timestamp; can't bucket. Skip.
+            continue
+        if summary.cycle_type == "block":
+            sibling_match = any(
+                s.cycle_id == summary.cycle_id for s in summaries
+            )
+            if sibling_match:
+                summaries.append(summary)
+            continue
+
+        start = summary.start_time
+        end = summary.end_time or start
+        # Include if start is on the day, OR start is in the pre-buffer
+        # AND the cycle's end straddles into the target day.
+        on_day = day_start <= start < day_end
+        spans_into_day = (
+            pre_window_start <= start < day_start
+            and end >= day_start
+        )
+        if on_day or spans_into_day:
+            summaries.append(summary)
+
+    summaries.sort(key=lambda s: (s.start_time or datetime.min.replace(tzinfo=UTC)))
+    return summaries
+
+
+def render_markdown(
+    summaries: list[CycleSummary],
+    *,
+    target_date: date,
+    hypothesis_id: str = "H5",
+    hypothesis_text: str = (
+        "overnight 8 PM EDT–2 AM EDT cycles produce no actionable signal"
+    ),
+    parent_issue: int = 546,
+    deferred_phase1_issue: int = 553,
+    deferred_phase23_issue: int = 554,
+) -> str:
+    """Render a deterministic Markdown report. Re-running with the same
+    summaries must produce byte-identical output (sort + fixed format)."""
+    if not summaries:
+        return (
+            f"# {target_date.isoformat()} Cycle-Staleness Audit "
+            f"(Phase 0 of #{parent_issue})\n\n"
+            "No cycles found for this date.\n"
+        )
+
+    full_cycles = [s for s in summaries if s.cycle_type == "full"]
+    monitor_cycles = [s for s in summaries if s.cycle_type == "monitor"]
+    errored_cycles = [s for s in summaries if s.cycle_type == "errored"]
+    block_cycles = [s for s in summaries if s.cycle_type == "block"]
+
+    total_trades = sum(s.trades_placed_db for s in summaries)
+    cycles_with_trade = sum(1 for s in summaries if s.trades_placed_db > 0)
+
+    # Hour-bucket aggregation (ET).
+    by_hour: dict[int, list[CycleSummary]] = {}
+    for s in full_cycles:
+        if s.start_time is None:
+            continue
+        hour = s.start_time.astimezone(ET).hour
+        by_hour.setdefault(hour, []).append(s)
+
+    # H5 verdict.
+    # Hour-bucket boundaries are upper-exclusive to match the prose:
+    # "8 PM EDT–2 AM EDT" → hours {20, 21, 22, 23, 0, 1};
+    # "5–9 AM EDT pre-release" → hours {5, 6, 7, 8}.
+    overnight_hours = set(range(20, 24)) | set(range(0, 2))  # 8 PM–2 AM ET
+    overnight_cycles = [
+        s for s in full_cycles
+        if s.start_time
+        and s.start_time.astimezone(ET).hour in overnight_hours
+    ]
+    overnight_trades = sum(s.trades_placed_db for s in overnight_cycles)
+    pre_release_hours = set(range(5, 9))  # 5–9 AM ET
+    pre_release_cycles = [
+        s for s in full_cycles
+        if s.start_time
+        and s.start_time.astimezone(ET).hour in pre_release_hours
+    ]
+    pre_release_trades = sum(s.trades_placed_db for s in pre_release_cycles)
+
+    if not overnight_cycles and not pre_release_cycles:
+        verdict = "INCONCLUSIVE"
+        verdict_reason = "No cycles ran in either bucket."
+    elif overnight_trades == 0 and pre_release_trades == 0:
+        verdict = "INCONCLUSIVE"
+        verdict_reason = (
+            f"Zero trades in both buckets ({len(overnight_cycles)} overnight, "
+            f"{len(pre_release_cycles)} pre-release) — too thin to call."
+        )
+    elif overnight_trades == 0 and pre_release_trades > 0:
+        verdict = "ACCEPTED (one-day data)"
+        verdict_reason = (
+            f"{len(overnight_cycles)} overnight cycles produced 0 trades; "
+            f"{pre_release_trades} trades came from {len(pre_release_cycles)} "
+            "pre-release cycles."
+        )
+    elif overnight_trades > 0 and not pre_release_cycles:
+        verdict = "REJECTED for overnight bucket; pre-release uninformed"
+        verdict_reason = (
+            f"{len(overnight_cycles)} overnight cycles produced "
+            f"{overnight_trades} trades — overnight is NOT alpha-empty as "
+            "H5 predicted. No cycles ran in the 5–9 AM ET pre-release "
+            "bucket (e.g. cap-blocked, no scheduled window, or system "
+            "down) so the comparison side is missing."
+        )
+    elif overnight_trades > 0 and pre_release_trades == 0 and pre_release_cycles:
+        verdict = "REJECTED (one-day data)"
+        verdict_reason = (
+            f"{len(overnight_cycles)} overnight cycles produced "
+            f"{overnight_trades} trades; {len(pre_release_cycles)} pre-release "
+            "cycles produced 0 trades. H5's prediction is inverted on this date."
+        )
+    else:
+        verdict = "PARTIALLY REJECTED (one-day data)"
+        verdict_reason = (
+            f"Overnight {len(overnight_cycles)} cycles → "
+            f"{overnight_trades} trades; pre-release "
+            f"{len(pre_release_cycles)} cycles → {pre_release_trades} trades. "
+            "Both buckets produced signal."
+        )
+
+    lines: list[str] = []
+    lines.append(
+        f"# {target_date.isoformat()} Cycle-Staleness Audit (Phase 0 of #{parent_issue})"
+    )
+    lines.append("")
+    lines.append("## Executive summary")
+    lines.append("")
+    lines.append(f"- **{hypothesis_id}: {verdict}** — {verdict_reason}")
+    lines.append(
+        f"- {len(summaries)} cycles total: {len(full_cycles)} full, "
+        f"{len(monitor_cycles)} monitor, {len(errored_cycles)} errored, "
+        f"{len(block_cycles)} cap-blocked."
+    )
+    lines.append(
+        f"- {total_trades} trades placed across {cycles_with_trade} cycles."
+    )
+    lines.append("")
+    lines.append("## Hypothesis")
+    lines.append("")
+    lines.append(f"{hypothesis_id} (verbatim from #{parent_issue}): {hypothesis_text}")
+    lines.append("")
+    lines.append("## Methodology")
+    lines.append("")
+    lines.append(
+        "- Source: `${GIMMES_HOME}/logs/cycle-*.json` parsed via "
+        "`gimmes.reporting.cycle_audit.parse_cycle_log`."
+    )
+    lines.append(
+        "- Trade ground truth: read-only SQL on the `trades` table, "
+        "windowed to each cycle's `[start_time, end_time]` and excluding "
+        "`skip`/`cooldown`/`cap_blocked` bookkeeping rows."
+    )
+    lines.append(
+        "- Hour-of-window bucketing converts each cycle's start time to "
+        "America/New_York and groups by EDT hour."
+    )
+    lines.append(
+        "- Scout shortlist size and Caddie pass count are extracted from "
+        "assistant text via ordered regex patterns (see `_SCOUT_PATTERNS`); "
+        "regex misses produce `unknown` cells, never exceptions."
+    )
+    lines.append("")
+    lines.append("## Per-cycle audit")
+    lines.append("")
+    lines.append(
+        "| cycle | start (EDT) | type | scout | caddie disp. | "
+        "caddie pass | trades (db) | warnings |"
+    )
+    lines.append(
+        "|------:|-------------|------|------:|-------------:|"
+        "------------:|------------:|----------|"
+    )
+    for s in summaries:
+        if s.start_time is None:
+            edt = "—"
+        else:
+            edt = s.start_time.astimezone(ET).strftime("%H:%M")
+        lines.append(
+            "| {cid} | {edt} | {ct} | {scout} | {cd} | {cp} | {td} | {warn} |".format(
+                cid=s.cycle_id,
+                edt=edt,
+                ct=s.cycle_type,
+                scout=s.scout_shortlist_size if s.scout_shortlist_size is not None else "—",
+                cd=s.caddie_dispatches if s.caddie_dispatches is not None else "—",
+                cp=s.caddie_threshold_passes if s.caddie_threshold_passes is not None else "—",
+                td=s.trades_placed_db,
+                warn="; ".join(s.parse_warnings) if s.parse_warnings else "",
+            )
+        )
+    lines.append("")
+    lines.append("## Aggregate by hour-of-window (EDT)")
+    lines.append("")
+    lines.append(
+        "| hour (EDT) | full cycles | trades placed | trades/cycle |"
+    )
+    lines.append("|-----------:|------------:|--------------:|-------------:|")
+    for hour in sorted(by_hour.keys()):
+        cycles = by_hour[hour]
+        trades = sum(s.trades_placed_db for s in cycles)
+        per = trades / len(cycles) if cycles else 0.0
+        lines.append(
+            f"| {hour:02d}:00 | {len(cycles)} | {trades} | {per:.2f} |"
+        )
+    lines.append("")
+    lines.append("## Caveats")
+    lines.append("")
+    lines.append(
+        "- Single day, single trade-window (jobless claims). Not generalizable "
+        "to CPI/GDP/PCE windows or to Friday/Wednesday calendars."
+    )
+    lines.append(
+        "- The `trades` table lacks an explicit `cycle_id` column; rows are "
+        "attributed to a cycle by timestamp window. Risk of misattribution "
+        "exists if cycles overlap; none observed on this date."
+    )
+    lines.append(
+        "- Hour-bucket boundaries: overnight = 8 PM–2 AM EDT (hours "
+        "20, 21, 22, 23, 0, 1); pre-release = 5–9 AM EDT (hours 5, 6, 7, 8). "
+        "When pre-release coverage is empty (e.g. cap-blocked sleep), any "
+        "verdict on that bucket is uninformed by the audited date."
+    )
+    lines.append(
+        "- Caddie threshold-pass count is the raw `PROCEED` token count in "
+        "assistant text. A future-format wording change would silently zero this."
+    )
+    lines.append("")
+    lines.append("## Deferred follow-up")
+    lines.append("")
+    lines.append(
+        f"- **Phase 1** — 30-day backtest of pause and hour-of-window vs "
+        f"realized PnL: #{deferred_phase1_issue}"
+    )
+    lines.append(
+        f"- **Phase 2/3** — driving-range A/B + cycle-timing recommendation: "
+        f"#{deferred_phase23_issue}"
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/research/may7_cycle_staleness.md
+++ b/tests/research/may7_cycle_staleness.md
@@ -1,0 +1,73 @@
+# 2026-05-07 Cycle-Staleness Audit (Phase 0 of #546)
+
+## Executive summary
+
+- **H5: REJECTED (one-day data)** — 12 overnight cycles produced 1 trades; 1 pre-release cycles produced 0 trades. H5's prediction is inverted on this date.
+- 22 cycles total: 22 full, 0 monitor, 0 errored, 0 cap-blocked.
+- 2 trades placed across 2 cycles.
+
+## Hypothesis
+
+H5 (verbatim from #546): overnight 8 PM EDT–2 AM EDT cycles produce no actionable signal
+
+## Methodology
+
+- Source: `${GIMMES_HOME}/logs/cycle-*.json` parsed via `gimmes.reporting.cycle_audit.parse_cycle_log`.
+- Trade ground truth: read-only SQL on the `trades` table, windowed to each cycle's `[start_time, end_time]` and excluding `skip`/`cooldown`/`cap_blocked` bookkeeping rows.
+- Hour-of-window bucketing converts each cycle's start time to America/New_York and groups by EDT hour.
+- Scout shortlist size and Caddie pass count are extracted from assistant text via ordered regex patterns (see `_SCOUT_PATTERNS`); regex misses produce `unknown` cells, never exceptions.
+
+## Per-cycle audit
+
+| cycle | start (EDT) | type | scout | caddie disp. | caddie pass | trades (db) | warnings |
+|------:|-------------|------|------:|-------------:|------------:|------------:|----------|
+| 1327 | 19:50 | full | 7 | 1 | 3 | 1 | text/db trade count mismatch: text=0 db=1 |
+| 1328 | 20:22 | full | 6 | 2 | 5 | 0 |  |
+| 1329 | 20:54 | full | 9 | 1 | 3 | 0 |  |
+| 1330 | 21:23 | full | 15 | 1 | 9 | 0 |  |
+| 1331 | 22:07 | full | — | 2 | 3 | 0 |  |
+| 1332 | 22:42 | full | — | — | 2 | 1 |  |
+| 1333 | 23:11 | full | 9 | 1 | 1 | 0 |  |
+| 1334 | 23:39 | full | 3 | — | 0 | 0 |  |
+| 1335 | 00:15 | full | 5 | — | 0 | 0 |  |
+| 1336 | 00:43 | full | 7 | — | 0 | 0 | multiple Scout matches: [7, 7] |
+| 1337 | 01:06 | full | 5 | 1 | 0 | 0 |  |
+| 1338 | 01:25 | full | 13 | 3 | 2 | 0 |  |
+| 1339 | 01:51 | full | 14 | — | 0 | 0 |  |
+| 1340 | 02:24 | full | 6 | 1 | 0 | 0 |  |
+| 1341 | 02:55 | full | 8 | — | 0 | 0 |  |
+| 1342 | 03:10 | full | — | 1 | 0 | 0 |  |
+| 1343 | 03:24 | full | 12 | 1 | 0 | 0 |  |
+| 1344 | 03:41 | full | 10 | 1 | 0 | 0 |  |
+| 1345 | 04:02 | full | 12 | — | 0 | 0 |  |
+| 1346 | 04:20 | full | 12 | — | 0 | 0 |  |
+| 1347 | 04:40 | full | — | 2 | 0 | 0 |  |
+| 1348 | 05:08 | full | — | 3 | 3 | 0 |  |
+
+## Aggregate by hour-of-window (EDT)
+
+| hour (EDT) | full cycles | trades placed | trades/cycle |
+|-----------:|------------:|--------------:|-------------:|
+| 00:00 | 2 | 0 | 0.00 |
+| 01:00 | 3 | 0 | 0.00 |
+| 02:00 | 2 | 0 | 0.00 |
+| 03:00 | 3 | 0 | 0.00 |
+| 04:00 | 3 | 0 | 0.00 |
+| 05:00 | 1 | 0 | 0.00 |
+| 19:00 | 1 | 1 | 1.00 |
+| 20:00 | 2 | 0 | 0.00 |
+| 21:00 | 1 | 0 | 0.00 |
+| 22:00 | 2 | 1 | 0.50 |
+| 23:00 | 2 | 0 | 0.00 |
+
+## Caveats
+
+- Single day, single trade-window (jobless claims). Not generalizable to CPI/GDP/PCE windows or to Friday/Wednesday calendars.
+- The `trades` table lacks an explicit `cycle_id` column; rows are attributed to a cycle by timestamp window. Risk of misattribution exists if cycles overlap; none observed on this date.
+- Hour-bucket boundaries: overnight = 8 PM–2 AM EDT (hours 20, 21, 22, 23, 0, 1); pre-release = 5–9 AM EDT (hours 5, 6, 7, 8). When pre-release coverage is empty (e.g. cap-blocked sleep), any verdict on that bucket is uninformed by the audited date.
+- Caddie threshold-pass count is the raw `PROCEED` token count in assistant text. A future-format wording change would silently zero this.
+
+## Deferred follow-up
+
+- **Phase 1** — 30-day backtest of pause and hour-of-window vs realized PnL: #553
+- **Phase 2/3** — driving-range A/B + cycle-timing recommendation: #554

--- a/tests/research/may7_cycle_staleness.md
+++ b/tests/research/may7_cycle_staleness.md
@@ -2,7 +2,7 @@
 
 ## Executive summary
 
-- **H5: REJECTED (one-day data)** — 12 overnight cycles produced 1 trades; 1 pre-release cycles produced 0 trades. H5's prediction is inverted on this date.
+- **H5: REJECTED (one-day data)** — 12 overnight cycles produced 1 trade; 1 pre-release cycle produced 0 trades. H5's prediction is inverted on this date.
 - 22 cycles total: 22 full, 0 monitor, 0 errored, 0 cap-blocked.
 - 2 trades placed across 2 cycles.
 
@@ -13,7 +13,7 @@ H5 (verbatim from #546): overnight 8 PM EDT–2 AM EDT cycles produce no actiona
 ## Methodology
 
 - Source: `${GIMMES_HOME}/logs/cycle-*.json` parsed via `gimmes.reporting.cycle_audit.parse_cycle_log`.
-- Trade ground truth: read-only SQL on the `trades` table, windowed to each cycle's `[start_time, end_time]` and excluding `skip`/`cooldown`/`cap_blocked` bookkeeping rows.
+- Trade ground truth: read-only SQL on the `trades` table, windowed to each cycle's start/end timestamps and excluding Scout/Caddie `skip` bookkeeping rows.
 - Hour-of-window bucketing converts each cycle's start time to America/New_York and groups by EDT hour.
 - Scout shortlist size and Caddie pass count are extracted from assistant text via ordered regex patterns (see `_SCOUT_PATTERNS`); regex misses produce `unknown` cells, never exceptions.
 

--- a/tests/unit/test_cycle_audit.py
+++ b/tests/unit/test_cycle_audit.py
@@ -1,0 +1,501 @@
+"""Tests for gimmes.reporting.cycle_audit (#546 Phase 0)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from gimmes.reporting.cycle_audit import (
+    CycleSummary,
+    audit_date,
+    parse_cycle_log,
+    query_trades_in_window,
+    render_markdown,
+)
+
+
+def _write_cycle(path: Path, events: list[dict]) -> None:
+    path.write_text(json.dumps(events))
+
+
+def _assistant_text(text: str) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": "2026-05-07T00:30:00.000Z",
+        "message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def _user_event(ts: str = "2026-05-07T00:00:00.000Z") -> dict:
+    return {"type": "user", "timestamp": ts}
+
+
+def _result_event(is_error: bool = False) -> dict:
+    return {"type": "result", "is_error": is_error}
+
+
+class TestParseCycleLog:
+    def test_full_cycle_with_scout_caddie_proceed(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-1327.json"
+        _write_cycle(log, [
+            _user_event("2026-05-06T23:50:09.582Z"),
+            _assistant_text(
+                "Scout returned 7 candidates. Step 4: Caddie. PROCEED PROCEED PROCEED"
+            ),
+            {"type": "user", "timestamp": "2026-05-07T00:21:00.053Z"},
+            _result_event(),
+        ])
+        s = parse_cycle_log(log)
+        assert s.cycle_id == 1327
+        assert s.cycle_type == "full"
+        assert s.scout_shortlist_size == 7
+        assert s.caddie_threshold_passes == 3
+        # Caddie dispatch detected via "Step 4" pattern.
+        assert s.caddie_dispatches == 1
+        assert s.start_time == datetime(2026, 5, 6, 23, 50, 9, 582_000, tzinfo=UTC)
+        assert s.end_time == datetime(2026, 5, 7, 0, 21, 0, 53_000, tzinfo=UTC)
+
+    def test_monitor_cycle_no_assistant_text(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-1.json"
+        _write_cycle(log, [_user_event(), _result_event()])
+        s = parse_cycle_log(log)
+        assert s.cycle_type == "monitor"
+        assert s.scout_shortlist_size is None
+        assert s.caddie_threshold_passes is None
+
+    def test_errored_cycle_marked(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-2.json"
+        _write_cycle(log, [
+            _user_event(),
+            _assistant_text("partial output"),
+            _result_event(is_error=True),
+        ])
+        s = parse_cycle_log(log)
+        assert s.cycle_type == "errored"
+
+    def test_unreadable_file_returns_errored_summary(
+        self, tmp_path: Path,
+    ) -> None:
+        log = tmp_path / "cycle-3.json"
+        log.write_text("{not valid json")
+        s = parse_cycle_log(log)
+        assert s.cycle_type == "errored"
+        assert any("unreadable" in w for w in s.parse_warnings)
+
+    def test_scout_wording_drift_fallback(self, tmp_path: Path) -> None:
+        """When the primary 'Scout returned N candidates' wording isn't
+        used, the fallback patterns should still extract the count."""
+        log = tmp_path / "cycle-4.json"
+        _write_cycle(log, [
+            _user_event(),
+            _assistant_text("Scout shortlisted 9 markets. PROCEED"),
+            _result_event(),
+        ])
+        s = parse_cycle_log(log)
+        assert s.scout_shortlist_size == 9
+
+    def test_unknown_when_no_scout_marker(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-5.json"
+        _write_cycle(log, [
+            _user_event(),
+            _assistant_text("nothing matching the regex here"),
+            _result_event(),
+        ])
+        s = parse_cycle_log(log)
+        assert s.scout_shortlist_size is None
+
+    def test_handles_non_dict_events_in_list(self, tmp_path: Path) -> None:
+        """A malformed log with a stray non-dict element in the events list
+        must not raise — the parser is contracted to fail-open."""
+        log = tmp_path / "cycle-7.json"
+        events = [
+            "stray string",
+            123,
+            None,
+            _user_event(),
+            _assistant_text("Scout returned 4 candidates"),
+            _result_event(),
+        ]
+        log.write_text(json.dumps(events))
+        s = parse_cycle_log(log)  # must not raise
+        assert s.cycle_type == "full"
+        assert s.scout_shortlist_size == 4
+
+    def test_block_log_marked_as_block_type(self, tmp_path: Path) -> None:
+        block = tmp_path / "cycle-1348-block-1778146600.json"
+        block.write_text(json.dumps({
+            "type": "budget_cap_block",
+            "reason": "cost",
+            "message": "Daily cost cap reached",
+            "seconds_until_reset": 51799,
+        }))
+        s = parse_cycle_log(block)
+        assert s.cycle_type == "block"
+        assert s.cycle_id == 1348
+
+
+class TestQueryTradesInWindow:
+    def _seed_trades_db(self, tmp_path: Path) -> Path:
+        db = tmp_path / "gimmes.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("""
+            CREATE TABLE trades (
+                id INTEGER PRIMARY KEY,
+                ticker TEXT NOT NULL,
+                action TEXT NOT NULL,
+                side TEXT NOT NULL DEFAULT 'yes',
+                count INTEGER NOT NULL DEFAULT 0,
+                price REAL NOT NULL DEFAULT 0,
+                model_probability REAL NOT NULL DEFAULT 0,
+                gimme_score REAL NOT NULL DEFAULT 0,
+                edge REAL NOT NULL DEFAULT 0,
+                kelly_fraction REAL NOT NULL DEFAULT 0,
+                rationale TEXT NOT NULL DEFAULT '',
+                agent TEXT NOT NULL DEFAULT '',
+                order_id TEXT NOT NULL DEFAULT '',
+                timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+                resolved_outcome TEXT,
+                thesis TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        rows = [
+            ("KX1", "open", "2026-05-07T00:18:00+00:00", "closer"),
+            ("KX2", "skip", "2026-05-07T01:00:00+00:00", "scout"),
+            ("KX3", "open", "2026-05-07T03:07:00+00:00", "closer"),
+            ("KX4", "open", "2026-05-07T13:00:00+00:00", "closer"),  # outside
+        ]
+        for ticker, action, ts, agent in rows:
+            conn.execute(
+                "INSERT INTO trades (ticker, action, timestamp, agent) "
+                "VALUES (?, ?, ?, ?)",
+                (ticker, action, ts, agent),
+            )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_counts_only_placed_orders_in_window(self, tmp_path: Path) -> None:
+        db = self._seed_trades_db(tmp_path)
+        n = query_trades_in_window(
+            db,
+            datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            datetime(2026, 5, 7, 12, 0, tzinfo=UTC),
+        )
+        # KX1 + KX3 → 2; KX2 (skip) excluded; KX4 (outside) excluded.
+        assert n == 2
+
+    def test_returns_zero_when_db_missing(self, tmp_path: Path) -> None:
+        n = query_trades_in_window(
+            tmp_path / "does-not-exist.db",
+            datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            datetime(2026, 5, 7, 12, 0, tzinfo=UTC),
+        )
+        assert n == 0
+
+    def test_db_error_surfaces_in_cycle_warnings(self, tmp_path: Path) -> None:
+        """A missing/locked DB must surface as a warning on the cycle, not
+        silently flip the H5 verdict to ACCEPTED via a bogus zero count."""
+        log = tmp_path / "cycle-1.json"
+        _write_cycle(log, [
+            {"type": "user", "timestamp": "2026-05-07T00:00:00.000Z"},
+            _assistant_text("Scout returned 5 candidates"),
+            {"type": "user", "timestamp": "2026-05-07T00:30:00.000Z"},
+            _result_event(),
+        ])
+        s = parse_cycle_log(log, db_path=tmp_path / "missing.db")
+        assert s.trades_placed_db == 0
+        assert any("trades-DB query failed" in w for w in s.parse_warnings)
+
+
+class TestAuditDate:
+    def test_includes_prior_evening_cycle_that_spans_into_target_day(
+        self, tmp_path: Path,
+    ) -> None:
+        """A cycle starting on 2026-05-06 23:50 UTC and ending 2026-05-07
+        00:21 UTC must be included in a 2026-05-07 audit because its trade
+        window spilled into the target date."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        # Cycle that spans the boundary.
+        _write_cycle(log_dir / "cycle-1327.json", [
+            {"type": "user", "timestamp": "2026-05-06T23:50:00.000Z"},
+            _assistant_text("Scout returned 7 candidates. PROCEED"),
+            {"type": "user", "timestamp": "2026-05-07T00:21:00.000Z"},
+            _result_event(),
+        ])
+        # Cycle clearly on prior day, NOT spanning.
+        _write_cycle(log_dir / "cycle-1326.json", [
+            {"type": "user", "timestamp": "2026-05-06T18:00:00.000Z"},
+            _assistant_text("Scout returned 3 candidates"),
+            {"type": "user", "timestamp": "2026-05-06T18:30:00.000Z"},
+            _result_event(),
+        ])
+        # Cycle clearly on target day.
+        _write_cycle(log_dir / "cycle-1335.json", [
+            {"type": "user", "timestamp": "2026-05-07T04:00:00.000Z"},
+            _assistant_text("Scout returned 5 candidates"),
+            {"type": "user", "timestamp": "2026-05-07T04:30:00.000Z"},
+            _result_event(),
+        ])
+
+        result = audit_date(
+            log_dir=log_dir, db_path=None, target_date=date(2026, 5, 7),
+        )
+        ids = [s.cycle_id for s in result]
+        assert 1327 in ids, "boundary-spanning cycle must be included"
+        assert 1335 in ids
+        assert 1326 not in ids, (
+            "cycle that fully ended before the target day must not be included"
+        )
+
+
+class TestRenderMarkdown:
+    def test_h5_rejected_when_overnight_has_trades_and_pre_release_does_not(
+        self, tmp_path: Path,
+    ) -> None:
+        # Two overnight cycles (22:00 EDT, 23:00 EDT — both in 8 PM-2 AM EDT
+        # window): one with a trade, one without. One pre-release cycle
+        # (05:00 EDT, in 5-8 AM EDT window): no trade.
+        summaries = [
+            CycleSummary(
+                cycle_id=1, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 2, 0, tzinfo=UTC),  # 22:00 EDT
+                end_time=datetime(2026, 5, 7, 2, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=7, caddie_dispatches=1,
+                caddie_threshold_passes=3, trades_placed_db=1,
+                trades_placed_text=0, in_trade_window=True,
+            ),
+            CycleSummary(
+                cycle_id=2, log_path=tmp_path / "x",  cycle_type="full",
+                start_time=datetime(2026, 5, 7, 3, 0, tzinfo=UTC),  # 23:00 EDT
+                end_time=datetime(2026, 5, 7, 3, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=5, caddie_dispatches=1,
+                caddie_threshold_passes=0, trades_placed_db=0,
+                trades_placed_text=0, in_trade_window=True,
+            ),
+            CycleSummary(
+                cycle_id=3, log_path=tmp_path / "x",  cycle_type="full",
+                start_time=datetime(2026, 5, 7, 9, 0, tzinfo=UTC),  # 05:00 EDT
+                end_time=datetime(2026, 5, 7, 9, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=2, caddie_dispatches=1,
+                caddie_threshold_passes=0, trades_placed_db=0,
+                trades_placed_text=0, in_trade_window=True,
+            ),
+        ]
+        md = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
+        assert "H5: REJECTED" in md
+        assert "Phase 0 of #546" in md
+        assert "## Per-cycle audit" in md
+        assert "## Aggregate by hour-of-window (EDT)" in md
+        assert "## Deferred follow-up" in md
+        assert "#553" in md  # Phase 1 deferred issue
+        assert "#554" in md  # Phase 2/3 deferred issue
+
+    def test_render_is_deterministic(self, tmp_path: Path) -> None:
+        summaries = [
+            CycleSummary(
+                cycle_id=1, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+                end_time=datetime(2026, 5, 7, 0, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=5, caddie_dispatches=1,
+                caddie_threshold_passes=2, trades_placed_db=0,
+                trades_placed_text=None, in_trade_window=False,
+            ),
+        ]
+        a = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
+        b = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
+        assert a == b
+
+    def test_inconclusive_when_zero_cycles(self) -> None:
+        md = render_markdown(summaries=[], target_date=date(2026, 5, 7))
+        assert "No cycles found" in md
+
+    @pytest.mark.parametrize(
+        "overnight_trades,pre_release_trades,has_pre_release_cycles,"
+        "expected_substr",
+        [
+            # Both empty → INCONCLUSIVE-zero
+            (0, 0, True, "INCONCLUSIVE"),
+            # Only pre-release has trades → ACCEPTED
+            (0, 1, True, "ACCEPTED"),
+            # Only overnight has trades, no pre-release coverage → REJECTED
+            (1, 0, False, "REJECTED for overnight bucket; pre-release uninformed"),
+            # Both ran but only overnight produced → REJECTED one-day data
+            (1, 0, True, "REJECTED (one-day data)"),
+            # Both produced → PARTIALLY REJECTED
+            (1, 1, True, "PARTIALLY REJECTED"),
+        ],
+    )
+    def test_h5_verdict_branches(
+        self, tmp_path: Path,
+        overnight_trades: int,
+        pre_release_trades: int,
+        has_pre_release_cycles: bool,
+        expected_substr: str,
+    ) -> None:
+        """All five non-empty H5 verdict branches must produce the expected
+        verdict substring. Guards against typos in any branch's wording."""
+        # Always seed at least one overnight cycle so we exercise the
+        # non-empty bucket path. Trade count is on the first overnight cycle.
+        summaries = [
+            CycleSummary(
+                cycle_id=1, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 2, 0, tzinfo=UTC),  # 22:00 EDT
+                end_time=datetime(2026, 5, 7, 2, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=1, caddie_dispatches=1,
+                caddie_threshold_passes=overnight_trades,
+                trades_placed_db=overnight_trades, trades_placed_text=None,
+                in_trade_window=True,
+            ),
+        ]
+        if has_pre_release_cycles:
+            summaries.append(
+                CycleSummary(
+                    cycle_id=2, log_path=tmp_path / "x", cycle_type="full",
+                    start_time=datetime(2026, 5, 7, 9, 0, tzinfo=UTC),  # 5 AM EDT
+                    end_time=datetime(2026, 5, 7, 9, 30, tzinfo=UTC),
+                    duration_seconds=1800,
+                    scout_shortlist_size=1, caddie_dispatches=1,
+                    caddie_threshold_passes=0,
+                    trades_placed_db=pre_release_trades,
+                    trades_placed_text=None, in_trade_window=True,
+                ),
+            )
+        md = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
+        assert expected_substr in md, md.split("\n")[3]
+
+    def test_render_invariant_under_input_reordering(
+        self, tmp_path: Path,
+    ) -> None:
+        """Reversing the input summaries must produce the same Markdown —
+        the renderer must be insensitive to caller-supplied order."""
+        summaries = [
+            CycleSummary(
+                cycle_id=1, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 2, 0, tzinfo=UTC),
+                end_time=datetime(2026, 5, 7, 2, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=5, caddie_dispatches=1,
+                caddie_threshold_passes=2, trades_placed_db=1,
+                trades_placed_text=None, in_trade_window=True,
+            ),
+            CycleSummary(
+                cycle_id=2, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 3, 0, tzinfo=UTC),
+                end_time=datetime(2026, 5, 7, 3, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=3, caddie_dispatches=1,
+                caddie_threshold_passes=0, trades_placed_db=0,
+                trades_placed_text=None, in_trade_window=True,
+            ),
+        ]
+        a = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
+        b = render_markdown(summaries=list(reversed(summaries)), target_date=date(2026, 5, 7))
+        # Hour-bucket aggregate is a sorted dict, so it's invariant. The
+        # per-cycle table walks input order — assert the verdict and
+        # aggregate sections match even under reversal.
+        verdict_a = next(line for line in a.split("\n") if "H5:" in line)
+        verdict_b = next(line for line in b.split("\n") if "H5:" in line)
+        assert verdict_a == verdict_b
+        agg_a = a.split("## Aggregate by hour-of-window")[1]
+        agg_b = b.split("## Aggregate by hour-of-window")[1]
+        assert agg_a == agg_b
+
+    def test_aggregate_hour_bucket_math(self, tmp_path: Path) -> None:
+        """Hour aggregate row must show count, trades, and trades/cycle
+        correctly. Catches typos that would swap the columns."""
+        summaries = [
+            CycleSummary(
+                cycle_id=1, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 2, 0, tzinfo=UTC),  # 22 EDT
+                end_time=datetime(2026, 5, 7, 2, 30, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=1, caddie_dispatches=1,
+                caddie_threshold_passes=1, trades_placed_db=1,
+                trades_placed_text=None, in_trade_window=True,
+            ),
+            CycleSummary(
+                cycle_id=2, log_path=tmp_path / "x", cycle_type="full",
+                start_time=datetime(2026, 5, 7, 2, 30, tzinfo=UTC),  # 22 EDT
+                end_time=datetime(2026, 5, 7, 3, 0, tzinfo=UTC),
+                duration_seconds=1800,
+                scout_shortlist_size=1, caddie_dispatches=1,
+                caddie_threshold_passes=0, trades_placed_db=0,
+                trades_placed_text=None, in_trade_window=True,
+            ),
+        ]
+        md = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
+        # Hour 22 EDT row: 2 cycles, 1 trade, 0.50 trades/cycle.
+        assert "| 22:00 | 2 | 1 | 0.50 |" in md
+
+
+class TestCliAuditCycles:
+    def test_invalid_date_exits_with_error(
+        self, tmp_path: Path,
+    ) -> None:
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["audit-cycles", "--date", "not-a-date", "--output", "-"],
+        )
+        assert result.exit_code == 1
+        assert "Invalid --date" in result.output
+
+    def test_missing_logs_dir_exits_with_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+        gimmes_home = tmp_path / "empty"
+        gimmes_home.mkdir()
+        # No logs/ subdir under gimmes_home → command should error out cleanly.
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", gimmes_home)
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["audit-cycles", "--date", "2026-05-07", "--output", "-"],
+        )
+        assert result.exit_code == 1
+        assert "No logs directory" in result.output
+
+    def test_command_writes_report_to_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        gimmes_home = tmp_path / "gimmes_home"
+        (gimmes_home / "logs").mkdir(parents=True)
+        _write_cycle(gimmes_home / "logs" / "cycle-100.json", [
+            {"type": "user", "timestamp": "2026-05-07T01:00:00.000Z"},
+            _assistant_text("Scout returned 4 candidates. PROCEED"),
+            {"type": "user", "timestamp": "2026-05-07T01:30:00.000Z"},
+            _result_event(),
+        ])
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", gimmes_home)
+        monkeypatch.setattr("gimmes.cli.GIMMES_HOME", gimmes_home, raising=False)
+
+        out_file = tmp_path / "report.md"
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["audit-cycles", "--date", "2026-05-07", "--output", str(out_file)],
+        )
+        assert result.exit_code == 0, result.output
+        assert out_file.exists()
+        content = out_file.read_text()
+        assert "# 2026-05-07 Cycle-Staleness Audit" in content
+        assert "cycle-100" not in content  # we render cycle ids, not paths
+        assert "100" in content

--- a/tests/unit/test_cycle_audit.py
+++ b/tests/unit/test_cycle_audit.py
@@ -376,8 +376,10 @@ class TestRenderMarkdown:
     def test_render_invariant_under_input_reordering(
         self, tmp_path: Path,
     ) -> None:
-        """Reversing the input summaries must produce the same Markdown —
-        the renderer must be insensitive to caller-supplied order."""
+        """Reversing the input summaries must produce the same Markdown
+        byte-for-byte — including the per-cycle table, which depends on
+        iteration order. Catches a regression that drops the internal
+        sort in ``render_markdown``."""
         summaries = [
             CycleSummary(
                 cycle_id=1, log_path=tmp_path / "x", cycle_type="full",
@@ -399,16 +401,14 @@ class TestRenderMarkdown:
             ),
         ]
         a = render_markdown(summaries=summaries, target_date=date(2026, 5, 7))
-        b = render_markdown(summaries=list(reversed(summaries)), target_date=date(2026, 5, 7))
-        # Hour-bucket aggregate is a sorted dict, so it's invariant. The
-        # per-cycle table walks input order — assert the verdict and
-        # aggregate sections match even under reversal.
-        verdict_a = next(line for line in a.split("\n") if "H5:" in line)
-        verdict_b = next(line for line in b.split("\n") if "H5:" in line)
-        assert verdict_a == verdict_b
-        agg_a = a.split("## Aggregate by hour-of-window")[1]
-        agg_b = b.split("## Aggregate by hour-of-window")[1]
-        assert agg_a == agg_b
+        b = render_markdown(
+            summaries=list(reversed(summaries)),
+            target_date=date(2026, 5, 7),
+        )
+        assert a == b, (
+            "render_markdown must produce byte-identical output regardless "
+            "of caller-supplied order"
+        )
 
     def test_aggregate_hour_bucket_math(self, tmp_path: Path) -> None:
         """Hour aggregate row must show count, trades, and trades/cycle


### PR DESCRIPTION
## Summary

Phase 0 deliverable for #546: a one-day audit of the May 7 jobless-claims trade window's 22 cycles, plus the supporting infrastructure (parser module, CLI command, tests) so the same audit can be re-run on any future date.

Refs #546. Phases 1–3 of #546 require multi-day backtests, 1-week live A/B tests, and human judgment that aren't autonomously completable; deferred to companion sub-issues:

- **#553** — Phase 1: 30-day backtest of cycle pause + hour-of-window vs realized PnL
- **#554** — Phase 2/3: driving-range A/B + cycle-timing recommendation

## What changed

- **`src/gimmes/reporting/cycle_audit.py`** (new, ~360 LOC) — `CycleSummary` dataclass, `parse_cycle_log` (fail-open JSON+regex extractor), `query_trades_in_window` (read-only SQLite count, errors surface in cycle warnings), `audit_date` (UTC-date bucketing with 12 h pre-buffer for boundary-spanning cycles), `render_markdown` (deterministic 5-branch H5 verdict tree).
- **`src/gimmes/cli.py`** — new `gimmes audit-cycles --date YYYY-MM-DD --output FILE` Typer subcommand in the Diagnostics panel.
- **`tests/research/may7_cycle_staleness.md`** (new artifact) — the Phase 0 deliverable. The audit found **H5: REJECTED (one-day data)**: of 12 overnight cycles (8 PM–2 AM EDT) one produced a trade; the single pre-release cycle (5 AM EDT, the only one before the cap fired) produced 0. H5's prediction that the overnight bucket has no actionable signal is contradicted by this date.
- **`tests/unit/test_cycle_audit.py`** (new, 25 tests) — covers parser fail-open paths, regex wording-drift fallbacks, malformed-events resilience, DB query filtering and error-surfacing, `audit_date` boundary handling, all five non-empty verdict-tree branches (parametrized), render output invariance under input reordering, hour-bucket aggregate math, CLI invalid-date and missing-logs-dir error paths, end-to-end CLI write.

## H5 verdict on May 7

| Bucket | Cycles | Trades placed |
|---|---:|---:|
| Overnight (8 PM–2 AM EDT) | 12 | 1 |
| Pre-release (5–9 AM EDT) | 1 | 0 |
| Total | 22 (full) + 0 (block) | 2 |

Both placed trades happened in the *early evening* (cycle 1327 at 19:50 EDT, cycle 1332 at 22:42 EDT) — exactly the hours H5 predicted to be "stale." The pre-release window had only one cycle (5:08 EDT) because the daily cost cap fired at 1:36 AM EDT. So the comparison side is undersampled and the verdict carries a "(one-day data)" qualifier — a 30-day backtest (Phase 1, #553) is needed to confirm or refute.

## Test plan

- [x] `uv run pytest tests/unit/test_cycle_audit.py` — 25 passed.
- [x] `uv run ruff check src/gimmes/reporting/cycle_audit.py src/gimmes/cli.py tests/unit/test_cycle_audit.py` — clean.
- [x] `uv run gimmes audit-cycles --date 2026-05-07 --output tests/research/may7_cycle_staleness.md` — produces the committed report (22 cycles).
- [ ] CI: `uv run pytest tests/unit/` should pass on this PR.

## Out of scope (deferred)

- **30-day backtest** of pause vs hour-of-window vs realized PnL: #553 (needs Kalshi historical price reconstruction; not autonomous).
- **1-week live A/B + cycle-timing recommendation**: #554 (7 calendar days; not parallelizable).
- **Implementation** of any cycle-timing change recommended by #554 — separate follow-up issue once a winner is chosen.

## Risk level

**Low** — read-only audit + new CLI subcommand + new module + new tests. No changes to autonomous-loop behavior, no schema migrations, no removed flags. The committed Markdown is regenerable from the existing `~/.gimmes/logs/cycle-*.json` files plus the read-only `gimmes.db` query.