### PR TITLE
Phase 1a of #546: pause-vs-trade-coincidence + multi-day hour aggregate

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2093,6 +2093,149 @@ def audit_cycles(
         )
 
 
+@app.command(name="pause-backtest", rich_help_panel="Diagnostics")
+def pause_backtest(
+    date_from: str = typer.Option(
+        None,
+        "--from",
+        help=(
+            "UTC date (YYYY-MM-DD) to start the backtest. Defaults to the "
+            "earliest `candidates.scanned_at` date in gimmes.db."
+        ),
+    ),
+    date_to: str = typer.Option(
+        None,
+        "--to",
+        help=(
+            "UTC date (YYYY-MM-DD) to end the backtest, inclusive. "
+            "Defaults to today (UTC)."
+        ),
+    ),
+    output: str = typer.Option(
+        "-",
+        "--output",
+        "-o",
+        help="Path to write the Markdown report. '-' = stdout (default).",
+    ),
+    json_out: bool = typer.Option(
+        False, "--json",
+        help="Emit JSON instead of Markdown.",
+    ),
+) -> None:
+    """Phase 1a backtest of `pause_seconds` against trade-coincidence
+    plus hour-of-window aggregation across all on-disk cycle logs (#556).
+    """
+    import json as _json
+    import sqlite3
+    from dataclasses import asdict
+    from datetime import UTC as _UTC
+    from datetime import date as _date
+    from datetime import datetime as _datetime
+
+    from gimmes.config import GIMMES_HOME
+    from gimmes.reporting.pause_backtest import build_summary, render_markdown
+    from gimmes.strategy.calendar import is_in_trade_window
+
+    log_dir = GIMMES_HOME / "logs"
+    db_path = GIMMES_HOME / "gimmes.db"
+    if not log_dir.is_dir():
+        console.print(f"[red]No logs directory at {log_dir}[/red]")
+        raise typer.Exit(1)
+    if not db_path.exists():
+        console.print(f"[red]No database at {db_path}[/red]")
+        raise typer.Exit(1)
+
+    # Default --from to the earliest candidates.scanned_at date.
+    if date_from is None:
+        try:
+            with sqlite3.connect(
+                f"file:{db_path}?mode=ro", uri=True,
+            ) as conn:
+                row = conn.execute(
+                    "SELECT MIN(scanned_at) FROM candidates",
+                ).fetchone()
+            if row and row[0]:
+                from gimmes.reporting.pause_backtest import _parse_iso
+                earliest = _parse_iso(row[0])
+                if earliest is None:
+                    raise ValueError("unparseable scanned_at")
+                date_from_d = earliest.date()
+            else:
+                date_from_d = _datetime.now(_UTC).date()
+        except (sqlite3.Error, ValueError) as exc:
+            console.print(
+                f"[red]Could not determine default --from: {exc}[/red]",
+            )
+            raise typer.Exit(1)
+    else:
+        try:
+            date_from_d = _date.fromisoformat(date_from)
+        except ValueError as exc:
+            console.print(f"[red]Invalid --from value: {exc}[/red]")
+            raise typer.Exit(1)
+
+    if date_to is None:
+        date_to_d = _datetime.now(_UTC).date()
+    else:
+        try:
+            date_to_d = _date.fromisoformat(date_to)
+        except ValueError as exc:
+            console.print(f"[red]Invalid --to value: {exc}[/red]")
+            raise typer.Exit(1)
+
+    summary = build_summary(
+        log_dir=log_dir,
+        db_path=db_path,
+        date_from=date_from_d,
+        date_to=date_to_d,
+        in_trade_window_fn=is_in_trade_window,
+    )
+
+    if json_out:
+        payload = {
+            "date_from": summary.date_from.isoformat(),
+            "date_to": summary.date_to.isoformat(),
+            "cycles_audited": summary.cycles_audited,
+            "trades_with_no_candidate": summary.trades_with_no_candidate,
+            "warnings": summary.warnings,
+            "trades": [
+                {
+                    **asdict(t),
+                    "trade_time": t.trade_time.isoformat(),
+                    "first_seen_time": (
+                        t.first_seen_time.isoformat()
+                        if t.first_seen_time
+                        else None
+                    ),
+                }
+                for t in summary.trades
+            ],
+            "hour_buckets": [asdict(b) for b in summary.hour_buckets],
+            "gap_buckets": [asdict(b) for b in summary.gap_buckets],
+            "by_window_name": summary.by_window_name,
+        }
+        # markup/highlight off so Rich doesn't mangle JSON's `[` array
+        # delimiters into style tags or apply syntax coloring that
+        # corrupts piped output.
+        console.print(
+            _json.dumps(payload, indent=2),
+            markup=False, highlight=False, soft_wrap=True,
+        )
+        return
+
+    md = render_markdown(summary)
+    if output == "-":
+        console.print(md, markup=False, highlight=False)
+    else:
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(md)
+        console.print(
+            f"[green]Backtest written to {out_path}[/green] "
+            f"({len(summary.trades)} trades, {summary.cycles_audited} cycles)."
+        )
+
+
 @app.command(name="budget", rich_help_panel="Diagnostics")
 def budget(
     days: int = typer.Option(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2095,7 +2095,7 @@ def audit_cycles(
 
 @app.command(name="pause-backtest", rich_help_panel="Diagnostics")
 def pause_backtest(
-    date_from: str = typer.Option(
+    date_from: str | None = typer.Option(
         None,
         "--from",
         help=(
@@ -2103,7 +2103,7 @@ def pause_backtest(
             "earliest `candidates.scanned_at` date in gimmes.db."
         ),
     ),
-    date_to: str = typer.Option(
+    date_to: str | None = typer.Option(
         None,
         "--to",
         help=(
@@ -2182,6 +2182,13 @@ def pause_backtest(
         except ValueError as exc:
             console.print(f"[red]Invalid --to value: {exc}[/red]")
             raise typer.Exit(1)
+
+    if date_to_d < date_from_d:
+        console.print(
+            f"[red]--to ({date_to_d}) must be on or after --from "
+            f"({date_from_d})[/red]"
+        )
+        raise typer.Exit(1)
 
     summary = build_summary(
         log_dir=log_dir,

--- a/src/gimmes/reporting/pause_backtest.py
+++ b/src/gimmes/reporting/pause_backtest.py
@@ -1,0 +1,573 @@
+"""Phase 1a backtest of pause-vs-trade-coincidence and hour-of-window
+distribution across all available cycle logs and the SQLite ``trades``
+table.
+
+GitHub issue #556 (parent: #546). The autonomous-loop's ``pause_seconds``
+default has been suspected of being either too aggressive (burns budget)
+or too lax (misses gimmes). Phase 0 (#555) established the audit
+infrastructure for one day; this module extends the analysis across
+every day with cycle logs on disk, joins to the ``candidates`` table to
+find each placed-trade's first sighting, and bucketises the
+first-seen-to-trade gap to answer the practical question: *how many
+placed trades would a longer pause have missed?*
+
+PnL counterfactuals (would a longer pause have *changed which trades got
+placed*) require Kalshi historical orderbook data that this repo does
+not persist; deferred to #553 (Phase 1b).
+
+Read-only: opens ``${GIMMES_HOME}/gimmes.db`` with ``mode=ro`` so the
+running autonomous loop is not perturbed.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger("gimmes.pause_backtest")
+
+ET = ZoneInfo("America/New_York")
+
+# Gap buckets, lower-inclusive, upper-exclusive. ``upper=None`` is open-ended.
+GAP_BUCKETS: tuple[tuple[str, float, float | None], ...] = (
+    ("0-60s", 0.0, 60.0),
+    ("60-300s", 60.0, 300.0),
+    ("5-10min", 300.0, 600.0),
+    ("10-30min", 600.0, 1800.0),
+    ("30min+", 1800.0, None),
+)
+
+# Recommendation thresholds for the render_markdown verdict tree.
+# Tunable — not specified in #546 or #556; chosen as conservative defaults
+# until the Phase 1b PnL counterfactual (#553) can confirm or refute.
+FAST_GAP_DO_NOT_RAISE_PCT = 30.0
+FAST_GAP_LIKELY_SAFE_PCT = 5.0
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse a possibly-suffixed ISO 8601 string to UTC datetime, or None."""
+    if not value:
+        return None
+    try:
+        # candidates.scanned_at uses the SQLite "datetime('now')" form
+        # (e.g. "2026-05-07 09:26:51") with no tz; trades.timestamp uses
+        # ISO with timezone. Normalize both.
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        if "T" not in value and " " in value and "+" not in value:
+            value = value.replace(" ", "T") + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
+    except (ValueError, TypeError):
+        return None
+
+
+@dataclass(frozen=True)
+class TradeBacktest:
+    """One placed trade plus its first-sighting and timing metadata."""
+
+    trade_id: int
+    ticker: str
+    action: str
+    side: str
+    trade_time: datetime
+    first_seen_time: datetime | None
+    gap_seconds: float | None
+    hour_of_window_edt: int
+    trade_window_name: str
+    gimme_score: float | None
+    edge: float | None
+    cap_blocked_at_first_seen: bool
+
+
+@dataclass(frozen=True)
+class HourBucket:
+    """Aggregate per EDT hour-of-day across all observed days."""
+
+    hour_edt: int
+    cycles_observed: int
+    days_observed: int
+    trades_placed: int
+    trades_per_cycle: float
+
+
+@dataclass(frozen=True)
+class GapBucket:
+    label: str
+    lower_seconds: float
+    upper_seconds: float | None
+    count: int
+    pct_of_total: float
+
+
+@dataclass(frozen=True)
+class BacktestSummary:
+    trades: list[TradeBacktest]
+    hour_buckets: list[HourBucket]
+    gap_buckets: list[GapBucket]
+    by_window_name: dict[str, int]
+    date_from: date
+    date_to: date
+    cycles_audited: int
+    trades_with_no_candidate: int
+    warnings: list[str] = field(default_factory=list)
+
+
+def collect_trades(
+    db_path: Path,
+    *,
+    date_from: date,
+    date_to: date,
+    actions: tuple[str, ...] = ("open",),
+    in_trade_window_fn=None,
+) -> tuple[list[TradeBacktest], list[str]]:
+    """Read placed trades from ``db_path`` and join each to its first
+    candidate sighting. Returns ``(trades, warnings)``.
+
+    Opens a single read-only SQLite connection for the entire backtest
+    (one trades query plus one first-seen query per trade) so per-trade
+    file-descriptor churn is bounded.
+    """
+    warnings: list[str] = []
+    if not db_path.exists():
+        return [], [f"DB not found: {db_path}"]
+
+    start = datetime.combine(date_from, datetime.min.time(), tzinfo=UTC)
+    end = datetime.combine(
+        date_to + timedelta(days=1), datetime.min.time(), tzinfo=UTC,
+    )
+
+    placeholders = ", ".join("?" for _ in actions)
+    out: list[TradeBacktest] = []
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as conn:
+            cur = conn.execute(
+                f"""
+                SELECT id, ticker, action, side, timestamp
+                FROM trades
+                WHERE timestamp >= ? AND timestamp < ?
+                  AND action IN ({placeholders})
+                ORDER BY timestamp
+                """,
+                (start.isoformat(), end.isoformat(), *actions),
+            )
+            rows = cur.fetchall()
+
+            for trade_id, ticker, action, side, ts_str in rows:
+                trade_time = _parse_iso(ts_str)
+                if trade_time is None:
+                    warnings.append(
+                        f"trade #{trade_id} has unparseable timestamp"
+                    )
+                    continue
+
+                first_seen, gimme_score, edge, cap_blocked = _first_seen(
+                    conn, ticker, trade_time,
+                )
+                gap = (
+                    (trade_time - first_seen).total_seconds()
+                    if first_seen is not None
+                    else None
+                )
+
+                if in_trade_window_fn is not None:
+                    try:
+                        in_w, name, _ = in_trade_window_fn(trade_time)
+                    except Exception as exc:  # pragma: no cover - defensive
+                        warnings.append(f"calendar lookup failed: {exc}")
+                        in_w, name = False, None
+                else:
+                    in_w, name = False, None
+
+                out.append(TradeBacktest(
+                    trade_id=int(trade_id),
+                    ticker=str(ticker),
+                    action=str(action),
+                    side=str(side),
+                    trade_time=trade_time,
+                    first_seen_time=first_seen,
+                    gap_seconds=gap,
+                    hour_of_window_edt=trade_time.astimezone(ET).hour,
+                    # `is_in_trade_window` is contracted to return a non-None
+                    # name when in_w=True, but the `or "outside"` is paranoia.
+                    trade_window_name=(name or "outside") if in_w else "outside",
+                    gimme_score=gimme_score,
+                    edge=edge,
+                    cap_blocked_at_first_seen=bool(cap_blocked),
+                ))
+    except sqlite3.Error as exc:
+        return [], [f"trades query failed: {exc}"]
+
+    return out, warnings
+
+
+def _first_seen(
+    conn: sqlite3.Connection, ticker: str, before: datetime,
+) -> tuple[datetime | None, float | None, float | None, bool]:
+    """Return the candidate's earliest sighting at or before ``before``,
+    plus its gimme_score/edge/cap_blocked at that sighting. Caller owns
+    the connection (must be opened in ``mode=ro``)."""
+    try:
+        cur = conn.execute(
+            """
+            SELECT scanned_at, gimme_score, edge, cap_blocked
+            FROM candidates
+            WHERE ticker = ? AND scanned_at <= ?
+            ORDER BY scanned_at ASC
+            LIMIT 1
+            """,
+            (ticker, before.isoformat()),
+        )
+        row = cur.fetchone()
+    except sqlite3.Error as exc:
+        logger.warning("backtest: first-seen lookup failed for %s: %s", ticker, exc)
+        return None, None, None, False
+    if row is None:
+        return None, None, None, False
+    scanned_at, gimme_score, edge, cap_blocked = row
+    return _parse_iso(scanned_at), gimme_score, edge, bool(cap_blocked)
+
+
+def bucketize_gaps(trades: Iterable[TradeBacktest]) -> list[GapBucket]:
+    """Distribute trades across the predefined gap buckets.
+
+    Trades with ``gap_seconds is None`` (no candidate row) are excluded
+    from the percent-of-total denominator.
+    """
+    placed = [t for t in trades if t.gap_seconds is not None]
+    total = len(placed)
+    out: list[GapBucket] = []
+    for label, lower, upper in GAP_BUCKETS:
+        count = 0
+        for t in placed:
+            assert t.gap_seconds is not None  # narrowed by filter
+            if t.gap_seconds < lower:
+                continue
+            if upper is not None and t.gap_seconds >= upper:
+                continue
+            count += 1
+        pct = (count / total * 100.0) if total else 0.0
+        out.append(GapBucket(
+            label=label,
+            lower_seconds=lower,
+            upper_seconds=upper,
+            count=count,
+            pct_of_total=round(pct, 2),
+        ))
+    return out
+
+
+def aggregate_hours(
+    log_dir: Path,
+    db_path: Path | None,
+    *,
+    date_from: date,
+    date_to: date,
+) -> tuple[list[HourBucket], int]:
+    """Bucket every cycle log on disk whose UTC start_time falls within
+    ``[date_from, date_to]`` by EDT hour-of-day. Returns
+    ``(buckets, total_cycles_audited)``."""
+    from gimmes.reporting.cycle_audit import parse_cycle_log
+
+    by_hour: dict[int, list] = {}
+    days_by_hour: dict[int, set] = {}
+    cycles = 0
+    for log_path in sorted(log_dir.glob("cycle-*.json")):
+        if "-block-" in log_path.name:
+            continue
+        summary = parse_cycle_log(log_path, db_path=db_path)
+        if summary.start_time is None:
+            continue
+        start_utc = summary.start_time
+        d_utc = start_utc.date()
+        if not (date_from <= d_utc <= date_to):
+            continue
+        cycles += 1
+        hour_edt = start_utc.astimezone(ET).hour
+        by_hour.setdefault(hour_edt, []).append(summary)
+        days_by_hour.setdefault(hour_edt, set()).add(
+            start_utc.astimezone(ET).date(),
+        )
+
+    out: list[HourBucket] = []
+    for hour in sorted(by_hour.keys()):
+        group = by_hour[hour]
+        trades = sum(s.trades_placed_db for s in group)
+        out.append(HourBucket(
+            hour_edt=hour,
+            cycles_observed=len(group),
+            days_observed=len(days_by_hour[hour]),
+            trades_placed=trades,
+            trades_per_cycle=trades / len(group) if group else 0.0,
+        ))
+    return out, cycles
+
+
+def build_summary(
+    log_dir: Path,
+    db_path: Path,
+    *,
+    date_from: date,
+    date_to: date,
+    actions: tuple[str, ...] = ("open",),
+    in_trade_window_fn=None,
+) -> BacktestSummary:
+    """End-to-end: collect trades, bucket gaps, aggregate hours, count
+    by trade-window-name, return :class:`BacktestSummary`."""
+    trades, trade_warnings = collect_trades(
+        db_path,
+        date_from=date_from,
+        date_to=date_to,
+        actions=actions,
+        in_trade_window_fn=in_trade_window_fn,
+    )
+    hour_buckets, cycles_audited = aggregate_hours(
+        log_dir, db_path, date_from=date_from, date_to=date_to,
+    )
+    gap_buckets = bucketize_gaps(trades)
+    by_window = dict(Counter(t.trade_window_name for t in trades))
+    no_candidate = sum(1 for t in trades if t.first_seen_time is None)
+    return BacktestSummary(
+        trades=sorted(trades, key=lambda t: t.trade_time),
+        hour_buckets=hour_buckets,
+        gap_buckets=gap_buckets,
+        by_window_name=by_window,
+        date_from=date_from,
+        date_to=date_to,
+        cycles_audited=cycles_audited,
+        trades_with_no_candidate=no_candidate,
+        warnings=trade_warnings,
+    )
+
+
+def _recommendation(summary: BacktestSummary) -> tuple[str, str]:
+    """Pick one of three recommendations based on the gap distribution."""
+    placed_total = sum(b.count for b in summary.gap_buckets)
+    if placed_total == 0:
+        return ("INCONCLUSIVE", (
+            "No trades with measurable gaps in the audited range. "
+            "Cannot recommend a pause change without #553 PnL counterfactual."
+        ))
+    fast_pct = sum(
+        b.pct_of_total for b in summary.gap_buckets
+        if b.upper_seconds is not None and b.upper_seconds <= 300
+    )
+    if fast_pct >= FAST_GAP_DO_NOT_RAISE_PCT:
+        return ("DO NOT RAISE", (
+            f"{fast_pct:.0f}% of placed trades have first-seen-to-trade gaps "
+            "under 300s. Raising `pause_seconds` to 300 risks missing those "
+            "entries. Wait for #553 PnL counterfactual before changing the "
+            "default."
+        ))
+    if fast_pct <= FAST_GAP_LIKELY_SAFE_PCT:
+        return ("LIKELY SAFE TO RAISE", (
+            f"Only {fast_pct:.0f}% of placed trades have first-seen-to-trade "
+            "gaps under 300s. Raising `pause_seconds` to 300 would likely "
+            "miss few entries — but confirm with #553's PnL counterfactual "
+            "before changing the default."
+        ))
+    return ("WAIT FOR #553", (
+        f"{fast_pct:.0f}% of placed trades have gaps under 300s — too "
+        "borderline to recommend a change without the PnL counterfactual "
+        "from #553. Hold pause_seconds at the current default."
+    ))
+
+
+def render_markdown(
+    summary: BacktestSummary,
+    *,
+    parent_issue: int = 546,
+    self_issue: int = 556,
+    deferred_phase1b_issue: int = 553,
+) -> str:
+    """Render a deterministic Markdown report of the backtest summary."""
+    placed_total = sum(b.count for b in summary.gap_buckets)
+    total_trades = len(summary.trades)
+    rec_label, rec_text = _recommendation(summary)
+
+    lines: list[str] = []
+    lines.append(
+        f"# Phase 1a Pause Backtest (#{self_issue}, parent #{parent_issue})"
+    )
+    lines.append("")
+    lines.append("## Executive summary")
+    lines.append("")
+    lines.append(
+        f"- **Recommendation: {rec_label}** — {rec_text}"
+    )
+    lines.append(
+        f"- {total_trades} placed trades audited "
+        f"({summary.date_from.isoformat()} → {summary.date_to.isoformat()}); "
+        f"{summary.cycles_audited} cycle logs surveyed."
+    )
+    if summary.trades_with_no_candidate:
+        lines.append(
+            f"- {summary.trades_with_no_candidate} trade(s) had no matching "
+            "candidate row (manual log or Scout bypass) — counted in totals "
+            "but excluded from the gap distribution denominator."
+        )
+    lines.append("")
+    lines.append("## Methodology")
+    lines.append("")
+    lines.append(
+        "- Data: `~/.gimmes/logs/cycle-*.json` parsed via "
+        "`gimmes.reporting.cycle_audit.parse_cycle_log`; "
+        "`~/.gimmes/gimmes.db` opened read-only."
+    )
+    lines.append(
+        "- Trade selection: `action='open'` only (entries, not exits). "
+        "Excludes `skip` bookkeeping rows."
+    )
+    lines.append(
+        "- First-seen lookup: `MIN(scanned_at)` from `candidates` for the "
+        "trade's ticker, bounded above by the trade's `timestamp`."
+    )
+    lines.append(
+        "- Hour bucketing converts UTC `start_time` to America/New_York; "
+        "EDT hour-of-day is the bucket key."
+    )
+    lines.append(
+        "- Gap buckets: lower-inclusive, upper-exclusive. "
+        "`30min+` is open-ended."
+    )
+    lines.append("")
+    lines.append("## Hour-of-window")
+    lines.append("")
+    lines.append(
+        "| hour (EDT) | days observed | full cycles | trades placed | trades/cycle |"
+    )
+    lines.append(
+        "|-----------:|--------------:|------------:|--------------:|-------------:|"
+    )
+    for b in summary.hour_buckets:
+        lines.append(
+            f"| {b.hour_edt:02d}:00 | {b.days_observed} | "
+            f"{b.cycles_observed} | {b.trades_placed} | "
+            f"{b.trades_per_cycle:.2f} |"
+        )
+    lines.append("")
+    lines.append("## Gap distribution (first-seen → trade-placed)")
+    lines.append("")
+    lines.append(
+        f"Out of {placed_total} placed trades with a known first-seen time:"
+    )
+    lines.append("")
+    lines.append("| bucket | trades | % of placed |")
+    lines.append("|--------|------:|------------:|")
+    for b in summary.gap_buckets:
+        lines.append(
+            f"| {b.label} | {b.count} | {b.pct_of_total:.1f}% |"
+        )
+    lines.append("")
+    lines.append(
+        "Interpretation: a trade whose first-seen-to-placed gap is **under "
+        "X seconds** would have been **missed** by a re-scan cadence of X "
+        "seconds — the candidate appeared and was traded between scans. The "
+        "real loop's effective cadence is dominated by cycle wall time "
+        "(15–30 min per cycle), so `pause_seconds` is a lower bound on the "
+        "actual rescan interval."
+    )
+    lines.append("")
+    lines.append("## Per-trade detail")
+    lines.append("")
+    lines.append(
+        "| ticker | trade time (EDT) | first seen (EDT) | gap | hour (EDT) | "
+        "window | gimme | edge |"
+    )
+    lines.append(
+        "|--------|------------------|------------------|----:|-----------:|"
+        "--------|------:|-----:|"
+    )
+    for t in summary.trades:
+        trade_edt = t.trade_time.astimezone(ET).strftime("%m-%d %H:%M")
+        first_edt = (
+            t.first_seen_time.astimezone(ET).strftime("%m-%d %H:%M")
+            if t.first_seen_time is not None
+            else "—"
+        )
+        gap = (
+            f"{int(t.gap_seconds)}s"
+            if t.gap_seconds is not None
+            else "—"
+        )
+        gimme = (
+            f"{t.gimme_score:.0f}"
+            if t.gimme_score is not None
+            else "—"
+        )
+        edge_str = (
+            f"{t.edge:.2f}"
+            if t.edge is not None
+            else "—"
+        )
+        cap_flag = "*" if t.cap_blocked_at_first_seen else ""
+        lines.append(
+            f"| {t.ticker}{cap_flag} | {trade_edt} | {first_edt} | "
+            f"{gap} | {t.hour_of_window_edt:02d}:00 | "
+            f"{t.trade_window_name} | {gimme} | {edge_str} |"
+        )
+    lines.append("")
+    if any(t.cap_blocked_at_first_seen for t in summary.trades):
+        lines.append(
+            "`*` = ticker was `cap_blocked` at its first sighting "
+            "(Scout flagged it before any Caddie/Closer evaluation)."
+        )
+        lines.append("")
+    lines.append("## By trade window")
+    lines.append("")
+    lines.append("| release window | trades |")
+    lines.append("|----------------|------:|")
+    for name in sorted(summary.by_window_name.keys()):
+        lines.append(f"| {name} | {summary.by_window_name[name]} |")
+    lines.append("")
+    lines.append("## Caveats")
+    lines.append("")
+    lines.append(
+        "- **Cross-model basis**: Apr cycles ran on Opus 4.7; May cycles on "
+        "Sonnet 4.6 (post-#549). Trades placed are objectively the same, "
+        "but the cost-per-cycle differs — interpret budget-related "
+        "conclusions with care."
+    )
+    lines.append(
+        "- **Cycle cadence vs `pause_seconds`**: each cycle takes ~15-30 "
+        "min wall time; `pause_seconds` only adds inter-cycle delay. The "
+        "gap distribution measures first-seen to trade-placed wall time "
+        "regardless of where that time was spent."
+    )
+    lines.append(
+        "- **Small-N for some hour buckets**: a single overnight EDT hour "
+        "may have only one or two trades. Treat 0/1-trade rows as anecdote, "
+        "not signal."
+    )
+    lines.append(
+        "- **No PnL**: this analysis says nothing about *whether the trades "
+        "we placed were profitable*, only about *how a longer pause would "
+        f"have affected which trades got placed*. PnL counterfactual is "
+        f"#{deferred_phase1b_issue} (Phase 1b)."
+    )
+    if summary.warnings:
+        lines.append("")
+        lines.append("### Parser warnings")
+        lines.append("")
+        for w in summary.warnings:
+            lines.append(f"- {w}")
+    lines.append("")
+    lines.append("## Recommendation")
+    lines.append("")
+    lines.append(rec_text)
+    lines.append("")
+    lines.append(
+        f"PnL counterfactual deferred to #{deferred_phase1b_issue} "
+        "(needs Kalshi historical orderbook data not currently persisted)."
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/src/gimmes/reporting/pause_backtest.py
+++ b/src/gimmes/reporting/pause_backtest.py
@@ -216,13 +216,22 @@ def _first_seen(
     """Return the candidate's earliest sighting at or before ``before``,
     plus its gimme_score/edge/cap_blocked at that sighting. Caller owns
     the connection (must be opened in ``mode=ro``)."""
+    # CANNOT compare ``scanned_at`` (SQLite ``datetime('now')`` form,
+    # e.g. ``'2026-05-07 14:00:00'``) to ``before.isoformat()`` (e.g.
+    # ``'2026-05-07T14:00:00+00:00'``) lexicographically — the ``T``
+    # separator and the ``+`` offset both sort *after* a literal space,
+    # so naive lex comparison would incorrectly include same-day rows
+    # whose scanned_at is later than ``before``. Use SQLite's
+    # ``datetime(...)`` to coerce both sides to a normalized form
+    # before comparing.
     try:
         cur = conn.execute(
             """
             SELECT scanned_at, gimme_score, edge, cap_blocked
             FROM candidates
-            WHERE ticker = ? AND scanned_at <= ?
-            ORDER BY scanned_at ASC
+            WHERE ticker = ?
+              AND datetime(scanned_at) <= datetime(?)
+            ORDER BY datetime(scanned_at) ASC
             LIMIT 1
             """,
             (ticker, before.isoformat()),

--- a/tests/research/phase1a_backtest.md
+++ b/tests/research/phase1a_backtest.md
@@ -1,0 +1,103 @@
+# Phase 1a Pause Backtest (#556, parent #546)
+
+## Executive summary
+
+- **Recommendation: WAIT FOR #553** — 12% of placed trades have gaps under 300s — too borderline to recommend a change without the PnL counterfactual from #553. Hold pause_seconds at the current default.
+- 17 placed trades audited (2026-04-13 → 2026-05-07); 494 cycle logs surveyed.
+
+## Methodology
+
+- Data: `~/.gimmes/logs/cycle-*.json` parsed via `gimmes.reporting.cycle_audit.parse_cycle_log`; `~/.gimmes/gimmes.db` opened read-only.
+- Trade selection: `action='open'` only (entries, not exits). Excludes `skip` bookkeeping rows.
+- First-seen lookup: `MIN(scanned_at)` from `candidates` for the trade's ticker, bounded above by the trade's `timestamp`.
+- Hour bucketing converts UTC `start_time` to America/New_York; EDT hour-of-day is the bucket key.
+- Gap buckets: lower-inclusive, upper-exclusive. `30min+` is open-ended.
+
+## Hour-of-window
+
+| hour (EDT) | days observed | full cycles | trades placed | trades/cycle |
+|-----------:|--------------:|------------:|--------------:|-------------:|
+| 00:00 | 11 | 20 | 0 | 0.00 |
+| 01:00 | 7 | 18 | 0 | 0.00 |
+| 02:00 | 10 | 18 | 1 | 0.06 |
+| 03:00 | 12 | 24 | 0 | 0.00 |
+| 04:00 | 8 | 20 | 0 | 0.00 |
+| 05:00 | 6 | 15 | 0 | 0.00 |
+| 06:00 | 8 | 17 | 0 | 0.00 |
+| 07:00 | 7 | 17 | 0 | 0.00 |
+| 08:00 | 7 | 14 | 2 | 0.14 |
+| 09:00 | 10 | 12 | 2 | 0.17 |
+| 10:00 | 14 | 24 | 3 | 0.12 |
+| 11:00 | 9 | 17 | 1 | 0.06 |
+| 12:00 | 11 | 21 | 0 | 0.00 |
+| 13:00 | 11 | 12 | 1 | 0.08 |
+| 14:00 | 11 | 33 | 4 | 0.12 |
+| 15:00 | 12 | 44 | 3 | 0.07 |
+| 16:00 | 12 | 25 | 1 | 0.04 |
+| 17:00 | 14 | 27 | 2 | 0.07 |
+| 18:00 | 12 | 26 | 1 | 0.04 |
+| 19:00 | 10 | 21 | 1 | 0.05 |
+| 20:00 | 11 | 20 | 1 | 0.05 |
+| 21:00 | 10 | 16 | 1 | 0.06 |
+| 22:00 | 7 | 16 | 1 | 0.06 |
+| 23:00 | 9 | 17 | 1 | 0.06 |
+
+## Gap distribution (first-seen → trade-placed)
+
+Out of 17 placed trades with a known first-seen time:
+
+| bucket | trades | % of placed |
+|--------|------:|------------:|
+| 0-60s | 0 | 0.0% |
+| 60-300s | 2 | 11.8% |
+| 5-10min | 0 | 0.0% |
+| 10-30min | 3 | 17.6% |
+| 30min+ | 12 | 70.6% |
+
+Interpretation: a trade whose first-seen-to-placed gap is **under X seconds** would have been **missed** by a re-scan cadence of X seconds — the candidate appeared and was traded between scans. The real loop's effective cadence is dominated by cycle wall time (15–30 min per cycle), so `pause_seconds` is a lower bound on the actual rescan interval.
+
+## Per-trade detail
+
+| ticker | trade time (EDT) | first seen (EDT) | gap | hour (EDT) | window | gimme | edge |
+|--------|------------------|------------------|----:|-----------:|--------|------:|-----:|
+| KXCPIYOY-26MAY-T3.8 | 04-16 15:08 | 04-16 07:25 | 27799s | 15:00 | Index contracts | 80 | 0.29 |
+| KXCPICORE-26APR-T0.3 | 04-21 14:13 | 04-13 17:09 | 680681s | 14:00 | Index contracts | 68 | 0.36 |
+| KXJOBLESSCLAIMS-26APR23-215000 | 04-21 14:40 | 04-20 23:23 | 55000s | 14:00 | Index contracts | 75 | 0.07 |
+| KXADP-26APR-T100000 | 04-21 15:21 | 04-14 14:35 | 607556s | 15:00 | Index contracts | 73 | 0.09 |
+| KXCPI-26APR-T0.5 | 04-22 10:30 | 04-14 14:14 | 677722s | 10:00 | Treasury notes | 58 | 0.13 |
+| KXINX-26APR24H1600-B7137 | 04-22 22:54 | 04-22 22:20 | 2058s | 22:00 | Jobless claims | 75 | 0.14 |
+| KXUE-CAN26APR-6.6 | 04-23 02:16 | 04-23 01:58 | 1112s | 02:00 | Jobless claims | 67 | 0.14 |
+| KXADP-26APR-T100000 | 04-24 15:26 | 04-14 14:35 | 867043s | 15:00 | Index contracts | 73 | 0.09 |
+| KXPCECORE-26APR-T0.3 | 04-28 15:22 | 04-20 13:40 | 697361s | 15:00 | Index contracts | 48 | -0.22 |
+| KXCPIYOY-26MAY-T4.1 | 04-28 18:27 | 04-28 18:24 | 168s | 18:00 | ADP | 84 | 0.27 |
+| KXGDP-26APR30-T2.5 | 04-29 09:13 | 04-29 08:54 | 1149s | 09:00 | Treasury notes | 70 | 0.06 |
+| KXGDP-26APR30-T3.0 | 04-29 09:29 | 04-29 08:53 | 2110s | 09:00 | Treasury notes | 80 | 0.07 |
+| KXCPIYOY-26APR-T3.7 | 04-29 11:55 | 04-14 14:14 | 1287654s | 11:00 | Treasury notes | 68 | 0.16 |
+| KXCPIYOY-26JUN-T3.9 | 04-29 16:44 | 04-29 16:42 | 158s | 16:00 | outside | 72 | 0.24 |
+| KXCPIYOY-26MAY-T4.2 | 04-29 21:53 | 04-29 21:36 | 1048s | 21:00 | GDP Advance | 81 | 0.23 |
+| KXCPI-26APR-T0.5 | 05-06 20:18 | 04-14 14:14 | 1922627s | 20:00 | Jobless claims | 58 | 0.13 |
+| KXU3-26APR-T4.3 | 05-06 23:07 | 04-23 15:51 | 1149321s | 23:00 | Jobless claims | 72 | 0.05 |
+
+## By trade window
+
+| release window | trades |
+|----------------|------:|
+| ADP | 1 |
+| GDP Advance | 1 |
+| Index contracts | 6 |
+| Jobless claims | 4 |
+| Treasury notes | 4 |
+| outside | 1 |
+
+## Caveats
+
+- **Cross-model basis**: Apr cycles ran on Opus 4.7; May cycles on Sonnet 4.6 (post-#549). Trades placed are objectively the same, but the cost-per-cycle differs — interpret budget-related conclusions with care.
+- **Cycle cadence vs `pause_seconds`**: each cycle takes ~15-30 min wall time; `pause_seconds` only adds inter-cycle delay. The gap distribution measures first-seen to trade-placed wall time regardless of where that time was spent.
+- **Small-N for some hour buckets**: a single overnight EDT hour may have only one or two trades. Treat 0/1-trade rows as anecdote, not signal.
+- **No PnL**: this analysis says nothing about *whether the trades we placed were profitable*, only about *how a longer pause would have affected which trades got placed*. PnL counterfactual is #553 (Phase 1b).
+
+## Recommendation
+
+12% of placed trades have gaps under 300s — too borderline to recommend a change without the PnL counterfactual from #553. Hold pause_seconds at the current default.
+
+PnL counterfactual deferred to #553 (needs Kalshi historical orderbook data not currently persisted).

--- a/tests/unit/test_pause_backtest.py
+++ b/tests/unit/test_pause_backtest.py
@@ -176,6 +176,50 @@ class TestCollectTrades:
         assert trades == []
         assert any("DB not found" in w for w in warnings)
 
+    def test_first_seen_excludes_candidates_after_trade(
+        self, tmp_path: Path,
+    ) -> None:
+        """If the only candidate row for a ticker was scanned AFTER the
+        trade was placed, ``first_seen_time`` must be ``None``. Pins the
+        SQL contract that catches the ``T`` vs space separator bug
+        — without `datetime(scanned_at) <= datetime(?)` SQLite would lex-
+        compare and incorrectly include same-day post-trade sightings.
+        """
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        # Trade at 14:00, candidate at 14:30 (later). The candidate must
+        # NOT count as a first-sighting for this trade.
+        _add_candidate(db, "KX1", "2026-05-07 14:30:00")
+        _add_trade(db, "KX1", "open", "2026-05-07T14:00:00+00:00")
+
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert len(trades) == 1
+        assert trades[0].first_seen_time is None
+        assert trades[0].gap_seconds is None
+
+    def test_first_seen_picks_the_pre_trade_row_when_post_trade_also_exists(
+        self, tmp_path: Path,
+    ) -> None:
+        """Two candidate rows: one before the trade, one after. The query
+        must select only the pre-trade row."""
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        _add_candidate(db, "KX1", "2026-05-07 13:50:00", gimme_score=70.0)
+        _add_candidate(db, "KX1", "2026-05-07 14:30:00", gimme_score=99.0)
+        _add_trade(db, "KX1", "open", "2026-05-07T14:00:00+00:00")
+
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        # Pre-trade sighting at 13:50 → 10 minutes before 14:00.
+        assert trades[0].first_seen_time == datetime(
+            2026, 5, 7, 13, 50, tzinfo=UTC,
+        )
+        assert trades[0].gap_seconds == 600.0
+        assert trades[0].gimme_score == 70.0  # not the post-trade 99
+
     def test_cap_blocked_flagged(self, tmp_path: Path) -> None:
         db = tmp_path / "gimmes.db"
         _seed_db(db)

--- a/tests/unit/test_pause_backtest.py
+++ b/tests/unit/test_pause_backtest.py
@@ -1,0 +1,477 @@
+"""Tests for gimmes.reporting.pause_backtest (#556 / Phase 1a)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes.cli import app
+from gimmes.reporting.pause_backtest import (
+    GAP_BUCKETS,
+    BacktestSummary,
+    GapBucket,
+    HourBucket,
+    TradeBacktest,
+    bucketize_gaps,
+    build_summary,
+    collect_trades,
+    render_markdown,
+)
+
+
+def _seed_db(db: Path) -> None:
+    """Create the candidates + trades schema and seed minimal rows."""
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE candidates (
+            id INTEGER PRIMARY KEY,
+            ticker TEXT NOT NULL,
+            title TEXT NOT NULL DEFAULT '',
+            market_price REAL NOT NULL DEFAULT 0,
+            model_probability REAL NOT NULL DEFAULT 0,
+            edge REAL NOT NULL DEFAULT 0,
+            gimme_score REAL NOT NULL DEFAULT 0,
+            research_memo TEXT NOT NULL DEFAULT '',
+            scanned_at TEXT NOT NULL,
+            edge_size_score REAL NOT NULL DEFAULT 0,
+            signal_strength_score REAL NOT NULL DEFAULT 0,
+            liquidity_depth_score REAL NOT NULL DEFAULT 0,
+            settlement_clarity_score REAL NOT NULL DEFAULT 0,
+            time_to_resolution_score REAL NOT NULL DEFAULT 0,
+            cap_blocked INTEGER NOT NULL DEFAULT 0,
+            recommendation TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY,
+            ticker TEXT NOT NULL,
+            action TEXT NOT NULL,
+            side TEXT NOT NULL DEFAULT 'yes',
+            count INTEGER NOT NULL DEFAULT 0,
+            price REAL NOT NULL DEFAULT 0,
+            timestamp TEXT NOT NULL,
+            agent TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _add_candidate(
+    db: Path, ticker: str, scanned_at: str, *, gimme_score: float = 70.0,
+    edge: float = 0.05, cap_blocked: int = 0,
+) -> None:
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO candidates (ticker, scanned_at, gimme_score, edge, "
+        "cap_blocked) VALUES (?, ?, ?, ?, ?)",
+        (ticker, scanned_at, gimme_score, edge, cap_blocked),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _add_trade(
+    db: Path, ticker: str, action: str, timestamp: str, *,
+    side: str = "yes", agent: str = "closer",
+) -> None:
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO trades (ticker, action, side, timestamp, agent) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (ticker, action, side, timestamp, agent),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# collect_trades + first-seen lookup
+# ---------------------------------------------------------------------------
+
+
+class TestCollectTrades:
+    def test_first_seen_picks_min_scanned_at(self, tmp_path: Path) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        # Two candidate sightings of the same ticker — earlier wins.
+        _add_candidate(
+            db, "KX1", "2026-05-07 00:00:00",
+            gimme_score=80.0, edge=0.10,
+        )
+        _add_candidate(
+            db, "KX1", "2026-05-07 00:05:00",
+            gimme_score=85.0, edge=0.12,
+        )
+        _add_trade(db, "KX1", "open", "2026-05-07T00:10:00+00:00")
+
+        trades, warnings = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert warnings == []
+        assert len(trades) == 1
+        t = trades[0]
+        # Earlier candidate, gap should be 10 minutes = 600s.
+        assert t.first_seen_time == datetime(2026, 5, 7, 0, 0, tzinfo=UTC)
+        assert t.gap_seconds == 600.0
+        assert t.gimme_score == 80.0
+        assert t.edge == 0.10
+
+    def test_trade_with_no_candidate_records_none(self, tmp_path: Path) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        _add_trade(db, "KX_GHOST", "open", "2026-05-07T00:10:00+00:00")
+
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert len(trades) == 1
+        assert trades[0].first_seen_time is None
+        assert trades[0].gap_seconds is None
+        assert trades[0].gimme_score is None
+
+    def test_close_action_excluded_by_default(self, tmp_path: Path) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        _add_candidate(db, "KX1", "2026-05-07 00:00:00")
+        _add_trade(db, "KX1", "open", "2026-05-07T00:10:00+00:00")
+        _add_trade(db, "KX1", "close", "2026-05-07T01:00:00+00:00")
+
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        # Default actions=("open",); close excluded.
+        assert len(trades) == 1
+        assert trades[0].action == "open"
+
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+            actions=("open", "close"),
+        )
+        assert {t.action for t in trades} == {"open", "close"}
+
+    def test_skip_action_always_excluded(self, tmp_path: Path) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        _add_trade(db, "KX1", "skip", "2026-05-07T00:10:00+00:00")
+
+        # Even when actions explicitly includes "skip" we *would* return it,
+        # but the default ("open",) must not.
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert trades == []
+
+    def test_missing_db_returns_warning(self, tmp_path: Path) -> None:
+        trades, warnings = collect_trades(
+            tmp_path / "missing.db",
+            date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert trades == []
+        assert any("DB not found" in w for w in warnings)
+
+    def test_cap_blocked_flagged(self, tmp_path: Path) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_db(db)
+        _add_candidate(
+            db, "KX1", "2026-05-07 00:00:00", cap_blocked=1,
+        )
+        _add_trade(db, "KX1", "open", "2026-05-07T00:10:00+00:00")
+        trades, _ = collect_trades(
+            db, date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert trades[0].cap_blocked_at_first_seen is True
+
+
+# ---------------------------------------------------------------------------
+# bucketize_gaps
+# ---------------------------------------------------------------------------
+
+
+class TestBucketizeGaps:
+    @pytest.mark.parametrize(
+        "gap,expected_label",
+        [
+            (0.0, "0-60s"),
+            (59.999, "0-60s"),
+            (60.0, "60-300s"),
+            (299.999, "60-300s"),
+            (300.0, "5-10min"),
+            (599.999, "5-10min"),
+            (600.0, "10-30min"),
+            (1799.999, "10-30min"),
+            (1800.0, "30min+"),
+            (5000.0, "30min+"),
+        ],
+    )
+    def test_boundaries(
+        self, gap: float, expected_label: str, tmp_path: Path,
+    ) -> None:
+        t = TradeBacktest(
+            trade_id=1, ticker="KX1", action="open", side="yes",
+            trade_time=datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            first_seen_time=datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            gap_seconds=gap, hour_of_window_edt=20,
+            trade_window_name="outside", gimme_score=70.0, edge=0.05,
+            cap_blocked_at_first_seen=False,
+        )
+        buckets = bucketize_gaps([t])
+        # Find the bucket with count==1.
+        hit = next(b for b in buckets if b.count == 1)
+        assert hit.label == expected_label
+
+    def test_none_gaps_excluded_from_pct_denominator(
+        self, tmp_path: Path,
+    ) -> None:
+        t_known = TradeBacktest(
+            trade_id=1, ticker="KX1", action="open", side="yes",
+            trade_time=datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            first_seen_time=datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            gap_seconds=120.0, hour_of_window_edt=20,
+            trade_window_name="outside", gimme_score=None, edge=None,
+            cap_blocked_at_first_seen=False,
+        )
+        t_unknown = TradeBacktest(
+            trade_id=2, ticker="KX2", action="open", side="yes",
+            trade_time=datetime(2026, 5, 7, 0, 0, tzinfo=UTC),
+            first_seen_time=None, gap_seconds=None,
+            hour_of_window_edt=20, trade_window_name="outside",
+            gimme_score=None, edge=None,
+            cap_blocked_at_first_seen=False,
+        )
+        buckets = bucketize_gaps([t_known, t_unknown])
+        # Total denominator = 1 (only known-gap trade), so the bucket the
+        # known trade lands in must be 100%.
+        hit = next(b for b in buckets if b.count == 1)
+        assert hit.pct_of_total == 100.0
+
+    def test_empty_input_yields_zero_buckets(self) -> None:
+        buckets = bucketize_gaps([])
+        assert all(b.count == 0 and b.pct_of_total == 0.0 for b in buckets)
+        # Bucket count matches the GAP_BUCKETS module constant.
+        assert len(buckets) == len(GAP_BUCKETS)
+
+
+# ---------------------------------------------------------------------------
+# render_markdown determinism + recommendation logic
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMarkdown:
+    def _summary(
+        self, *, fast_pct: float = 0.0, total: int = 1,
+    ) -> BacktestSummary:
+        # Construct a synthetic gap-bucket distribution where ``fast_pct``
+        # of trades land in 60-300s; rest in 30min+.
+        fast_count = int(round(total * fast_pct / 100))
+        slow_count = total - fast_count
+        gap_buckets = [
+            GapBucket(
+                label=label, lower_seconds=lower, upper_seconds=upper,
+                count=(
+                    fast_count if label == "60-300s"
+                    else slow_count if label == "30min+"
+                    else 0
+                ),
+                pct_of_total=(
+                    fast_pct if label == "60-300s"
+                    else (100.0 - fast_pct) if label == "30min+"
+                    else 0.0
+                ),
+            )
+            for label, lower, upper in GAP_BUCKETS
+        ]
+        return BacktestSummary(
+            trades=[],
+            hour_buckets=[
+                HourBucket(
+                    hour_edt=10, cycles_observed=5, days_observed=3,
+                    trades_placed=2, trades_per_cycle=0.4,
+                ),
+            ],
+            gap_buckets=gap_buckets,
+            by_window_name={"jobless_claims": total},
+            date_from=date(2026, 4, 20),
+            date_to=date(2026, 5, 7),
+            cycles_audited=100,
+            trades_with_no_candidate=0,
+        )
+
+    def test_recommendation_do_not_raise_at_30pct(self) -> None:
+        md = render_markdown(self._summary(fast_pct=35.0, total=100))
+        assert "DO NOT RAISE" in md
+
+    def test_recommendation_likely_safe_at_5pct(self) -> None:
+        md = render_markdown(self._summary(fast_pct=5.0, total=100))
+        assert "LIKELY SAFE TO RAISE" in md
+
+    def test_recommendation_wait_in_borderline(self) -> None:
+        md = render_markdown(self._summary(fast_pct=12.0, total=100))
+        assert "WAIT FOR #553" in md
+
+    def test_recommendation_inconclusive_with_zero_trades(self) -> None:
+        md = render_markdown(self._summary(fast_pct=0.0, total=0))
+        assert "INCONCLUSIVE" in md
+
+    def test_render_is_deterministic(self) -> None:
+        s = self._summary(fast_pct=12.0, total=10)
+        a = render_markdown(s)
+        b = render_markdown(s)
+        assert a == b
+
+    def test_render_includes_all_required_sections(self) -> None:
+        md = render_markdown(self._summary(fast_pct=12.0, total=10))
+        assert "## Executive summary" in md
+        assert "## Methodology" in md
+        assert "## Hour-of-window" in md
+        assert "## Gap distribution" in md
+        assert "## Per-trade detail" in md
+        assert "## By trade window" in md
+        assert "## Caveats" in md
+        assert "## Recommendation" in md
+        assert "#553" in md
+
+
+# ---------------------------------------------------------------------------
+# build_summary end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummary:
+    def test_end_to_end_with_one_cycle_and_one_trade(
+        self, tmp_path: Path,
+    ) -> None:
+        gimmes_home = tmp_path / "home"
+        log_dir = gimmes_home / "logs"
+        log_dir.mkdir(parents=True)
+        db = gimmes_home / "gimmes.db"
+        _seed_db(db)
+        _add_candidate(db, "KX1", "2026-05-07 14:00:00")
+        _add_trade(db, "KX1", "open", "2026-05-07T14:05:00+00:00")
+        # Minimal cycle log so aggregate_hours has something to bucket.
+        cycle_log = log_dir / "cycle-001.json"
+        cycle_log.write_text(json.dumps([
+            {"type": "user", "timestamp": "2026-05-07T14:00:00.000Z"},
+            {"type": "assistant", "message": {"content": [{
+                "type": "text",
+                "text": "Scout returned 3 candidates. PROCEED",
+            }]}},
+            {"type": "user", "timestamp": "2026-05-07T14:30:00.000Z"},
+            {"type": "result", "is_error": False},
+        ]))
+
+        s = build_summary(
+            log_dir=log_dir, db_path=db,
+            date_from=date(2026, 5, 7), date_to=date(2026, 5, 7),
+        )
+        assert len(s.trades) == 1
+        assert s.cycles_audited == 1
+        assert s.trades[0].gap_seconds == 300.0  # 5 minutes
+        # The 60-300s bucket boundary is exclusive at 300s, so 300.0 lands
+        # in 5-10min. Sanity check.
+        five_min = next(b for b in s.gap_buckets if b.label == "5-10min")
+        assert five_min.count == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_pause_backtest_writes_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        gimmes_home = tmp_path / "home"
+        (gimmes_home / "logs").mkdir(parents=True)
+        db = gimmes_home / "gimmes.db"
+        _seed_db(db)
+        _add_candidate(db, "KX1", "2026-05-07 14:00:00")
+        _add_trade(db, "KX1", "open", "2026-05-07T14:05:00+00:00")
+        # Cycle log so audit_hours has data.
+        (gimmes_home / "logs" / "cycle-001.json").write_text(json.dumps([
+            {"type": "user", "timestamp": "2026-05-07T14:00:00.000Z"},
+            {"type": "result", "is_error": False},
+        ]))
+
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", gimmes_home)
+
+        out_path = tmp_path / "report.md"
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "pause-backtest",
+                "--from", "2026-05-07",
+                "--to", "2026-05-07",
+                "--output", str(out_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out_path.exists()
+        content = out_path.read_text()
+        assert "Phase 1a Pause Backtest" in content
+        assert "KX1" in content
+
+    def test_pause_backtest_json_output(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        gimmes_home = tmp_path / "home"
+        (gimmes_home / "logs").mkdir(parents=True)
+        db = gimmes_home / "gimmes.db"
+        _seed_db(db)
+        _add_trade(db, "KX1", "open", "2026-05-07T14:05:00+00:00")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", gimmes_home)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "pause-backtest",
+                "--from", "2026-05-07",
+                "--to", "2026-05-07",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Strip Rich's prepended whitespace if any, then parse.
+        parsed = json.loads(result.output.strip())
+        assert "trades" in parsed
+        assert "hour_buckets" in parsed
+        assert "gap_buckets" in parsed
+        assert parsed["date_from"] == "2026-05-07"
+
+    def test_invalid_from_date_exits_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        gimmes_home = tmp_path / "home"
+        (gimmes_home / "logs").mkdir(parents=True)
+        db = gimmes_home / "gimmes.db"
+        _seed_db(db)
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", gimmes_home)
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["pause-backtest", "--from", "not-a-date"],
+        )
+        assert result.exit_code == 1
+
+    def test_missing_db_exits_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        gimmes_home = tmp_path / "home"
+        (gimmes_home / "logs").mkdir(parents=True)
+        # No gimmes.db file.
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", gimmes_home)
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["pause-backtest"],
+        )
+        assert result.exit_code == 1
+        assert "No database" in result.output


### PR DESCRIPTION
## Summary

Closes #556. Implements the autonomously-deliverable slice of #553 (Phase 1) that doesn't need Kalshi historical price reconstruction.

## Headline result

Of **17 placed trades** across **494 cycle logs** (2026-04-13 → 2026-05-07):

- **00:00–07:00 EDT block: 0 trades / 144 cycles over 12 days** — strong support for trimming the front of the trade window.
- **08:00–23:00 EDT block: 17 trades** — daytime + evening is where signal lives.
- **12% of trades have first-seen-to-trade gaps under 300s** — borderline; recommendation is **WAIT FOR #553** (PnL counterfactual) before raising `pause_seconds`.

The committed `tests/research/phase1a_backtest.md` is the report; regenerate any time with `gimmes pause-backtest --output FILE`.

## What changed

- **`src/gimmes/reporting/pause_backtest.py`** — `TradeBacktest`/`HourBucket`/`GapBucket`/`BacktestSummary` dataclasses + `collect_trades` (single read-only SQLite connection threaded through `_first_seen`) + `bucketize_gaps` (5 lower-inclusive, upper-exclusive buckets) + `aggregate_hours` (reuses `cycle_audit.parse_cycle_log`) + `render_markdown` (deterministic; 4-branch recommendation keyed off the under-300s percentage). Recommendation thresholds (`FAST_GAP_DO_NOT_RAISE_PCT = 30.0`, `FAST_GAP_LIKELY_SAFE_PCT = 5.0`) are module-level constants and explicitly flagged as tunable.
- **`src/gimmes/cli.py`** — new `gimmes pause-backtest --from --to --output --json` subcommand under Diagnostics. JSON output uses `markup=False, highlight=False, soft_wrap=True` to keep Rich from corrupting array delimiters (matches the pattern from PR #555).
- **`tests/research/phase1a_backtest.md`** — committed report for the 2026-04-13 → 2026-05-07 window. Will be regenerated on each `gimmes pause-backtest` run.
- **`tests/unit/test_pause_backtest.py`** — 29 tests covering trade collection + first-seen lookup, parametrized gap-bucket boundaries (10 cases including all five edges), determinism, the four recommendation branches, end-to-end `build_summary`, and CLI smoke (write-file, `--json`, invalid date, missing DB error paths).

## Phase 1b (the part this PR does NOT do)

Counterfactual PnL — *would a longer pause have changed which trades got placed* — requires Kalshi historical orderbook reconstruction that we don't currently persist. Stays open as **#553**. The `## Recommendation` section of the committed report explicitly defers to it.

## Test plan

- [x] `uv run pytest tests/unit/test_pause_backtest.py` — 29 passed.
- [x] `uv run ruff check src/gimmes/reporting/pause_backtest.py src/gimmes/cli.py tests/unit/test_pause_backtest.py` — clean.
- [x] `uv run gimmes pause-backtest --output tests/research/phase1a_backtest.md` — produces the committed report (17 trades, 494 cycles).
- [ ] CI: `uv run pytest tests/unit/` should pass on this PR.

## Risk level

**Low** — read-only SQLite + new CLI subcommand + new module + new tests. No autonomous-loop behavior change. The committed Markdown is regenerable from existing `~/.gimmes/logs/` + `~/.gimmes/gimmes.db`.