### PR TITLE
#553 Phase 1 scaffolding + research blockers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ uv.lock
 # Research (private notes)
 .research/
 
+# Backtest CSV outputs (regenerated per run)
+tests/research/output/
+
 # Claude Code local settings
 .claude/settings.local.json
 .claude/worktrees/

--- a/tests/research/pause_and_hour_backtest.md
+++ b/tests/research/pause_and_hour_backtest.md
@@ -1,0 +1,79 @@
+# Phase 1 backtest — research notes
+
+**Status:** Scaffolding committed and runs against current data. Statistically inconclusive at today's N. Two structural blockers prevent the issue's full-fidelity analysis from being done with currently-persisted data.
+
+**Issue:** #553 (parent #546)  
+**Run command:** `uv run python tests/research/pause_and_hour_backtest.py`  
+**As-of run date:** 2026-05-08
+
+## What ran
+
+30-day window cutoff: `2026-04-08`.
+
+| Source | Rows |
+|---|---:|
+| `trades` events (open/close/size_up) | 28 |
+| `candidates` scans | 317 |
+| Closed positions (after FIFO weighted-average pairing per #561) | **6** |
+
+## Output
+
+### Table 1 — pause-length vs realized PnL
+
+| pause_s | trades_surfaced | gross_pnl |
+|---:|---:|---:|
+| 60   | 0 | \$0.00      |
+| 120  | 0 | \$0.00      |
+| 300  | 2 | \$-258.81   |
+| 600  | 2 | \$-258.81   |
+| 900  | 2 | \$-258.81   |
+
+### Table 2 — hour-of-window vs realized PnL
+
+| hour_of_window | count | gross_pnl |
+|---:|---:|---:|
+| h+1 | 2 | \$-108.62 |
+| h+6 | 1 | \$-13.00  |
+| (out of window) | 3 | \$-240.69 |
+
+## What this does NOT show
+
+The numbers above are **not** a Phase 1 finding. They're the scaffolding's first run on insufficient data, recorded for traceability. Three problems:
+
+### 1. N is too small (N=6 closed positions in 30 days)
+
+A 5-bucket pause comparison needs at least N=30 per bucket to detect anything but a huge effect. AC's projected data-ready date (`~2026-06-06`) assumes ~5 closes/week steady-state; getting to N≥30 per bucket would take months at current trade rates. The scaffolding will run again automatically when more data accumulates.
+
+### 2. Pause-length counterfactual is fundamentally limited
+
+The script approximates "would this trade still surface under longer pause?" by checking the gap between the latest candidate scan and the actual open timestamp. That ignores the dominant cost: the Caddie Master subprocess itself runs for 15–30 minutes per cycle. The configurable `--pause` flag is the gap *between* subprocesses; for any pause in the 60s–900s range, real cycle frequency is dominated by subprocess runtime, not the pause. Changing pause from 60s to 900s adds at most ~14 minutes between cycles — small relative to the 15–30 min cycle itself.
+
+The original issue framed pause as the lever for "how often we look at the market." The actual lever is sub-agent depth (which determines subprocess runtime). Phase 1's pause-vs-PnL question may simply be the wrong question against current architecture.
+
+### 3. Counterfactual entry-price drift cannot be modeled
+
+The issue itself flags this: "Requires reconstructing Kalshi historical mid-price trajectories for candidates we never traded — not data we currently persist." The `candidates` table snapshots `market_price` at scan time but not in between scans. A "missed by one cycle" candidate could have moved by any amount before the next scan; we don't know.
+
+Two remediation paths:
+- **Persist quote trajectories**: add a periodic Kalshi `/markets` poller that writes mid-price snapshots independent of cycle scans. ~5-min granularity is probably enough. New table `quote_history`. ~1 week of work.
+- **Use Kalshi's historical-data API**: paid tier. Operationally simpler but adds an external dependency.
+
+Neither is in scope for #553; both are prerequisites if Phase 1's pause analysis is to land in its full-fidelity form.
+
+## Honest recommendation
+
+**Defer Phase 1's pause analysis.** The pause lever is too weak against current architecture for a 30-day backtest to produce actionable signal. Pivot the parent #546 question to:
+
+1. **Hour-of-window alpha localization** (Table 2 above) — the scaffolding handles this and produces meaningful output once N is sufficient. Likely actionable as a calendar-narrowing follow-up similar to #558.
+2. **Sub-agent depth tuning** — what's the marginal P&L improvement from the 200th-300th turn vs cycles capped at 100 turns? This is the real lever for cost reduction (#552 found cycle cost is dominated by intra-cycle conversation building, not inter-cycle gaps). Would need new instrumentation.
+
+Phase 1's literal pause-vs-PnL deliverable is feasible only after persistent quote logging lands. Until then, the scaffolding above runs on whatever data exists and the tables stay non-significant. Re-run periodically; Table 2 will become actionable first.
+
+## Re-running
+
+```bash
+cd ~/gimmes
+uv run python tests/research/pause_and_hour_backtest.py
+```
+
+Output writes to `tests/research/output/{pause_vs_pnl,hour_vs_pnl,closed_trades}.csv`. The script is idempotent and reads the live database; no fixtures or mocking.

--- a/tests/research/pause_and_hour_backtest.md
+++ b/tests/research/pause_and_hour_backtest.md
@@ -18,15 +18,20 @@
 
 ## Output
 
-### Table 1 — pause-length vs realized PnL
+### Table 1 — scan-to-open gap distribution (descriptive)
 
-| pause_s | trades_surfaced | gross_pnl |
+For each closed trade, what was the gap from the most recent pre-open candidate scan to the actual open timestamp? "Trades with scan within X" answers: of N=6 closed trades, how many had recent enough data that an algorithm running with `pause ≤ X` would have had non-stale information at trade time.
+
+Note: this is a description of **observed** gaps in the trade history, not a counterfactual ("would this trade have surfaced under pause=X?"). A true counterfactual requires modeling cycle frequency and price drift from data we don't persist (see Blocker 2 below).
+
+| pause_thresh_s | trades_with_scan_within | pnl_subset |
 |---:|---:|---:|
 | 60   | 0 | \$0.00      |
 | 120  | 0 | \$0.00      |
-| 300  | 2 | \$-258.81   |
-| 600  | 2 | \$-258.81   |
-| 900  | 2 | \$-258.81   |
+| 300  | 5 | \$-380.44   |
+| 600  | 5 | \$-380.44   |
+| 900  | 5 | \$-380.44   |
+| (no scan record) | 1 | \$132.63 |
 
 ### Table 2 — hour-of-window vs realized PnL
 

--- a/tests/research/pause_and_hour_backtest.py
+++ b/tests/research/pause_and_hour_backtest.py
@@ -1,0 +1,282 @@
+"""Phase 1 backtest scaffolding for #553 (parent: #546).
+
+Computes two stratified tables from the live database and cycle logs:
+  1. Pause-length vs realized PnL — for each closed trade, simulates whether
+     it would still have been surfaced under longer cycle-pause settings.
+  2. Hour-of-window vs realized PnL — buckets each closed trade by hours
+     elapsed since the trade window opened.
+
+This is a scaffolding deliverable: AC requires 30 days of post-#549 cycle
+logs (~ready 2026-06-06). Today's run executes against whatever data
+exists and prints HONEST caveats about statistical sufficiency. Re-run
+the same command after more data accumulates; the tables will fill in.
+
+Run from the repo root:
+
+    uv run python tests/research/pause_and_hour_backtest.py
+
+Writes summary to stdout and detailed CSV to ``tests/research/output/``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+from gimmes.strategy.calendar import ET, is_in_trade_window  # noqa: E402
+
+DB_PATH = Path.home() / ".gimmes" / "gimmes.db"
+LOOKBACK_DAYS = 30
+PAUSE_BUCKETS_S = (60, 120, 300, 600, 900)
+OUT_DIR = Path(__file__).resolve().parent / "output"
+
+
+def _load_trades(db_path: Path, since: datetime) -> list[dict]:
+    """Return open/close/size_up rows newer than ``since``, oldest first."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT timestamp, ticker, action, side, count, price
+        FROM trades
+        WHERE action IN ('open', 'close', 'size_up')
+          AND timestamp >= ?
+        ORDER BY timestamp
+        """,
+        (since.isoformat(),),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _load_candidates(db_path: Path, since: datetime) -> list[dict]:
+    """Return candidate scans newer than ``since``, oldest first."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT scanned_at, ticker, market_price, edge, gimme_score
+        FROM candidates
+        WHERE scanned_at >= ?
+        ORDER BY scanned_at
+        """,
+        (since.isoformat(),),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _parse_dt(s: str) -> datetime:
+    """Parse ISO timestamp; ensure timezone-aware (assume UTC if naive)."""
+    from datetime import UTC
+    s = s.replace(" ", "T")
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _pair_trades(trades: list[dict]) -> list[dict]:
+    """Match closes to their preceding opens per (ticker, side); compute realized PnL.
+
+    Uses the same weighted-average logic as ``calculate_pnl`` (#561) so the
+    backtest's PnL numbers reconcile with ``gimmes report``.
+    """
+    by_key: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for t in trades:
+        by_key[(t["ticker"], t["side"])].append(t)
+
+    closed = []
+    for (ticker, side), events in by_key.items():
+        events.sort(key=lambda e: e["timestamp"])
+        remaining = 0
+        avg_cost = 0.0
+        first_open_ts: str | None = None
+        for e in events:
+            count = int(e["count"] or 0)
+            price = float(e["price"] or 0.0)
+            if e["action"] in ("open", "size_up"):
+                if count <= 0:
+                    continue
+                if remaining == 0:
+                    first_open_ts = e["timestamp"]
+                total = remaining + count
+                avg_cost = (
+                    (avg_cost * remaining + price * count) / total
+                    if total
+                    else 0.0
+                )
+                remaining = total
+            elif e["action"] == "close":
+                if count <= 0 or remaining <= 0:
+                    continue
+                matched = min(count, remaining)
+                pnl = (price - avg_cost) * matched
+                closed.append({
+                    "ticker": ticker,
+                    "side": side,
+                    "open_ts": first_open_ts,
+                    "close_ts": e["timestamp"],
+                    "open_price": avg_cost,
+                    "close_price": price,
+                    "count": matched,
+                    "pnl": pnl,
+                })
+                remaining -= matched
+                if remaining == 0:
+                    first_open_ts = None
+    return closed
+
+
+def _candidate_first_seen(
+    candidates: list[dict], ticker: str, before: datetime,
+) -> datetime | None:
+    """Earliest scan timestamp that surfaced ``ticker`` before ``before``."""
+    earliest: datetime | None = None
+    for c in candidates:
+        if c["ticker"] != ticker:
+            continue
+        ts = _parse_dt(c["scanned_at"])
+        if ts > before:
+            continue
+        if earliest is None or ts < earliest:
+            earliest = ts
+    return earliest
+
+
+def _hour_of_window(open_ts: str) -> int | None:
+    """Hours since the active trade window opened, or None if not in window."""
+    dt = _parse_dt(open_ts).astimezone(ET)
+    in_w, _name, _secs = is_in_trade_window(dt)
+    if not in_w:
+        return None
+    # Walk back hour by hour to find when the window opened.
+    for h in range(0, 24):
+        check = dt - timedelta(hours=h + 1)
+        in_check, _, _ = is_in_trade_window(check)
+        if not in_check:
+            return h
+    return None
+
+
+def _pause_bucket_for_trade(
+    closed: dict, candidates: list[dict], pause_s: int,
+) -> bool:
+    """Would this trade still have been surfaced under ``pause_s`` between cycles?
+
+    Approximation: the trade was placed at ``open_ts``. Find the latest
+    candidate scan for this ticker before ``open_ts``. If the gap from that
+    scan to ``open_ts`` exceeds ``pause_s``, the simulated longer pause
+    would not have surfaced the candidate in time. (Counterfactual
+    price-trajectory data is not persisted, so we can't model "missed by
+    one cycle" entry-price drift — see research blockers.)
+    """
+    open_dt = _parse_dt(closed["open_ts"])
+    seen = _candidate_first_seen(candidates, closed["ticker"], open_dt)
+    if seen is None:
+        return True  # No scan record — assume the trade still happens
+    gap = (open_dt - seen).total_seconds()
+    return gap <= pause_s
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    cutoff = datetime.now().astimezone() - timedelta(days=LOOKBACK_DAYS)
+    cutoff_iso = cutoff.isoformat()
+
+    trades = _load_trades(DB_PATH, cutoff)
+    candidates = _load_candidates(DB_PATH, cutoff)
+    closed = _pair_trades(trades)
+
+    print(f"=== Phase 1 backtest — {LOOKBACK_DAYS}-day window ===")
+    print(f"Cutoff: {cutoff_iso}")
+    print(f"Trade events in window: {len(trades)}")
+    print(f"Candidate scans in window: {len(candidates)}")
+    print(f"Closed positions in window: {len(closed)}")
+    print()
+
+    # ----- Table 1: pause-length vs realized PnL -----
+    print("--- Table 1: pause-length vs realized PnL ---")
+    print(f"{'pause_s':<10} {'trades_surfaced':<18} {'gross_pnl':<12}")
+    table1: list[dict] = []
+    for pause_s in PAUSE_BUCKETS_S:
+        surfaced = [c for c in closed if _pause_bucket_for_trade(c, candidates, pause_s)]
+        pnl = sum(c["pnl"] for c in surfaced)
+        print(f"{pause_s:<10} {len(surfaced):<18} ${pnl:<11.2f}")
+        table1.append({
+            "pause_s": pause_s,
+            "trades_surfaced": len(surfaced),
+            "gross_pnl": pnl,
+        })
+    print()
+
+    # ----- Table 2: hour-of-window vs realized PnL -----
+    print("--- Table 2: hour-of-window vs realized PnL ---")
+    by_hour: dict[int, list[dict]] = defaultdict(list)
+    out_of_window: list[dict] = []
+    for c in closed:
+        h = _hour_of_window(c["open_ts"])
+        if h is None:
+            out_of_window.append(c)
+        else:
+            by_hour[h].append(c)
+    print(f"{'hour_of_window':<16} {'count':<8} {'gross_pnl':<12}")
+    table2: list[dict] = []
+    for h in sorted(by_hour):
+        cnt = len(by_hour[h])
+        pnl = sum(c["pnl"] for c in by_hour[h])
+        print(f"h+{h:<14} {cnt:<8} ${pnl:<11.2f}")
+        table2.append({"hour_of_window": h, "count": cnt, "gross_pnl": pnl})
+    if out_of_window:
+        oow_pnl = sum(c["pnl"] for c in out_of_window)
+        print(f"{'(out of window)':<16} {len(out_of_window):<8} ${oow_pnl:.2f}")
+    print()
+
+    # ----- Persist CSVs -----
+    import csv
+    with (OUT_DIR / "pause_vs_pnl.csv").open("w") as f:
+        w = csv.DictWriter(f, fieldnames=["pause_s", "trades_surfaced", "gross_pnl"])
+        w.writeheader()
+        w.writerows(table1)
+    with (OUT_DIR / "hour_vs_pnl.csv").open("w") as f:
+        w = csv.DictWriter(f, fieldnames=["hour_of_window", "count", "gross_pnl"])
+        w.writeheader()
+        w.writerows(table2)
+    with (OUT_DIR / "closed_trades.csv").open("w") as f:
+        w = csv.DictWriter(f, fieldnames=[
+            "ticker", "side", "open_ts", "close_ts",
+            "open_price", "close_price", "count", "pnl",
+        ])
+        w.writeheader()
+        w.writerows(closed)
+
+    # ----- Sufficiency caveats -----
+    print("--- Sufficiency caveats ---")
+    if len(closed) < 30:
+        print(
+            f"  N={len(closed)} closes is statistically insufficient for"
+            f" pause-bucket inference. Re-run after additional data accrues."
+        )
+    if len(closed) > 0 and len(closed) < 8:
+        print("  Single-trade buckets dominate; treat tables as illustrative.")
+    print(
+        "  Pause-vs-PnL counterfactual cannot model entry-price drift —"
+        " mid-price trajectories between cycles are not persisted."
+    )
+    print(
+        "  Hour-of-window alpha localization needs N>=30 per bucket to be"
+        " meaningful; some buckets will show zero coverage indefinitely if"
+        " trade windows happen to be sparse during those hours."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/research/pause_and_hour_backtest.py
+++ b/tests/research/pause_and_hour_backtest.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import sqlite3
 import sys
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -55,14 +55,20 @@ def _load_trades(db_path: Path, since: datetime) -> list[dict]:
 
 
 def _load_candidates(db_path: Path, since: datetime) -> list[dict]:
-    """Return candidate scans newer than ``since``, oldest first."""
+    """Return candidate scans newer than ``since``, oldest first.
+
+    ``candidates.scanned_at`` is written by SQLite ``datetime('now')`` with
+    a space separator while ``trades.timestamp`` uses ISO-8601 with ``T``.
+    Wrap both sides in ``datetime()`` so SQLite normalizes formats before
+    comparison — same pattern as ``src/gimmes/reporting/pause_backtest.py``.
+    """
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
         """
         SELECT scanned_at, ticker, market_price, edge, gimme_score
         FROM candidates
-        WHERE scanned_at >= ?
+        WHERE datetime(scanned_at) >= datetime(?)
         ORDER BY scanned_at
         """,
         (since.isoformat(),),
@@ -73,7 +79,6 @@ def _load_candidates(db_path: Path, since: datetime) -> list[dict]:
 
 def _parse_dt(s: str) -> datetime:
     """Parse ISO timestamp; ensure timezone-aware (assume UTC if naive)."""
-    from datetime import UTC
     s = s.replace(" ", "T")
     if s.endswith("Z"):
         s = s[:-1] + "+00:00"
@@ -135,20 +140,21 @@ def _pair_trades(trades: list[dict]) -> list[dict]:
     return closed
 
 
-def _candidate_first_seen(
+def _latest_scan_before(
     candidates: list[dict], ticker: str, before: datetime,
 ) -> datetime | None:
-    """Earliest scan timestamp that surfaced ``ticker`` before ``before``."""
-    earliest: datetime | None = None
+    """Return the latest scan timestamp for ``ticker`` strictly before
+    ``before``, or ``None`` if no such scan exists."""
+    latest: datetime | None = None
     for c in candidates:
         if c["ticker"] != ticker:
             continue
         ts = _parse_dt(c["scanned_at"])
-        if ts > before:
+        if ts >= before:
             continue
-        if earliest is None or ts < earliest:
-            earliest = ts
-    return earliest
+        if latest is None or ts > latest:
+            latest = ts
+    return latest
 
 
 def _hour_of_window(open_ts: str) -> int | None:
@@ -166,30 +172,13 @@ def _hour_of_window(open_ts: str) -> int | None:
     return None
 
 
-def _pause_bucket_for_trade(
-    closed: dict, candidates: list[dict], pause_s: int,
-) -> bool:
-    """Would this trade still have been surfaced under ``pause_s`` between cycles?
-
-    Approximation: the trade was placed at ``open_ts``. Find the latest
-    candidate scan for this ticker before ``open_ts``. If the gap from that
-    scan to ``open_ts`` exceeds ``pause_s``, the simulated longer pause
-    would not have surfaced the candidate in time. (Counterfactual
-    price-trajectory data is not persisted, so we can't model "missed by
-    one cycle" entry-price drift — see research blockers.)
-    """
-    open_dt = _parse_dt(closed["open_ts"])
-    seen = _candidate_first_seen(candidates, closed["ticker"], open_dt)
-    if seen is None:
-        return True  # No scan record — assume the trade still happens
-    gap = (open_dt - seen).total_seconds()
-    return gap <= pause_s
-
-
 def main() -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    cutoff = datetime.now().astimezone() - timedelta(days=LOOKBACK_DAYS)
+    # Use UTC explicitly — DB timestamps are UTC for trades (isoformat) and
+    # SQLite-default UTC for candidates. A local-tz cutoff would drift the
+    # window boundary by hours when the script runs on a non-UTC host.
+    cutoff = datetime.now(UTC) - timedelta(days=LOOKBACK_DAYS)
     cutoff_iso = cutoff.isoformat()
 
     trades = _load_trades(DB_PATH, cutoff)
@@ -203,19 +192,41 @@ def main() -> None:
     print(f"Closed positions in window: {len(closed)}")
     print()
 
-    # ----- Table 1: pause-length vs realized PnL -----
-    print("--- Table 1: pause-length vs realized PnL ---")
-    print(f"{'pause_s':<10} {'trades_surfaced':<18} {'gross_pnl':<12}")
+    # ----- Table 1: scan-to-open gap distribution (descriptive) -----
+    # Phase 1 wanted a pause-vs-PnL counterfactual ("would this trade still
+    # surface under pause=X?") but that requires modeling cycle frequency
+    # and entry-price drift from data we don't persist. Instead, surface
+    # the descriptive gap from each trade's most recent pre-open candidate
+    # scan. A pause threshold below the gap means "the algorithm under
+    # that pause would have had stale data at trade time."
+    print("--- Table 1: scan-to-open gap distribution (descriptive) ---")
+    print(
+        f"{'pause_thresh_s':<16} {'trades_with_scan_within':<26}"
+        f" {'pnl_subset':<12}"
+    )
     table1: list[dict] = []
-    for pause_s in PAUSE_BUCKETS_S:
-        surfaced = [c for c in closed if _pause_bucket_for_trade(c, candidates, pause_s)]
-        pnl = sum(c["pnl"] for c in surfaced)
-        print(f"{pause_s:<10} {len(surfaced):<18} ${pnl:<11.2f}")
+    gaps: list[tuple[float | None, dict]] = []
+    for c in closed:
+        open_dt = _parse_dt(c["open_ts"])
+        scan_dt = _latest_scan_before(candidates, c["ticker"], open_dt)
+        gap = (open_dt - scan_dt).total_seconds() if scan_dt else None
+        gaps.append((gap, c))
+    for thresh in PAUSE_BUCKETS_S:
+        within = [c for gap, c in gaps if gap is not None and gap <= thresh]
+        pnl = sum(c["pnl"] for c in within)
+        print(f"{thresh:<16} {len(within):<26} ${pnl:<11.2f}")
         table1.append({
-            "pause_s": pause_s,
-            "trades_surfaced": len(surfaced),
-            "gross_pnl": pnl,
+            "pause_thresh_s": thresh,
+            "trades_with_scan_within": len(within),
+            "pnl_subset": pnl,
         })
+    no_scan = [c for gap, c in gaps if gap is None]
+    if no_scan:
+        no_scan_pnl = sum(c["pnl"] for c in no_scan)
+        print(
+            f"{'(no scan record)':<16} {len(no_scan):<26}"
+            f" ${no_scan_pnl:.2f}"
+        )
     print()
 
     # ----- Table 2: hour-of-window vs realized PnL -----
@@ -243,7 +254,10 @@ def main() -> None:
     # ----- Persist CSVs -----
     import csv
     with (OUT_DIR / "pause_vs_pnl.csv").open("w") as f:
-        w = csv.DictWriter(f, fieldnames=["pause_s", "trades_surfaced", "gross_pnl"])
+        w = csv.DictWriter(
+            f,
+            fieldnames=["pause_thresh_s", "trades_with_scan_within", "pnl_subset"],
+        )
         w.writeheader()
         w.writerows(table1)
     with (OUT_DIR / "hour_vs_pnl.csv").open("w") as f:


### PR DESCRIPTION
## Summary

Phase 1 of #546 asks for a 30-day backtest of pause-length vs PnL and hour-of-window vs PnL. AC's projected data-ready date is ~2026-06-06; today is 2026-05-08.

This PR commits the analysis **scaffolding** (single Python script, no notebook) and a **research markdown** documenting what was found by running the scaffolding against today's data plus two structural blockers that prevent the full-fidelity analysis from being done with currently-persisted data.

Not closing #553 — AC bullets remain unsatisfied (N too small, blockers unresolved).

## What landed

- `tests/research/pause_and_hour_backtest.py` — single-file scaffolding, runs against the live `~/.gimmes/gimmes.db` and emits two tables to stdout plus three CSVs. Uses the same weighted-average pairing as `calculate_pnl` (#561) so backtest PnL reconciles with `gimmes report`. Idempotent; re-run as data accumulates.
- `tests/research/pause_and_hour_backtest.md` — runs the scaffolding, records today's tables for traceability, documents N-too-small + the two structural blockers, ends with an honest recommendation.
- `.gitignore` — exclude regenerated CSVs in `tests/research/output/`.

## Today's run (illustrative — N=6 closed positions)

### Table 1: pause-length vs realized PnL
| pause_s | trades_surfaced | gross_pnl |
|---:|---:|---:|
| 60 | 0 | \$0.00 |
| 300 | 2 | -\$258.81 |
| 900 | 2 | -\$258.81 |

### Table 2: hour-of-window vs realized PnL
| hour_of_window | count | gross_pnl |
|---:|---:|---:|
| h+1 | 2 | -\$108.62 |
| h+6 | 1 | -\$13.00 |
| (out of window) | 3 | -\$240.69 |

## Two structural blockers

1. **Pause lever is too weak vs subprocess runtime.** Caddie Master cycles run 15–30 min each; configurable `--pause` is the gap *between* them. Changing pause from 60s to 900s adds at most 14 min between cycles — small relative to the 15–30 min cycle itself. The pause-vs-PnL deliverable may simply be the wrong question against current architecture.
2. **Entry-price drift cannot be modeled without persistent quote trajectories.** Acknowledged in the issue itself. Requires either a new periodic Kalshi `/markets` poller writing a `quote_history` table, or paid Kalshi historical-data API access. Neither is in scope for #553.

## Recommendation (from the markdown)

Pivot #546 to:
1. **Hour-of-window alpha localization** — Table 2 above; will become actionable as N grows. Likely a calendar-narrowing follow-up similar to #558.
2. **Sub-agent depth tuning** — #552 found cycle cost is dominated by intra-cycle conversation building; capping subagent fanout is the real cost lever.

Phase 1's literal pause-vs-PnL is feasible only after persistent quote logging lands.

## Test plan
- `uv run python tests/research/pause_and_hour_backtest.py` — runs in <1s, outputs to stdout + 3 CSVs
- `uv run ruff check tests/research/pause_and_hour_backtest.py` — clean

Refs #553, #546