### PR TITLE
Post-#563 validation: real per-cycle cost is ~5× the recorded $25 cap

### DIFF
--- a/tests/research/cache_creation_diff.md
+++ b/tests/research/cache_creation_diff.md
@@ -67,3 +67,26 @@ The cache_creation tail is doing its job. The ~$5/cycle full-pipeline cost is a 
 
 - **#563 (filed)** — `parse_usage_from_stream_json` undercount fix. Sum across **all** assistant events plus the result. Critical for the daily budget cap to bind at the right point.
 - After #563 lands, re-evaluate whether the daily cap (default \$25) should be raised or lowered; with corrected accounting, \$25 binds at *fewer* cycles than the design-time 80-session assumption — operators may want to update the cap or accept that real ceiling.
+
+## Post-#563 validation (2026-05-08)
+
+Now that #563 has merged, sampled 17 full-pipeline cycles from May 8 (1356–1372) to validate the corrected parser against the still-running v0.7.0 daemon's broken accounting and Anthropic's authoritative `result.total_cost_usd`.
+
+| | cache_creation | cache_read | cost (17 cycles) |
+|---|---:|---:|---:|
+| Old parser (result envelope only)         | 1,214,398   | 23,706,474   | — |
+| New parser (sum-across-assistant-turns)   | 12,833,585  | 200,964,981  | — |
+| Multiplier                                 | **10.57×**  | **8.48×**    | |
+| Anthropic authoritative `result.total_cost_usd` | — | — | **\$82.86** |
+| Local PRICING applied to new totals       | — | — | \$108.52 |
+| budget.json recorded for full May 8 (24 cycles) | 1,860,124 | 36,445,024 | \$25.02 |
+
+**Findings:**
+
+1. The 10× cache_create undercount factor predicted from May 7 data **holds on May 8**: 10.57× across 17 trade-window cycles. cache_read was 8.48×, slightly lower — consistent with subagent dispatches contributing more cache_create per turn than cache_read.
+2. The new parser **slightly overestimates** total cost (\$108.52 vs Anthropic's \$82.86, ~30% over). Plausible cause: Claude Code emits subagent dispatch envelopes as separate `assistant` events, and the dispatch + subagent execution may both report overlapping usage. Net effect is a conservative overcount — safer for a budget cap to bind early than late, but worth a follow-up to align with `result.total_cost_usd` exactly.
+3. The daemon recorded **\$25.02 for 24 cycles** (the cap binding point); the **real** spend across those 24 cycles is closer to **\$117** (\$4.87/cycle × 24). Operators have been consuming roughly **5× their stated daily cap**.
+
+**Recommended cap action:** raise `--max-daily-cost-usd` to a value reflecting the corrected per-cycle cost. At \$4.87/cycle authoritative, the current \$25 cap maps to ~5 cycles/day. To get back to the design-time ~80 cycles/day, the cap would need to be ~\$390/day; for a more modest 30 trade-window cycles/day, ~\$150/day. Operators should pick the value matching their actual willingness to spend, not the legacy \$25 default.
+
+**Closing #552.** The cache_creation tail is doing its job (Phase 1 finding); the apparent runaway cost was an accounting artifact (Phase 2 finding, fixed in #563); the cap should be re-tuned based on the validation table above (operator action). All three open threads are resolved.

--- a/tests/research/cache_creation_diff.md
+++ b/tests/research/cache_creation_diff.md
@@ -72,7 +72,7 @@ The cache_creation tail is doing its job. The ~$5/cycle full-pipeline cost is a 
 
 Now that #563 has merged, sampled 17 full-pipeline cycles from May 8 (1356–1372) to validate the corrected parser against the still-running v0.7.0 daemon's broken accounting and Anthropic's authoritative `result.total_cost_usd`.
 
-| | cache_creation | cache_read | cost (17 cycles) |
+| | cache_create | cache_read | cost (17 cycles) |
 |---|---:|---:|---:|
 | Old parser (result envelope only)         | 1,214,398   | 23,706,474   | — |
 | New parser (sum-across-assistant-turns)   | 12,833,585  | 200,964,981  | — |


### PR DESCRIPTION
## Summary

Closes the research thread on #552 with a fresh data validation now that #563 has merged.

Sampled 17 May 8 trade-window cycles (1356–1372) and computed three numbers per cycle:
- **Old (broken) parser:** result-event usage only — what the running v0.7.0 daemon was recording.
- **New (#563) parser:** sum across every assistant turn — what the daemon will record once redeployed.
- **Authoritative:** Anthropic's \`result.total_cost_usd\`.

| Source | cache_creation (17 cycles) | cache_read (17 cycles) | Cost (17 cycles) |
|---|---:|---:|---:|
| Old parser | 1.21M | 23.7M | — |
| New parser | **12.83M** | **200.96M** | (projected \$108.52) |
| Multiplier | **10.57×** | **8.48×** | |
| Anthropic authoritative | — | — | **\$82.86** |
| budget.json (full 24-cycle day) | 1.86M | 36.4M | \$25.02 |

## Findings

1. The 10× cache_creation undercount predicted from May 7 holds on fresh May 8 data: 10.57× cc / 8.48× cr.
2. Real per-cycle cost is **\$4.87 avg** (Anthropic authoritative). The recorded \$25/24 = \$1.04 was 4.7× lower than reality.
3. The new parser slightly over-counts (\$108.52 projected vs \$82.86 authoritative). Conservative for a cap; worth a follow-up to align with `result.total_cost_usd` directly.

## Recommended operator action (post-merge)

Raise `--max-daily-cost-usd` to match real per-cycle cost. At \$4.87/cycle:
- Legacy \$25 cap = **~5 cycles/day** before binding (where the cap has actually been binding).
- ~30 trade-window cycles/day requires ~\$150/day.
- ~80 cycles/day (the design-time intent) requires ~\$390/day.

Pick the value that matches actual willingness to spend, not the legacy default.

## Closes
- #552 (research thread done; recommendation captured in the doc).

## Test plan
- Documentation only.