### PR TITLE
Trim trade-window calendar to open at 04:00 ET on release day (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- All trade-window factories now open at 04:00 ET on the release day instead of the prior evening (formerly 18:30 ET, 20:00 ET, 23:00 ET, etc.). Window-close times unchanged. Eliminates the empirically dead 18:00–04:00 ET block where 12 days of cycle data showed ~0.009 trades/cycle (1 trade in 116 full cycles), while preserving the 5–8 AM EDT pre-positioning window where smart money activity concentrates. Affects `_jobless_claims`, `_treasury_notes`, `_adp`, `_ism_pmi`, `_nfp`, `_cpi`, `_core_pce`, and `_gdp_advance`. (#558)
+
 ## [0.7.0] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- All trade-window factories now open at 04:00 ET on the release day instead of the prior evening (formerly 18:30 ET, 20:00 ET, 23:00 ET, etc.). Window-close times unchanged. Eliminates the empirically dead 18:00–04:00 ET block where 12 days of cycle data showed ~0.009 trades/cycle (1 trade in 116 full cycles), while preserving the 5–8 AM EDT pre-positioning window where smart money activity concentrates. Affects `_jobless_claims`, `_treasury_notes`, `_adp`, `_ism_pmi`, `_nfp`, `_cpi`, `_core_pce`, and `_gdp_advance`. (#558)
+- All formerly overnight release windows now open at 04:00 ET on the release day instead of the prior evening (formerly 18:30 ET, 20:00 ET, 23:00 ET, etc.). Window-close times unchanged. `_index_contracts` (release-day-only 14:00–16:00 ET) is unaffected. Eliminates the empirically dead 18:00–04:00 ET block where 12 days of cycle data showed ~0.009 trades/cycle (1 trade in 116 full cycles), while preserving the 5–8 AM EDT pre-positioning window where smart money activity concentrates. Affects `_jobless_claims`, `_treasury_notes`, `_adp`, `_ism_pmi`, `_nfp`, `_cpi`, `_core_pce`, and `_gdp_advance`. (#558)
 
 ## [0.7.0] - 2026-05-06
 

--- a/src/gimmes/strategy/calendar.py
+++ b/src/gimmes/strategy/calendar.py
@@ -46,7 +46,7 @@ def _nearest_business_day(dt: datetime) -> datetime:
 
 
 def _release_day_window(
-    release_date: datetime,
+    release_dt: datetime,
     close_time: time,
     open_time: time = time(4, 0),
 ) -> tuple[datetime, datetime]:
@@ -59,10 +59,10 @@ def _release_day_window(
     skip; callers parameterizing ``open_time`` to 02:00–03:00 on the DST
     transition day risk a non-existent local time from ``replace()``.
     """
-    open_dt = release_date.replace(
+    open_dt = release_dt.replace(
         hour=open_time.hour, minute=open_time.minute, second=0, microsecond=0,
     )
-    close_dt = release_date.replace(
+    close_dt = release_dt.replace(
         hour=close_time.hour, minute=close_time.minute, second=0, microsecond=0,
     )
     return open_dt, close_dt

--- a/src/gimmes/strategy/calendar.py
+++ b/src/gimmes/strategy/calendar.py
@@ -45,14 +45,21 @@ def _nearest_business_day(dt: datetime) -> datetime:
     return dt
 
 
-def _overnight_window(
+def _release_day_window(
     release_date: datetime,
-    open_time: time,
     close_time: time,
+    open_time: time = time(4, 0),
 ) -> tuple[datetime, datetime]:
-    """Build an overnight window: open evening before, close on release day."""
-    day_before = release_date - timedelta(days=1)
-    open_dt = day_before.replace(
+    """Build a release-day window opening at 04:00 ET by default.
+
+    Per #558, all formerly-overnight windows now open at 04:00 ET on the
+    release day (eliminating the 18:00–04:00 ET dead zone where 12 days of
+    data showed ~0.009 trades/cycle).  Caller passes the close time on the
+    release day.  Note: 04:00 ET is safely past the spring-forward 02:00→03:00
+    skip; callers parameterizing ``open_time`` to 02:00–03:00 on the DST
+    transition day risk a non-existent local time from ``replace()``.
+    """
+    open_dt = release_date.replace(
         hour=open_time.hour, minute=open_time.minute, second=0, microsecond=0,
     )
     close_dt = release_date.replace(
@@ -118,43 +125,32 @@ def _index_contracts(year: int, month: int) -> list[tuple[datetime, datetime]]:
 
 
 def _treasury_notes(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Weekly: Tue 11:00 PM → Wed 1:00 PM ET."""
-    windows: list[tuple[datetime, datetime]] = []
-    last_day = _cal.monthrange(year, month)[1]
-    for day in range(1, last_day + 1):
-        dt = datetime(year, month, day, tzinfo=ET)
-        if dt.weekday() == 1:  # Tuesday
-            open_dt = dt.replace(hour=23, minute=0, second=0, microsecond=0)
-            close_dt = (dt + timedelta(days=1)).replace(
-                hour=13, minute=0, second=0, microsecond=0,
-            )
-            windows.append((open_dt, close_dt))
-    return windows
-
-
-def _jobless_claims(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Weekly: Wed 6:30 PM → Thu 8:30 AM ET."""
+    """Weekly: Wed 4:00 AM → Wed 1:00 PM ET (release day, post-#558)."""
     windows: list[tuple[datetime, datetime]] = []
     last_day = _cal.monthrange(year, month)[1]
     for day in range(1, last_day + 1):
         dt = datetime(year, month, day, tzinfo=ET)
         if dt.weekday() == 2:  # Wednesday
-            open_dt = dt.replace(hour=18, minute=30, second=0, microsecond=0)
-            close_dt = (dt + timedelta(days=1)).replace(
-                hour=8, minute=30, second=0, microsecond=0,
-            )
-            windows.append((open_dt, close_dt))
+            windows.append(_release_day_window(dt, time(13, 0)))
+    return windows
+
+
+def _jobless_claims(year: int, month: int) -> list[tuple[datetime, datetime]]:
+    """Weekly: Thu 4:00 AM → Thu 8:30 AM ET (release day, post-#558)."""
+    windows: list[tuple[datetime, datetime]] = []
+    last_day = _cal.monthrange(year, month)[1]
+    for day in range(1, last_day + 1):
+        dt = datetime(year, month, day, tzinfo=ET)
+        if dt.weekday() == 3:  # Thursday
+            windows.append(_release_day_window(dt, time(8, 30)))
     return windows
 
 
 def _adp(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Monthly: Tue before NFP 6:15 PM → Wed 8:15 AM ET."""
+    """Monthly: Wed before NFP 4:00 AM → 8:15 AM ET (release day, post-#558)."""
     nfp_friday = _first_friday(year, month)
-    adp_wednesday = nfp_friday - timedelta(days=2)  # Wednesday before NFP
-    adp_tuesday = adp_wednesday - timedelta(days=1)
-    open_dt = adp_tuesday.replace(hour=18, minute=15, second=0, microsecond=0)
-    close_dt = adp_wednesday.replace(hour=8, minute=15, second=0, microsecond=0)
-    return [(open_dt, close_dt)]
+    adp_wednesday = nfp_friday - timedelta(days=2)
+    return [_release_day_window(adp_wednesday, time(8, 15))]
 
 
 def _first_business_day(year: int, month: int) -> datetime:
@@ -166,22 +162,19 @@ def _first_business_day(year: int, month: int) -> datetime:
 
 
 def _ism_pmi(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Monthly: night before 1st business day 8:00 PM → 1st biz day 10:00 AM."""
+    """Monthly: 1st biz day 4:00 AM → 10:00 AM ET (release day, post-#558)."""
     biz_day = _first_business_day(year, month)
-    day_before = biz_day - timedelta(days=1)
-    open_dt = day_before.replace(hour=20, minute=0, second=0, microsecond=0)
-    close_dt = biz_day.replace(hour=10, minute=0, second=0, microsecond=0)
-    return [(open_dt, close_dt)]
+    return [_release_day_window(biz_day, time(10, 0))]
 
 
 def _nfp(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Monthly: Thu 6:30 PM → 1st Friday 8:30 AM ET."""
+    """Monthly: 1st Friday 4:00 AM → 8:30 AM ET (release day, post-#558)."""
     friday = _first_friday(year, month)
-    return [_overnight_window(friday, time(18, 30), time(8, 30))]
+    return [_release_day_window(friday, time(8, 30))]
 
 
 def _cpi(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Monthly: night before CPI release 6:30 PM → release day 8:30 AM ET."""
+    """Monthly: CPI release day 4:00 AM → 8:30 AM ET (post-#558)."""
     day = _CPI_DATES.get((year, month))
     if day is None:
         # Fallback: ~12th snapped to nearest business day
@@ -189,17 +182,17 @@ def _cpi(year: int, month: int) -> list[tuple[datetime, datetime]]:
         release = _nearest_business_day(target)
     else:
         release = datetime(year, month, day, tzinfo=ET)
-    return [_overnight_window(release, time(18, 30), time(8, 30))]
+    return [_release_day_window(release, time(8, 30))]
 
 
 def _core_pce(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Monthly: night before last Friday 6:30 PM → last Fri 8:30 AM ET."""
+    """Monthly: last Friday 4:00 AM → 8:30 AM ET (release day, post-#558)."""
     friday = _last_friday(year, month)
-    return [_overnight_window(friday, time(18, 30), time(8, 30))]
+    return [_release_day_window(friday, time(8, 30))]
 
 
 def _gdp_advance(year: int, month: int) -> list[tuple[datetime, datetime]]:
-    """Quarterly (Jan/Apr/Jul/Oct): night before GDP release 6:30 PM → release day 8:30 AM."""
+    """Quarterly (Jan/Apr/Jul/Oct): release day 4:00 AM → 8:30 AM ET (post-#558)."""
     if month not in (1, 4, 7, 10):
         return []
     day = _GDP_ADVANCE_DATES.get((year, month))
@@ -209,7 +202,7 @@ def _gdp_advance(year: int, month: int) -> list[tuple[datetime, datetime]]:
         release = _nearest_business_day(target)
     else:
         release = datetime(year, month, day, tzinfo=ET)
-    return [_overnight_window(release, time(18, 30), time(8, 30))]
+    return [_release_day_window(release, time(8, 30))]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -57,10 +57,11 @@ class TestIndexContracts:
 class TestJoblessClaims:
     def test_wednesday_evening_not_in_window(self) -> None:
         # Post-#558: night-before pre-roll dropped. Wed April 1 7:00 PM is
-        # now in the dead zone — the Thu window opens 04:00 ET on release day.
+        # in the dead zone — assert no window is active at all (not just
+        # that Jobless claims is silent).
         dt = datetime(2026, 4, 1, 19, 0, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "Jobless claims"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_thursday_4am_in_window(self) -> None:
         # Thursday April 2, 4:00 AM ET — new release-day window opens
@@ -85,10 +86,11 @@ class TestJoblessClaims:
 
 class TestTreasuryNotes:
     def test_tuesday_midnight_not_in_window(self) -> None:
-        # Post-#558: Tue 23:30 ET no longer opens the Wed Treasury window.
+        # Post-#558: Tue 23:30 ET no longer opens the Wed Treasury window
+        # and falls in the dead zone — assert no window is active.
         dt = datetime(2026, 4, 7, 23, 30, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "Treasury notes"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_wednesday_4am_in_window(self) -> None:
         # Wednesday April 8, 4:00 AM ET — new release-day window opens
@@ -107,10 +109,10 @@ class TestTreasuryNotes:
 
 class TestNFP:
     def test_thursday_before_first_friday_not_in_window(self) -> None:
-        # Post-#558: Thursday evening before NFP is no longer pre-roll.
+        # Post-#558: Thursday evening before NFP is in the dead zone.
         dt = datetime(2026, 4, 2, 19, 0, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "Non-Farm Payrolls"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_first_friday_4am_in_window(self) -> None:
         # Friday April 3, 4:00 AM ET — new release-day window opens
@@ -129,10 +131,10 @@ class TestNFP:
 
 class TestCPI:
     def test_thursday_evening_not_in_window(self) -> None:
-        # Post-#558: night before CPI is no longer pre-roll.
+        # Post-#558: night before CPI is in the dead zone.
         dt = datetime(2026, 4, 9, 19, 0, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "CPI"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_april_2026_release_4am(self) -> None:
         # Friday April 10 at 4:00 AM — new release-day window opens
@@ -164,10 +166,10 @@ class TestCPI:
 
 class TestCorePCE:
     def test_night_before_last_friday_not_in_window(self) -> None:
-        # Post-#558: Thursday evening before PCE is no longer pre-roll.
+        # Post-#558: Thursday evening before PCE is in the dead zone.
         dt = datetime(2026, 4, 23, 19, 0, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "Core PCE"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_last_friday_4am_in_window(self) -> None:
         # April 2026: last Friday is April 24, 4:00 AM ET window opens
@@ -179,10 +181,10 @@ class TestCorePCE:
 
 class TestGDPAdvance:
     def test_january_2026_evening_before_not_in_window(self) -> None:
-        # Post-#558: Wed Jan 28 19:00 ET is no longer pre-roll.
+        # Post-#558: Wed Jan 28 19:00 ET is in the dead zone.
         dt = datetime(2026, 1, 28, 19, 0, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "GDP Advance"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_january_2026_release_4am(self) -> None:
         # Thu Jan 29 04:00 ET — new release-day window opens
@@ -213,10 +215,10 @@ class TestGDPAdvance:
 
 class TestISMPMI:
     def test_evening_before_not_in_window(self) -> None:
-        # Post-#558: Tue Mar 31 20:00 ET is no longer pre-roll.
+        # Post-#558: Tue Mar 31 20:00 ET is in the dead zone.
         dt = datetime(2026, 3, 31, 20, 0, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "ISM PMI"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_first_business_day_4am_in_window(self) -> None:
         # March 2026: Mar 1 is Sunday → first biz day Mon Mar 2. ADP is
@@ -237,10 +239,10 @@ class TestISMPMI:
 
 class TestADP:
     def test_tuesday_evening_not_in_window(self) -> None:
-        # Post-#558: Tue Mar 31 18:30 ET is no longer pre-roll.
+        # Post-#558: Tue Mar 31 18:30 ET is in the dead zone.
         dt = datetime(2026, 3, 31, 18, 30, tzinfo=ET)
-        in_w, name, _ = is_in_trade_window(dt)
-        assert not in_w or name != "ADP"
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
     def test_wednesday_4am_in_window(self) -> None:
         # Wed Apr 1 04:00 ET — new release-day ADP window opens

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -55,9 +55,16 @@ class TestIndexContracts:
 
 
 class TestJoblessClaims:
-    def test_wednesday_evening_in_window(self) -> None:
-        # Wednesday April 1 2026, 7:00 PM ET
+    def test_wednesday_evening_not_in_window(self) -> None:
+        # Post-#558: night-before pre-roll dropped. Wed April 1 7:00 PM is
+        # now in the dead zone — the Thu window opens 04:00 ET on release day.
         dt = datetime(2026, 4, 1, 19, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "Jobless claims"
+
+    def test_thursday_4am_in_window(self) -> None:
+        # Thursday April 2, 4:00 AM ET — new release-day window opens
+        dt = datetime(2026, 4, 2, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "Jobless claims"
@@ -77,9 +84,15 @@ class TestJoblessClaims:
 
 
 class TestTreasuryNotes:
-    def test_tuesday_midnight_in_window(self) -> None:
-        # Tuesday April 7 2026 at 11:30 PM ET (no ADP overlap)
+    def test_tuesday_midnight_not_in_window(self) -> None:
+        # Post-#558: Tue 23:30 ET no longer opens the Wed Treasury window.
         dt = datetime(2026, 4, 7, 23, 30, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "Treasury notes"
+
+    def test_wednesday_4am_in_window(self) -> None:
+        # Wednesday April 8, 4:00 AM ET — new release-day window opens
+        dt = datetime(2026, 4, 8, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "Treasury notes"
@@ -93,10 +106,15 @@ class TestTreasuryNotes:
 
 
 class TestNFP:
-    def test_thursday_before_first_friday(self) -> None:
-        # April 2026: first Friday is April 3
-        # Thursday April 2, 7:00 PM ET
+    def test_thursday_before_first_friday_not_in_window(self) -> None:
+        # Post-#558: Thursday evening before NFP is no longer pre-roll.
         dt = datetime(2026, 4, 2, 19, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "Non-Farm Payrolls"
+
+    def test_first_friday_4am_in_window(self) -> None:
+        # Friday April 3, 4:00 AM ET — new release-day window opens
+        dt = datetime(2026, 4, 3, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "Non-Farm Payrolls"
@@ -110,10 +128,15 @@ class TestNFP:
 
 
 class TestCPI:
-    def test_april_2026_actual_date(self) -> None:
-        # April 2026 CPI releases on April 10 (Friday)
-        # Window: Thursday April 9 6:30 PM → Friday April 10 8:30 AM
+    def test_thursday_evening_not_in_window(self) -> None:
+        # Post-#558: night before CPI is no longer pre-roll.
         dt = datetime(2026, 4, 9, 19, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "CPI"
+
+    def test_april_2026_release_4am(self) -> None:
+        # Friday April 10 at 4:00 AM — new release-day window opens
+        dt = datetime(2026, 4, 10, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "CPI"
@@ -140,28 +163,37 @@ class TestCPI:
 
 
 class TestCorePCE:
-    def test_night_before_last_friday(self) -> None:
-        # April 2026: last Friday is April 24
-        # Window opens Thursday April 23 6:30 PM
+    def test_night_before_last_friday_not_in_window(self) -> None:
+        # Post-#558: Thursday evening before PCE is no longer pre-roll.
         dt = datetime(2026, 4, 23, 19, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "Core PCE"
+
+    def test_last_friday_4am_in_window(self) -> None:
+        # April 2026: last Friday is April 24, 4:00 AM ET window opens
+        dt = datetime(2026, 4, 24, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "Core PCE"
 
 
 class TestGDPAdvance:
-    def test_january_2026_actual_date(self) -> None:
-        # January 2026 GDP releases on Jan 29 (Thursday)
-        # Window: Wed Jan 28 6:30 PM → Thu Jan 29 8:30 AM
+    def test_january_2026_evening_before_not_in_window(self) -> None:
+        # Post-#558: Wed Jan 28 19:00 ET is no longer pre-roll.
         dt = datetime(2026, 1, 28, 19, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "GDP Advance"
+
+    def test_january_2026_release_4am(self) -> None:
+        # Thu Jan 29 04:00 ET — new release-day window opens
+        dt = datetime(2026, 1, 29, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "GDP Advance"
 
-    def test_april_2026_actual_date(self) -> None:
-        # April 2026 GDP releases on Apr 30 (Thursday)
-        # Window: Wed Apr 29 6:30 PM → Thu Apr 30 8:30 AM
-        dt = datetime(2026, 4, 29, 19, 0, tzinfo=ET)
+    def test_april_2026_release_4am(self) -> None:
+        # Thu Apr 30 04:00 ET — new release-day window opens
+        dt = datetime(2026, 4, 30, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "GDP Advance"
@@ -180,9 +212,23 @@ class TestGDPAdvance:
 
 
 class TestISMPMI:
+    def test_evening_before_not_in_window(self) -> None:
+        # Post-#558: Tue Mar 31 20:00 ET is no longer pre-roll.
+        dt = datetime(2026, 3, 31, 20, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "ISM PMI"
+
+    def test_first_business_day_4am_in_window(self) -> None:
+        # March 2026: Mar 1 is Sunday → first biz day Mon Mar 2. ADP is
+        # Wed Mar 4 (before NFP Fri Mar 6); NFP is Fri Mar 6. No collisions
+        # with ISM on Mon Mar 2 04:00 ET.
+        dt = datetime(2026, 3, 2, 4, 0, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert in_w is True
+        assert name == "ISM PMI"
+
     def test_first_business_day_morning(self) -> None:
-        # April 2026: 1st is Wednesday (business day)
-        # Window opens Tue March 31 8:00 PM, closes Wed April 1 10:00 AM
+        # April 2026: 1st is Wednesday (business day), 9:00 AM still in window
         dt = datetime(2026, 4, 1, 9, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
@@ -190,12 +236,15 @@ class TestISMPMI:
 
 
 class TestADP:
-    def test_tuesday_before_nfp(self) -> None:
-        # April 2026: NFP Friday is April 3, ADP Wednesday is April 1
-        # ADP Tuesday is March 31 — opens 6:15 PM
-        # The ADP window for that April release opens on March 31;
-        # _adp(2026, 4) returns a window whose start falls in the prior month
+    def test_tuesday_evening_not_in_window(self) -> None:
+        # Post-#558: Tue Mar 31 18:30 ET is no longer pre-roll.
         dt = datetime(2026, 3, 31, 18, 30, tzinfo=ET)
+        in_w, name, _ = is_in_trade_window(dt)
+        assert not in_w or name != "ADP"
+
+    def test_wednesday_4am_in_window(self) -> None:
+        # Wed Apr 1 04:00 ET — new release-day ADP window opens
+        dt = datetime(2026, 4, 1, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "ADP"
@@ -210,14 +259,16 @@ class TestNextTradeWindow:
         assert start.weekday() == 0  # Monday
         assert start.hour == 14
 
-    def test_after_index_close_next_is_claims_or_tomorrow(self) -> None:
+    def test_after_index_close_next_is_claims_thursday_morning(self) -> None:
         # Wednesday April 1 at 4:01 PM — just after index close
         dt = datetime(2026, 4, 1, 16, 1, tzinfo=ET)
         start, name = next_trade_window(dt)
-        # Next should be jobless claims (Wed 6:30 PM) — same day
+        # Post-#558: jobless claims now opens Thu 04:00 ET (release day),
+        # not Wed 18:30 ET — sleep increases from 1.5h to ~12h.
         assert name == "Jobless claims"
-        assert start.hour == 18
-        assert start.minute == 30
+        assert start.weekday() == 3  # Thursday
+        assert start.hour == 4
+        assert start.minute == 0
 
 
 class TestSecondsUntilNextWindow:
@@ -237,21 +288,43 @@ class TestSecondsUntilNextWindow:
 
 class TestDST:
     def test_spring_forward(self) -> None:
-        # March 8 2026 is spring forward day in US
-        # A Wednesday evening window should still work
-        # March 4 2026 is a Wednesday — jobless claims window
-        dt = datetime(2026, 3, 4, 19, 0, tzinfo=ET)
+        # March 8 2026 is spring forward day in US.
+        # Post-#558: jobless claims opens 04:00 ET on Thursday release day.
+        # Thursday March 5 2026 is the release; 04:00 ET is safely past
+        # spring-forward's 02:00→03:00 jump (which falls on Sunday Mar 8).
+        dt = datetime(2026, 3, 5, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "Jobless claims"
 
     def test_fall_back(self) -> None:
-        # November 1 2026 is fall back day
-        # Oct 28 2026 is a Wednesday — jobless claims
-        dt = datetime(2026, 10, 28, 19, 0, tzinfo=ET)
+        # November 1 2026 is fall back day.
+        # Thursday Oct 29 2026 is the jobless claims release day.
+        dt = datetime(2026, 10, 29, 4, 0, tzinfo=ET)
         in_w, name, _ = is_in_trade_window(dt)
         assert in_w is True
         assert name == "Jobless claims"
+
+
+class TestDeadZone:
+    """Regression: 00:00–04:00 ET on release day must stay out of any window.
+
+    #557 data showed 0 trades in 116 cycles across the 00:00–07:00 ET block;
+    #558 trims night-before windows to 04:00 ET on release day. This test
+    guards against future drift back into the dead zone.
+    """
+
+    def test_thursday_3am_not_in_any_window(self) -> None:
+        # Thursday April 2 2026 at 3:00 AM ET — pre-04:00, post-midnight
+        dt = datetime(2026, 4, 2, 3, 0, tzinfo=ET)
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
+
+    def test_friday_3am_cpi_release_day_not_in_window(self) -> None:
+        # CPI release day Apr 10 (Fri) at 3:00 AM ET — pre-04:00
+        dt = datetime(2026, 4, 10, 3, 0, tzinfo=ET)
+        in_w, _, _ = is_in_trade_window(dt)
+        assert in_w is False
 
 
 class TestPositionWindow:


### PR DESCRIPTION
## Summary

Per #557 data: 00:00–07:00 EDT produced **1 placed trade in 116 full cycles** across 12 days (~0.009 trades/cycle). This PR trims every formerly "night-before" trade window to open at **04:00 ET on the release day** instead of the prior evening. Close times unchanged.

Eliminates the 18:00–04:00 ET dead zone where the autonomous loop was running full cycles for ~zero trade output, while preserving the 5–8 AM EDT pre-positioning window where smart-money activity concentrates.

### Affected windows

| Factory | Old open | New open |
|---|---|---|
| `_jobless_claims` | Wed 18:30 ET | Thu 04:00 ET |
| `_treasury_notes` | Tue 23:00 ET | Wed 04:00 ET |
| `_adp` | Tue 18:15 ET | Wed 04:00 ET |
| `_ism_pmi` | day-before 20:00 ET | release day 04:00 ET |
| `_nfp` | Thu 18:30 ET | Fri 04:00 ET |
| `_cpi` | day-before 18:30 ET | release day 04:00 ET |
| `_core_pce` | Thu 18:30 ET | Fri 04:00 ET |
| `_gdp_advance` | day-before 18:30 ET | release day 04:00 ET |

`_index_contracts` (release-day-only 14:00–16:00) and `position_window` are unchanged.

### Implementation

- Replaced `_overnight_window(release, open_time, close_time)` with `_release_day_window(release_date, close_time, open_time=time(4, 0))`. The default open time encodes the policy.
- Updated `_treasury_notes` to match Wednesdays directly and `_jobless_claims` to match Thursdays directly (release-day match instead of prior-weekday match).
- Test updates: flipped 11 "evening-before in window" assertions to "not in window," added 04:00 ET release-morning checks per family, added a `TestDeadZone` regression class asserting 00:00–04:00 ET on release day stays out of every window.

### Side effect worth noting

`next_trade_window` after a Wednesday index-contracts close (Wed 16:01 ET) now returns Thu 04:00 ET (jobless claims) instead of Wed 18:30 ET — a sleep increase from ~1.5h to ~12h. That is the intended effect, not a bug. Tested in `test_after_index_close_next_is_claims_thursday_morning`.

Closes #558

## Test plan
- `uv run pytest tests/unit/test_calendar.py` — 42 passed in 0.03s (locally verified)
- `uv run ruff check src/gimmes/strategy/calendar.py tests/unit/test_calendar.py` — clean
- Post-merge manual verification (per AC): `gimmes audit-cycles --date <next-jobless-Thursday>` shows 0 cycles ran in the 18:30–04:00 ET window.