### PR TITLE
#571 Phase 1: characterize subagent fanout from cycle logs

### DIFF
--- a/src/gimmes/reporting/subagent_fanout.py
+++ b/src/gimmes/reporting/subagent_fanout.py
@@ -133,8 +133,21 @@ class FanoutSummary:
         return len(self.cycles)
 
     @property
-    def total_cost_usd_reported(self) -> float:
-        return sum(c.total_cost_usd_reported or 0.0 for c in self.cycles)
+    def cycles_with_reported_cost(self) -> int:
+        return sum(1 for c in self.cycles if c.total_cost_usd_reported is not None)
+
+    @property
+    def total_cost_usd_reported(self) -> float | None:
+        # Returns None when *no* audited cycle has a reported cost — that
+        # avoids rendering a misleading $0.00 sum. When some cycles
+        # reported and others didn't, returns the partial sum; the
+        # render layer surfaces "(N of M cycles reported)" so the
+        # coverage gap is visible rather than silently understated.
+        reported = [c.total_cost_usd_reported for c in self.cycles
+                    if c.total_cost_usd_reported is not None]
+        if not reported:
+            return None
+        return sum(reported)
 
     @property
     def total_cost_usd_computed(self) -> float:
@@ -423,10 +436,19 @@ def render_markdown(summary: FanoutSummary) -> str:
     lines: list[str] = []
     lines.append("# Subagent fanout characterization (Phase 1 of #571)")
     lines.append("")
+    if summary.total_cost_usd_reported is None:
+        reported_str = "**?** (no cycle reported a total)"
+    else:
+        coverage = ""
+        if summary.cycles_with_reported_cost < summary.cycles_audited:
+            coverage = (
+                f" ({summary.cycles_with_reported_cost} of"
+                f" {summary.cycles_audited} cycles reported)"
+            )
+        reported_str = f"**${summary.total_cost_usd_reported:.2f}**{coverage}"
     lines.append(
         f"Audited **{summary.cycles_audited}** cycles.  "
-        f"Sum of reported `result.total_cost_usd`: "
-        f"**${summary.total_cost_usd_reported:.2f}**.  "
+        f"Sum of reported `result.total_cost_usd`: {reported_str}.  "
         f"Sum of bucket costs (this report): "
         f"**${summary.total_cost_usd_computed:.2f}**.",
     )

--- a/src/gimmes/reporting/subagent_fanout.py
+++ b/src/gimmes/reporting/subagent_fanout.py
@@ -1,0 +1,527 @@
+"""Phase 1 characterization of intra-cycle subagent fanout (issue #571).
+
+Walks one or more ``cycle-NNNN.json`` stream-json logs, tallies ``Agent``
+dispatches by ``subagent_type``, and attributes per-turn token usage and
+dollar cost to either the parent ``caddie_master`` agent or the active
+subagent. Closes #569's recommendation that "sub-agent depth tuning is
+the real cost lever" by giving Phase 2 a numeric basis for picking which
+subagent to cap.
+
+## Attribution model
+
+A cycle's stream-json is a JSON **array** of events from the parent
+(Caddie Master) subprocess. Subagent dispatches surface as ``assistant``
+events containing a ``tool_use`` block with ``name == "Agent"``. The
+matching ``tool_result`` arrives in a ``user`` event some events later.
+Subagent internal turns surface as nested ``assistant`` events between
+dispatch and return — those carry their own ``message.usage``.
+
+The walker maintains an "active dispatch" pointer:
+
+- Before any dispatch: every ``assistant`` event's usage is attributed to
+  ``caddie_master``.
+- Once a dispatch fires, the *envelope* turn (the one containing the
+  ``Agent`` ``tool_use`` block) stays attributed to ``caddie_master`` —
+  the dispatch decision is Caddie Master's, not the dispatchee's.
+- Subsequent ``assistant`` events until the matching ``tool_result``
+  attribute to the dispatchee's ``subagent_type``.
+- After the result, attribution returns to ``caddie_master`` until the
+  next dispatch.
+
+Nested dispatches (subagent calling subagent) would require a stack;
+the production gimmes pipeline doesn't emit them, so this module uses a
+single active-dispatch pointer and emits a warning if a tool_use_id
+arrives mid-flight from an unexpected source.
+
+## Cost model
+
+All declared agents in ``.claude/agents/*.md`` use ``claude-sonnet-4-6``;
+the cycle log's first ``assistant.message.model`` is read as the cycle's
+billed model. Falls back to Sonnet pricing on unknown models, matching
+``budget.cost_from_usage`` policy.
+
+Read-only: this module never writes to ``~/.gimmes`` or ``gimmes.db``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from gimmes.budget import PRICING, cost_from_usage
+
+logger = logging.getLogger("gimmes.subagent_fanout")
+
+CADDIE_MASTER = "caddie_master"
+UNKNOWN = "unknown"
+
+# Token kinds that ``parse_usage_from_stream_json`` and
+# ``budget.cost_from_usage`` already use; mirror them here so the bucket
+# totals reconcile against the cycle-level totals.
+TOKEN_KINDS: tuple[str, ...] = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+
+@dataclass(frozen=True)
+class Dispatch:
+    """One ``Agent`` tool_use observed in a cycle log."""
+
+    tool_use_id: str
+    subagent_type: str
+    description: str
+    event_idx: int
+
+
+@dataclass(frozen=True)
+class BucketUsage:
+    """Aggregate token usage and dollar cost attributed to one bucket
+    (parent ``caddie_master`` or a subagent type)."""
+
+    bucket: str
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    cost_usd: float
+    turn_count: int
+
+
+@dataclass(frozen=True)
+class CycleFanout:
+    """Per-cycle fanout characterization."""
+
+    cycle_id: int
+    log_path: Path
+    model: str
+    total_cost_usd_reported: float | None
+    total_events: int
+    dispatches: tuple[Dispatch, ...]
+    buckets: tuple[BucketUsage, ...]
+    warnings: tuple[str, ...] = ()
+
+    def cost_by_bucket(self) -> dict[str, float]:
+        return {b.bucket: b.cost_usd for b in self.buckets}
+
+    def dispatch_count_by_type(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for d in self.dispatches:
+            counts[d.subagent_type] = counts.get(d.subagent_type, 0) + 1
+        return counts
+
+    def computed_total_cost_usd(self) -> float:
+        return sum(b.cost_usd for b in self.buckets)
+
+
+@dataclass(frozen=True)
+class FanoutSummary:
+    """Aggregate over multiple cycles, suitable for the deliverable markdown."""
+
+    cycles: tuple[CycleFanout, ...]
+    totals_by_bucket: tuple[BucketUsage, ...]
+    dispatch_counts_by_type: dict[str, int]
+    warnings: tuple[str, ...] = field(default=())
+
+    @property
+    def cycles_audited(self) -> int:
+        return len(self.cycles)
+
+    @property
+    def total_cost_usd_reported(self) -> float:
+        return sum(c.total_cost_usd_reported or 0.0 for c in self.cycles)
+
+    @property
+    def total_cost_usd_computed(self) -> float:
+        return sum(b.cost_usd for b in self.totals_by_bucket)
+
+    def highest_cost_bucket(self) -> BucketUsage | None:
+        non_master = [b for b in self.totals_by_bucket if b.bucket != CADDIE_MASTER]
+        return max(non_master, key=lambda b: b.cost_usd, default=None)
+
+
+def _normalize_subagent(name: object) -> str:
+    """Lowercase + ``str()`` the dispatchee name. Real logs include a
+    ``"monitor"`` (lowercase) variant alongside ``"Monitor"`` from a
+    different code path; treating them as one bucket avoids splitting
+    the same agent's cost across two rows."""
+    if name is None:
+        return UNKNOWN
+    text = str(name).strip()
+    if not text:
+        return UNKNOWN
+    return text.lower()
+
+
+def _iter_content_blocks(event: dict) -> Iterable[dict]:
+    msg = event.get("message")
+    if not isinstance(msg, dict):
+        return ()
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return ()
+    return (b for b in content if isinstance(b, dict))
+
+
+def _add(usage: dict[str, int], delta: dict | None) -> None:
+    if not isinstance(delta, dict):
+        return
+    for k in TOKEN_KINDS:
+        v = delta.get(k, 0) or 0
+        try:
+            usage[k] += int(v)
+        except (TypeError, ValueError):
+            continue
+
+
+def parse_cycle_log(path: Path) -> CycleFanout | None:
+    """Walk one cycle-NNNN.json and return per-bucket attribution.
+
+    Fail-open on parse errors — returns ``None`` so a sweep over many
+    cycles can skip malformed files without crashing the report."""
+    try:
+        with path.open() as f:
+            arr = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("subagent_fanout: skipping %s: %s", path, exc)
+        return None
+    if not isinstance(arr, list):
+        logger.warning("subagent_fanout: %s is not a JSON array", path)
+        return None
+
+    # Cycle id from filename: ``cycle-NNNN.json`` -> ``NNNN``
+    try:
+        cycle_id = int(path.stem.split("-", 1)[1])
+    except (IndexError, ValueError):
+        cycle_id = -1
+
+    bucket_usage: dict[str, dict[str, int]] = {}
+    bucket_turns: dict[str, int] = {}
+    dispatches: list[Dispatch] = []
+    warnings: list[str] = []
+
+    # Active dispatch pointer: tool_use_id of the in-flight subagent, or
+    # None when attribution should go to the parent.
+    active_tool_use_id: str | None = None
+    active_bucket: str = CADDIE_MASTER
+
+    # Resolve dispatch -> subagent_type lookups when the matching
+    # tool_result arrives; the result event itself doesn't echo the type.
+    dispatch_by_id: dict[str, str] = {}
+
+    model: str | None = None
+    total_cost_usd_reported: float | None = None
+
+    def attribute(bucket: str, usage: dict | None) -> None:
+        if not isinstance(usage, dict):
+            return
+        slot = bucket_usage.setdefault(
+            bucket, dict.fromkeys(TOKEN_KINDS, 0),
+        )
+        _add(slot, usage)
+        bucket_turns[bucket] = bucket_turns.get(bucket, 0) + 1
+
+    for idx, ev in enumerate(arr):
+        if not isinstance(ev, dict):
+            continue
+        ev_type = ev.get("type")
+
+        if ev_type == "assistant":
+            msg = ev.get("message")
+            if not isinstance(msg, dict):
+                continue
+            if model is None:
+                m = msg.get("model")
+                if isinstance(m, str) and m:
+                    model = m
+
+            usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else None
+
+            # Detect Agent tool_use blocks (subagent dispatches).
+            new_dispatches: list[Dispatch] = []
+            for blk in _iter_content_blocks(ev):
+                if blk.get("type") != "tool_use" or blk.get("name") != "Agent":
+                    continue
+                inp = blk.get("input") if isinstance(blk.get("input"), dict) else {}
+                tool_use_id = blk.get("id")
+                if not isinstance(tool_use_id, str):
+                    continue
+                subtype = _normalize_subagent(inp.get("subagent_type"))
+                desc = str(inp.get("description") or "")[:200]
+                d = Dispatch(
+                    tool_use_id=tool_use_id,
+                    subagent_type=subtype,
+                    description=desc,
+                    event_idx=idx,
+                )
+                new_dispatches.append(d)
+                dispatch_by_id[tool_use_id] = subtype
+
+            # Attribute THIS turn before flipping the active pointer:
+            # the envelope turn carrying the Agent tool_use is a
+            # caddie_master decision, not the dispatchee's work.
+            attribute(active_bucket, usage)
+
+            # If this turn dispatched one or more subagents, flip the
+            # active pointer to the LAST one (real logs serialize them).
+            if new_dispatches:
+                if active_tool_use_id is not None:
+                    warnings.append(
+                        f"event {idx}: new dispatch while another in"
+                        f" flight ({active_tool_use_id}); attribution"
+                        f" may be inaccurate",
+                    )
+                if len(new_dispatches) > 1:
+                    warnings.append(
+                        f"event {idx}: {len(new_dispatches)} Agent blocks"
+                        f" in one envelope; only the last subagent_type is"
+                        f" tracked as active",
+                    )
+                last = new_dispatches[-1]
+                active_tool_use_id = last.tool_use_id
+                active_bucket = last.subagent_type
+                dispatches.extend(new_dispatches)
+
+        elif ev_type == "user":
+            for blk in _iter_content_blocks(ev):
+                if blk.get("type") != "tool_result":
+                    continue
+                tool_use_id = blk.get("tool_use_id")
+                if not isinstance(tool_use_id, str):
+                    continue
+                if tool_use_id == active_tool_use_id:
+                    active_tool_use_id = None
+                    active_bucket = CADDIE_MASTER
+                elif tool_use_id in dispatch_by_id:
+                    # Result for a known-but-not-active dispatch — implies
+                    # nesting or interleaving the single-pointer model
+                    # doesn't capture. Emit a warning; don't attempt to
+                    # re-attribute.
+                    warnings.append(
+                        f"event {idx}: tool_result for {tool_use_id}"
+                        f" ({dispatch_by_id[tool_use_id]}) but active is"
+                        f" {active_tool_use_id};"
+                        f" nested/interleaved dispatch suspected",
+                    )
+                # Non-Agent tool_results (Bash, Read, etc.) carry no
+                # usage and don't change attribution.
+
+        elif ev_type == "result":
+            cost = ev.get("total_cost_usd")
+            if isinstance(cost, (int, float)):
+                total_cost_usd_reported = float(cost)
+            # Result event's own usage is parent-only; the per-turn
+            # attribution above already captured the cycle total.
+
+        # ``system`` and ``rate_limit_event`` events carry no usage.
+
+    if active_tool_use_id is not None:
+        warnings.append(
+            f"cycle ended with dispatch {active_tool_use_id}"
+            f" ({dispatch_by_id.get(active_tool_use_id, '?')}) still"
+            f" in flight; trailing turns attributed to its bucket",
+        )
+
+    bill_model = model or "claude-sonnet-4-6"
+    if bill_model not in PRICING:
+        warnings.append(
+            f"unknown model {bill_model!r}; bucket costs computed at"
+            f" Sonnet rates (update PRICING in src/gimmes/budget.py)",
+        )
+    buckets: list[BucketUsage] = []
+    for name, usage in bucket_usage.items():
+        cost = cost_from_usage(usage, bill_model)
+        buckets.append(BucketUsage(
+            bucket=name,
+            input_tokens=usage["input_tokens"],
+            output_tokens=usage["output_tokens"],
+            cache_creation_input_tokens=usage["cache_creation_input_tokens"],
+            cache_read_input_tokens=usage["cache_read_input_tokens"],
+            cost_usd=cost,
+            turn_count=bucket_turns.get(name, 0),
+        ))
+    buckets.sort(key=lambda b: (-b.cost_usd, b.bucket))
+
+    return CycleFanout(
+        cycle_id=cycle_id,
+        log_path=path,
+        model=bill_model,
+        total_cost_usd_reported=total_cost_usd_reported,
+        total_events=len(arr),
+        dispatches=tuple(dispatches),
+        buckets=tuple(buckets),
+        warnings=tuple(warnings),
+    )
+
+
+def build_summary(cycles: Iterable[CycleFanout]) -> FanoutSummary:
+    """Roll cycle attributions up across multiple cycles.
+
+    Costs are summed from each cycle's per-bucket cost (which was already
+    computed at that cycle's billed model). This is mathematically equal
+    to re-pricing aggregated tokens at one rate when every cycle uses the
+    same model — and remains correct when cycles span multiple models
+    (e.g. an Opus → Sonnet rotation), where re-pricing aggregated tokens
+    at one rate would silently misprice the others.
+    """
+    cycles_t = tuple(cycles)
+    totals: dict[str, dict[str, int]] = {}
+    turns: dict[str, int] = {}
+    cost_by_bucket: dict[str, float] = {}
+    dispatch_counts: dict[str, int] = {}
+    warnings: list[str] = []
+
+    for cyc in cycles_t:
+        for b in cyc.buckets:
+            slot = totals.setdefault(
+                b.bucket, dict.fromkeys(TOKEN_KINDS, 0),
+            )
+            slot["input_tokens"] += b.input_tokens
+            slot["output_tokens"] += b.output_tokens
+            slot["cache_creation_input_tokens"] += b.cache_creation_input_tokens
+            slot["cache_read_input_tokens"] += b.cache_read_input_tokens
+            turns[b.bucket] = turns.get(b.bucket, 0) + b.turn_count
+            cost_by_bucket[b.bucket] = cost_by_bucket.get(b.bucket, 0.0) + b.cost_usd
+        for d in cyc.dispatches:
+            dispatch_counts[d.subagent_type] = (
+                dispatch_counts.get(d.subagent_type, 0) + 1
+            )
+        warnings.extend(f"cycle {cyc.cycle_id}: {w}" for w in cyc.warnings)
+
+    bucket_totals = [
+        BucketUsage(
+            bucket=name,
+            input_tokens=usage["input_tokens"],
+            output_tokens=usage["output_tokens"],
+            cache_creation_input_tokens=usage["cache_creation_input_tokens"],
+            cache_read_input_tokens=usage["cache_read_input_tokens"],
+            cost_usd=cost_by_bucket.get(name, 0.0),
+            turn_count=turns.get(name, 0),
+        )
+        for name, usage in totals.items()
+    ]
+    bucket_totals.sort(key=lambda b: (-b.cost_usd, b.bucket))
+
+    return FanoutSummary(
+        cycles=cycles_t,
+        totals_by_bucket=tuple(bucket_totals),
+        dispatch_counts_by_type=dispatch_counts,
+        warnings=tuple(warnings),
+    )
+
+
+def render_markdown(summary: FanoutSummary) -> str:
+    """Render the deliverable markdown for ``tests/research/subagent_fanout.md``.
+
+    The output is deterministic given the same inputs (sorted bucket order,
+    fixed table columns), so the file can be regenerated and diffed."""
+    lines: list[str] = []
+    lines.append("# Subagent fanout characterization (Phase 1 of #571)")
+    lines.append("")
+    lines.append(
+        f"Audited **{summary.cycles_audited}** cycles.  "
+        f"Sum of reported `result.total_cost_usd`: "
+        f"**${summary.total_cost_usd_reported:.2f}**.  "
+        f"Sum of bucket costs (this report): "
+        f"**${summary.total_cost_usd_computed:.2f}**.",
+    )
+    lines.append("")
+
+    # Table 1 — dispatches per cycle by type
+    all_subagents = sorted({
+        d.subagent_type
+        for c in summary.cycles
+        for d in c.dispatches
+    })
+    lines.append("## Table 1 — Dispatches per cycle by subagent type")
+    lines.append("")
+    header = ["cycle", "events", "cost_usd"] + all_subagents + ["total"]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("|" + "|".join(["---:"] * len(header)) + "|")
+    for c in summary.cycles:
+        counts = c.dispatch_count_by_type()
+        cost = (
+            f"${c.total_cost_usd_reported:.2f}"
+            if c.total_cost_usd_reported is not None
+            else "?"
+        )
+        row = [str(c.cycle_id), str(c.total_events), cost]
+        row.extend(str(counts.get(s, 0)) for s in all_subagents)
+        row.append(str(len(c.dispatches)))
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+
+    # Table 2 — cost share by bucket (aggregate)
+    lines.append("## Table 2 — Cost share by bucket (aggregate)")
+    lines.append("")
+    total_cost = summary.total_cost_usd_computed
+    header2 = [
+        "bucket", "turns", "input_tok", "output_tok",
+        "cache_creation_tok", "cache_read_tok", "cost_usd", "% of total",
+    ]
+    lines.append("| " + " | ".join(header2) + " |")
+    lines.append("|" + "|".join([":---"] + ["---:"] * (len(header2) - 1)) + "|")
+    for b in summary.totals_by_bucket:
+        pct = (100.0 * b.cost_usd / total_cost) if total_cost > 0 else 0.0
+        lines.append(
+            f"| {b.bucket} | {b.turn_count} | {b.input_tokens:,} |"
+            f" {b.output_tokens:,} | {b.cache_creation_input_tokens:,} |"
+            f" {b.cache_read_input_tokens:,} | ${b.cost_usd:.2f} | {pct:.1f}% |",
+        )
+    lines.append("")
+
+    highest = summary.highest_cost_bucket()
+    if highest is not None:
+        pct = (
+            (100.0 * highest.cost_usd / total_cost) if total_cost > 0 else 0.0
+        )
+        lines.append(
+            f"**Highest-cost subagent path:** `{highest.bucket}` —"
+            f" ${highest.cost_usd:.2f} ({pct:.1f}% of total)."
+            f" {highest.turn_count} attributed turns across"
+            f" {summary.dispatch_counts_by_type.get(highest.bucket, 0)} dispatches.",
+        )
+    lines.append("")
+
+    # Table 3 — per-cycle decomposition
+    lines.append("## Table 3 — Per-cycle cost decomposition")
+    lines.append("")
+    lines.append(
+        "| cycle | total | top-1 | top-2 | caddie_master |",
+    )
+    lines.append("| ---: | ---: | :--- | :--- | ---: |")
+    for c in summary.cycles:
+        cm = c.cost_by_bucket().get(CADDIE_MASTER, 0.0)
+        non_master = [b for b in c.buckets if b.bucket != CADDIE_MASTER]
+        top1 = non_master[0] if len(non_master) >= 1 else None
+        top2 = non_master[1] if len(non_master) >= 2 else None
+        cost = (
+            f"${c.total_cost_usd_reported:.2f}"
+            if c.total_cost_usd_reported is not None
+            else "?"
+        )
+
+        def fmt(b: BucketUsage | None) -> str:
+            if b is None:
+                return "—"
+            return f"{b.bucket} (${b.cost_usd:.2f})"
+
+        lines.append(
+            f"| {c.cycle_id} | {cost} | {fmt(top1)} | {fmt(top2)} |"
+            f" ${cm:.2f} |",
+        )
+    lines.append("")
+
+    if summary.warnings:
+        lines.append("## Warnings")
+        lines.append("")
+        for w in summary.warnings:
+            lines.append(f"- {w}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tests/research/subagent_fanout.md
+++ b/tests/research/subagent_fanout.md
@@ -1,0 +1,187 @@
+# Subagent fanout characterization — Phase 1 of #571
+
+**Status:** Phase 1 deliverable complete. Phase 2 recommendation in this doc.
+Phase 3 (driving-range A/B + ship/no-ship decision) deferred — same gating
+pattern as PR #569 (Phase 1 of #553). Issue #571 stays open.
+
+**Issue:** #571 (parent #546)
+**Run command:** `uv run python tests/research/subagent_fanout.py`
+**As-of run date:** 2026-05-08
+
+## Methodology
+
+Walked the JSON-array stream-json logs at `~/.gimmes/logs/cycle-NNNN.json`
+for the cycles listed below and attributed every `assistant` event's
+`message.usage` to either the parent `caddie_master` agent or the active
+subagent (the dispatchee of the most recent in-flight `Agent` `tool_use`).
+The envelope turn carrying the `Agent` block is attributed to
+`caddie_master` because the dispatch decision is the parent's, not the
+dispatchee's. When a subagent's matching `tool_result` arrives in a `user`
+event, attribution returns to `caddie_master`.
+
+Cost is computed via `gimmes.budget.cost_from_usage` at
+`claude-sonnet-4-6` rates (every declared agent in `.claude/agents/` uses
+Sonnet 4.6 today).
+
+### Cycle selection (6 cycles)
+
+Stratified to span the observed dispatch-count and cost range across
+cycles 1340–1373:
+
+- cycle 1361: 4 dispatches, \$3.52, 573 events — low-end standard
+- cycle 1366: 4 dispatches, \$3.71, 704 events — typical standard
+- cycle 1369: 4 dispatches, \$4.67, 875 events — high-end standard
+- cycle 1367: 5 dispatches, \$4.94, 774 events — single-Caddie research
+- cycle 1373: 5 dispatches, \$5.34, 743 events — single-Caddie research, recent
+- cycle 1364: 8 dispatches, \$4.47, 660 events — Closer present, multi-Caddie execution
+
+## Tables
+
+### Table 1 — dispatches per cycle by subagent type
+
+| cycle | events | cost_usd | caddie | closer | groundskeeper | monitor | scorecard | scout | total |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1361 | 573 | \$3.52 | 0 | 0 | 1 | 1 | 1 | 1 | 4 |
+| 1366 | 704 | \$3.71 | 0 | 0 | 1 | 1 | 1 | 1 | 4 |
+| 1369 | 875 | \$4.67 | 0 | 0 | 1 | 1 | 1 | 1 | 4 |
+| 1367 | 774 | \$4.94 | 1 | 0 | 1 | 1 | 1 | 1 | 5 |
+| 1373 | 743 | \$5.34 | 1 | 0 | 1 | 1 | 1 | 1 | 5 |
+| 1364 | 660 | \$4.47 | 3 | 1 | 1 | 1 | 1 | 1 | 8 |
+
+Across the 6 cycles, every cycle dispatched Monitor / Scout / Scorecard /
+Groundskeeper exactly once. Caddie fanout varies (0, 1, or 3 per cycle).
+Closer was dispatched only when an order was actually placed.
+
+### Table 2 — cost share by bucket (aggregate across all 6 cycles)
+
+| bucket | turns | input_tok | output_tok | cache_creation_tok | cache_read_tok | cost_usd | % of total |
+|:---|---:|---:|---:|---:|---:|---:|---:|
+| monitor | 357 | 6,239 | 6,001 | 2,240,223 | 17,424,794 | \$13.74 | 39.0% |
+| scout | 634 | 656 | 24,394 | 648,940 | 22,048,554 | \$9.42 | 26.8% |
+| caddie_master | 351 | 375 | 5,698 | 1,011,290 | 18,404,015 | \$9.40 | 26.7% |
+| caddie | 133 | 14,528 | 4,235 | 216,736 | 2,779,923 | \$1.75 | 5.0% |
+| scorecard | 75 | 86 | 1,553 | 120,363 | 754,171 | \$0.70 | 2.0% |
+| groundskeeper | 25 | 36 | 728 | 18,913 | 178,450 | \$0.14 | 0.4% |
+| closer | 5 | 7 | 11 | 9,340 | 34,046 | \$0.05 | 0.1% |
+
+**Highest-cost subagent path:** `monitor` — \$13.74 (39.0% of total),
+357 attributed turns across 6 dispatches (~60 turns per dispatch).
+
+### Table 3 — per-cycle cost decomposition
+
+| cycle | total | top-1 | top-2 | caddie_master |
+| ---: | ---: | :--- | :--- | ---: |
+| 1361 | \$3.52 | scout (\$1.46) | monitor (\$1.24) | \$2.17 |
+| 1366 | \$3.71 | monitor (\$3.33) | scout (\$1.82) | \$0.85 |
+| 1369 | \$4.67 | scout (\$3.27) | monitor (\$2.63) | \$0.82 |
+| 1367 | \$4.94 | monitor (\$1.52) | scout (\$1.40) | \$2.30 |
+| 1373 | \$5.34 | monitor (\$3.11) | scout (\$0.87) | \$2.09 |
+| 1364 | \$4.47 | monitor (\$1.91) | caddie (\$0.67) | \$1.17 |
+
+The top-2 buckets are always Monitor + Scout (cycle 1364 swaps Scout for
+Caddie because that cycle had 3 Caddie dispatches). Caddie Master
+overhead ranges \$0.82–\$2.30 — when it's high (1361, 1367, 1373) it
+correlates with a cycle that dispatched Caddie at least once, suggesting
+Caddie Master's `Step 4c` review of Caddie's output is itself expensive.
+
+## Cost-reconciliation caveat
+
+Sum of bucket costs over the 6 cycles: **\$35.19**.
+Sum of `result.total_cost_usd` reported by Anthropic over the same 6
+cycles: **\$26.66**.
+
+The 32% over-attribution is consistent with the known finding from #568:
+`parse_usage_from_stream_json`'s sum-across-turns is slightly higher
+than Anthropic's authoritative billing (#568 measured 31% over for 17
+cycles: \$108 computed vs \$83 authoritative). This is a token-level
+artifact of cache_creation accounting; the **relative** percentages in
+Table 2 are unaffected. Cap recommendations below should be read as
+"X% of the cycle's parent-stream observed token cost" not "X% of the
+Anthropic invoice."
+
+## Phase 1 finding
+
+**The cost lever is Monitor and Scout intra-dispatch turn count, not
+dispatch fanout.** Three observations support this:
+
+1. **Dispatch count doesn't vary with cost in the dominant agents.** Every
+   cycle dispatches Monitor and Scout exactly once. The 6 cycles span
+   \$3.52–\$5.34 and the dispatch count is fixed for those agents.
+
+2. **Per-dispatch turn count is high.** Monitor averages ~60 turns per
+   dispatch. Scout averages ~106 turns per dispatch. By contrast, Caddie
+   averages ~20 turns per dispatch. Monitor checks each open position
+   sequentially; Scout iterates over many candidate markets.
+
+3. **Caddie is not the cost driver.** Despite being intuitively the most
+   expensive agent (does deep research), Caddie is 5% of total cost
+   because it's dispatched at most ~1×/cycle and its turn count is
+   bounded.
+
+This **contradicts** the original framing in #571's body, which expected
+Caddie to be the highest-cost path. Phase 1's job is to surface that
+mismatch — and it has.
+
+## Phase 2 recommendation
+
+**Posted as a comment on #571.** Summary:
+
+- **Reject Option A (hard cap on dispatch count per cycle).** All
+  high-cost agents are already dispatched ≤1× per cycle. Capping
+  dispatches doesn't address the cost.
+- **Reject Option B (depth cap).** No nested subagent dispatches were
+  observed — the pipeline is already depth-1.
+- **Reject Option D (Haiku swap).** Monitor and Scout do market-data
+  reasoning that's quality-sensitive; downgrading without measuring
+  decision-regression risk is premature. Revisit only if the targeted
+  cap below doesn't yield enough savings.
+- **Recommend a refined Option C — cap per-dispatch fanout inside
+  Monitor and Scout.** Specifically:
+  - Monitor: cap the number of open positions checked per dispatch
+    (process N most-recently-changed positions, defer the rest to the
+    next cycle).
+  - Scout: cap candidate-list size before per-candidate analysis (top-K
+    by edge or score, defer the long tail).
+
+The cost-reduction math from Table 2:
+
+```
+mean_monitor_cost_per_cycle = $13.74 / 6 = $2.29
+mean_scout_cost_per_cycle = $9.42 / 6 = $1.57
+combined = $3.86 / cycle (66% of mean cycle cost)
+```
+
+If a per-position/per-candidate cap halved Monitor and Scout's intra-
+dispatch turns (a guess; Phase 3 measures), per-cycle savings would be
+~\$1.93 — a third of mean cycle cost. Even a 20% turn reduction would
+free ~\$0.77/cycle, which against the recently-validated \$4.87
+authoritative mean (#568) is meaningful.
+
+Phase 3 is required before shipping any cap: a driving-range A/B with
+the cap applied, comparing cost AND trade decisions on the same fixture
+data. The cap must not regress decisions; if it does, the recommendation
+becomes "don't ship, re-investigate Monitor's per-position depth."
+
+## Phase 1 deliverable AC checklist
+
+- [x] `tests/research/subagent_fanout.md` characterizes current fanout
+      (Table 1).
+- [x] Identifies the highest-cost path (Monitor, 39%; Table 2 +
+      "Highest-cost subagent path" callout).
+- [x] Per-cycle cost decomposition by subagent type (Table 3).
+- [x] Phase 2 proposal posted as comment on #571.
+- [ ] Phase 3 (A/B + ship decision) — deferred, gates issue closure.
+
+## Reproducing this report
+
+```bash
+uv run python tests/research/subagent_fanout.py
+```
+
+Output:
+- `tests/research/output/subagent_fanout_per_cycle.csv`
+- `tests/research/output/subagent_fanout_buckets.csv`
+- Markdown to stdout (the tables above)
+
+The cycles audited are listed in `DEFAULT_CYCLES` at the top of the
+driver script. Editing that tuple and re-running gives a fresh sample.

--- a/tests/research/subagent_fanout.py
+++ b/tests/research/subagent_fanout.py
@@ -1,7 +1,8 @@
 """Phase 1 driver for #571: characterize current subagent fanout.
 
 Walks a stratified sample of recent ``cycle-NNNN.json`` logs from
-``${GIMMES_HOME}/logs`` and emits:
+``~/.gimmes/logs`` (matching the path used by ``pause_and_hour_backtest.py``
+and the autonomous loop's default ``logs_dir``) and emits:
 
 - ``tests/research/output/subagent_fanout_per_cycle.csv`` — Table 1 data.
 - ``tests/research/output/subagent_fanout_buckets.csv`` — Table 2 data.
@@ -71,7 +72,9 @@ def _write_csvs(summary, paths: list[Path]) -> None:
     """
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    with (OUT_DIR / "subagent_fanout_per_cycle.csv").open("w") as f:
+    with (OUT_DIR / "subagent_fanout_per_cycle.csv").open(
+        "w", newline="", encoding="utf-8",
+    ) as f:
         w = csv.DictWriter(
             f,
             fieldnames=[
@@ -88,6 +91,15 @@ def _write_csvs(summary, paths: list[Path]) -> None:
                 "cost_usd_reported": c.total_cost_usd_reported,
                 "cost_usd_computed": round(c.computed_total_cost_usd(), 6),
             }
+            if not counts:
+                # Cycle with zero dispatches still gets a row so every
+                # audited cycle is represented in the per-cycle CSV.
+                w.writerow({
+                    **base,
+                    "subagent_type": "",
+                    "dispatch_count": 0,
+                })
+                continue
             # Emit one row per dispatched subagent_type. Sorted so two
             # runs over the same cycles produce byte-identical output.
             for subtype in sorted(counts):
@@ -97,7 +109,9 @@ def _write_csvs(summary, paths: list[Path]) -> None:
                     "dispatch_count": counts[subtype],
                 })
 
-    with (OUT_DIR / "subagent_fanout_buckets.csv").open("w") as f:
+    with (OUT_DIR / "subagent_fanout_buckets.csv").open(
+        "w", newline="", encoding="utf-8",
+    ) as f:
         w = csv.DictWriter(
             f,
             fieldnames=[

--- a/tests/research/subagent_fanout.py
+++ b/tests/research/subagent_fanout.py
@@ -1,0 +1,153 @@
+"""Phase 1 driver for #571: characterize current subagent fanout.
+
+Walks a stratified sample of recent ``cycle-NNNN.json`` logs from
+``${GIMMES_HOME}/logs`` and emits:
+
+- ``tests/research/output/subagent_fanout_per_cycle.csv`` — Table 1 data.
+- ``tests/research/output/subagent_fanout_buckets.csv`` — Table 2 data.
+- Markdown tables to stdout (the deliverable
+  ``tests/research/subagent_fanout.md`` is hand-curated and embeds these
+  tables — same handoff pattern as ``pause_and_hour_backtest.py`` →
+  ``pause_and_hour_backtest.md``).
+
+Re-run as more data accumulates; cycle picks are listed in
+``DEFAULT_CYCLES`` and reflected in the markdown's Methodology section so
+the tables are reproducible.
+
+Run from the repo root:
+
+    uv run python tests/research/subagent_fanout.py
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+from gimmes.reporting.subagent_fanout import (  # noqa: E402
+    build_summary,
+    parse_cycle_log,
+    render_markdown,
+)
+
+LOGS_DIR = Path.home() / ".gimmes" / "logs"
+OUT_DIR = Path(__file__).resolve().parent / "output"
+
+# Stratified sample: 3 standard outside-window cycles (4 dispatches each),
+# 2 research cycles (Caddie present, no trade), 1 trade-execution cycle
+# (Closer present). Picked from a survey of cycles 1340-1373 to span the
+# observed cost range ($3.10-$7.64) and dispatch-count range (4-8).
+DEFAULT_CYCLES: tuple[int, ...] = (
+    1361,  # 4 dispatches, $3.52 — low end of standard
+    1366,  # 4 dispatches, $3.71 — typical standard
+    1369,  # 4 dispatches, $4.67 — high end of standard
+    1367,  # 5 dispatches, $4.94 — single-Caddie research
+    1373,  # 5 dispatches, $5.34 — single-Caddie research, recent
+    1364,  # 8 dispatches, $4.47 — Closer present, multi-Caddie execution
+)
+
+
+def _resolve_cycles(ids: tuple[int, ...]) -> list[Path]:
+    paths = []
+    for n in ids:
+        p = LOGS_DIR / f"cycle-{n}.json"
+        if not p.exists():
+            print(f"warn: {p} not found, skipping", file=sys.stderr)
+            continue
+        paths.append(p)
+    return paths
+
+
+def _write_csvs(summary, paths: list[Path]) -> None:
+    """Write per-cycle and per-bucket CSVs in **long form**.
+
+    Long form (one row per ``(cycle, subagent_type)``) keeps the schema
+    constant across runs even when different cycle samples include
+    different subagent types. Wide form (one column per subagent type)
+    would scramble columns between runs and make CSV diffs noisy.
+    """
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    with (OUT_DIR / "subagent_fanout_per_cycle.csv").open("w") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=[
+                "cycle_id", "events", "cost_usd_reported",
+                "cost_usd_computed", "subagent_type", "dispatch_count",
+            ],
+        )
+        w.writeheader()
+        for c in summary.cycles:
+            counts = c.dispatch_count_by_type()
+            base = {
+                "cycle_id": c.cycle_id,
+                "events": c.total_events,
+                "cost_usd_reported": c.total_cost_usd_reported,
+                "cost_usd_computed": round(c.computed_total_cost_usd(), 6),
+            }
+            # Emit one row per dispatched subagent_type. Sorted so two
+            # runs over the same cycles produce byte-identical output.
+            for subtype in sorted(counts):
+                w.writerow({
+                    **base,
+                    "subagent_type": subtype,
+                    "dispatch_count": counts[subtype],
+                })
+
+    with (OUT_DIR / "subagent_fanout_buckets.csv").open("w") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=[
+                "bucket", "turns",
+                "input_tokens", "output_tokens",
+                "cache_creation_input_tokens", "cache_read_input_tokens",
+                "cost_usd",
+            ],
+        )
+        w.writeheader()
+        for b in summary.totals_by_bucket:
+            w.writerow({
+                "bucket": b.bucket,
+                "turns": b.turn_count,
+                "input_tokens": b.input_tokens,
+                "output_tokens": b.output_tokens,
+                "cache_creation_input_tokens": b.cache_creation_input_tokens,
+                "cache_read_input_tokens": b.cache_read_input_tokens,
+                "cost_usd": round(b.cost_usd, 6),
+            })
+
+
+def main() -> None:
+    paths = _resolve_cycles(DEFAULT_CYCLES)
+    if not paths:
+        print(
+            f"error: no cycle logs found under {LOGS_DIR}; cannot render"
+            f" deliverable. Run a Caddie Master cycle first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cycles = [c for c in (parse_cycle_log(p) for p in paths) if c is not None]
+    if not cycles:
+        print(
+            "error: every selected cycle log failed to parse; check"
+            f" {LOGS_DIR} for JSON validity.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    summary = build_summary(cycles)
+    _write_csvs(summary, paths)
+
+    print(render_markdown(summary))
+    print(
+        f"\nWrote {(OUT_DIR / 'subagent_fanout_per_cycle.csv').relative_to(ROOT)},"
+        f" {(OUT_DIR / 'subagent_fanout_buckets.csv').relative_to(ROOT)}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_subagent_fanout.py
+++ b/tests/unit/test_subagent_fanout.py
@@ -1,0 +1,509 @@
+"""Tests for gimmes.reporting.subagent_fanout (#571 Phase 1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gimmes.reporting.subagent_fanout import (
+    CADDIE_MASTER,
+    UNKNOWN,
+    build_summary,
+    parse_cycle_log,
+    render_markdown,
+)
+
+
+def _write_cycle(path: Path, events: list[dict]) -> None:
+    path.write_text(json.dumps(events))
+
+
+def _assistant_event(usage: dict, content: list[dict] | None = None) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "model": "claude-sonnet-4-6",
+            "content": content or [{"type": "text", "text": "..."}],
+            "usage": usage,
+        },
+    }
+
+
+def _agent_dispatch(tool_use_id: str, subagent_type: str | None) -> dict:
+    return {
+        "type": "tool_use",
+        "id": tool_use_id,
+        "name": "Agent",
+        "input": {
+            "subagent_type": subagent_type,
+            "description": f"dispatch-{subagent_type}",
+        },
+    }
+
+
+def _tool_result(tool_use_id: str) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "content": [
+                {"type": "tool_result", "tool_use_id": tool_use_id, "content": "ok"},
+            ],
+        },
+    }
+
+
+def _basic_usage(out_tok: int = 100) -> dict:
+    return {
+        "input_tokens": 0,
+        "output_tokens": out_tok,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+
+
+class TestParseCycleLog:
+    def test_zero_dispatches_all_caddie_master(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0001.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(50)),
+            _assistant_event(_basic_usage(50)),
+            {"type": "result", "total_cost_usd": 0.0015},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert cyc.cycle_id == 1
+        assert cyc.dispatches == ()
+        # Both turns should land in caddie_master.
+        buckets = {b.bucket: b for b in cyc.buckets}
+        assert set(buckets.keys()) == {CADDIE_MASTER}
+        assert buckets[CADDIE_MASTER].turn_count == 2
+        assert buckets[CADDIE_MASTER].output_tokens == 100
+
+    def test_single_dispatch_attribution(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0042.json"
+        _write_cycle(log, [
+            # caddie_master pre-dispatch turn
+            _assistant_event(_basic_usage(10)),
+            # dispatch envelope (still caddie_master)
+            _assistant_event(_basic_usage(20), [
+                _agent_dispatch("tu-1", "Monitor"),
+            ]),
+            # subagent's internal turns
+            _assistant_event(_basic_usage(30)),
+            _assistant_event(_basic_usage(40)),
+            # tool_result returns control to caddie_master
+            _tool_result("tu-1"),
+            # caddie_master post-dispatch turn
+            _assistant_event(_basic_usage(50)),
+            {"type": "result", "total_cost_usd": 0.001},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert cyc.cycle_id == 42
+        assert len(cyc.dispatches) == 1
+        d = cyc.dispatches[0]
+        assert d.subagent_type == "monitor"  # normalized lowercase
+        assert d.tool_use_id == "tu-1"
+
+        buckets = {b.bucket: b for b in cyc.buckets}
+        # Caddie master: pre-dispatch (10) + envelope (20) + post-dispatch (50) = 80
+        assert buckets[CADDIE_MASTER].output_tokens == 80
+        assert buckets[CADDIE_MASTER].turn_count == 3
+        # Monitor: the two internal turns 30 + 40 = 70
+        assert buckets["monitor"].output_tokens == 70
+        assert buckets["monitor"].turn_count == 2
+
+    def test_subagent_type_case_normalized(self, tmp_path: Path) -> None:
+        # Real logs include both "Monitor" and "monitor" (different code
+        # paths). They must collapse into one bucket.
+        log = tmp_path / "cycle-0050.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("tu-A", "Monitor")]),
+            _assistant_event(_basic_usage(10)),
+            _tool_result("tu-A"),
+            _assistant_event(_basic_usage(0), [_agent_dispatch("tu-B", "monitor")]),
+            _assistant_event(_basic_usage(20)),
+            _tool_result("tu-B"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert len(cyc.dispatches) == 2
+        assert all(d.subagent_type == "monitor" for d in cyc.dispatches)
+        # Single bucket "monitor" with 30 output tokens combined.
+        buckets = {b.bucket: b for b in cyc.buckets}
+        assert buckets["monitor"].output_tokens == 30
+        assert buckets["monitor"].turn_count == 2
+
+    def test_unknown_subagent_type(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0060.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("tu-X", None)]),
+            _assistant_event(_basic_usage(15)),
+            _tool_result("tu-X"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        d = cyc.dispatches[0]
+        assert d.subagent_type == UNKNOWN
+        buckets = {b.bucket: b for b in cyc.buckets}
+        assert UNKNOWN in buckets
+        assert buckets[UNKNOWN].output_tokens == 15
+
+    def test_reconciliation_sum_equals_aggregate_usage(self, tmp_path: Path) -> None:
+        # Sum of buckets' raw token totals must equal what
+        # parse_usage_from_stream_json would return — the two are
+        # different views of the same cycle and must reconcile exactly.
+        log = tmp_path / "cycle-0070.json"
+        usages = [
+            {"input_tokens": 1, "output_tokens": 2,
+             "cache_creation_input_tokens": 100, "cache_read_input_tokens": 1000},
+            {"input_tokens": 3, "output_tokens": 4,
+             "cache_creation_input_tokens": 200, "cache_read_input_tokens": 2000},
+            {"input_tokens": 5, "output_tokens": 6,
+             "cache_creation_input_tokens": 300, "cache_read_input_tokens": 3000},
+        ]
+        _write_cycle(log, [
+            _assistant_event(usages[0]),
+            _assistant_event(usages[1], [_agent_dispatch("tu-1", "Scout")]),
+            _assistant_event(usages[2]),
+            _tool_result("tu-1"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+
+        def total(field: str) -> int:
+            return sum(getattr(b, field) for b in cyc.buckets)
+
+        assert total("input_tokens") == 1 + 3 + 5
+        assert total("output_tokens") == 2 + 4 + 6
+        assert total("cache_creation_input_tokens") == 100 + 200 + 300
+        assert total("cache_read_input_tokens") == 1000 + 2000 + 3000
+
+    def test_malformed_log_returns_none(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0080.json"
+        log.write_text("{not valid json")
+        assert parse_cycle_log(log) is None
+
+    def test_non_array_log_returns_none(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0081.json"
+        log.write_text(json.dumps({"events": []}))
+        assert parse_cycle_log(log) is None
+
+    def test_missing_log_returns_none(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-9999.json"
+        # File never created.
+        assert parse_cycle_log(log) is None
+
+    def test_dispatch_still_in_flight_at_eof_warns(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0090.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("tu-1", "Caddie")]),
+            _assistant_event(_basic_usage(10)),
+            # No tool_result for tu-1 — cycle truncated.
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert any("still in flight" in w for w in cyc.warnings)
+        # Trailing turn still attributed to caddie even though result missing.
+        buckets = {b.bucket: b for b in cyc.buckets}
+        assert buckets["caddie"].output_tokens == 10
+
+    def test_multiple_dispatches_same_envelope_uses_last(self, tmp_path: Path) -> None:
+        # Real logs serialize dispatches one per envelope, but the walker
+        # tolerates two-in-one: it records both, flips active to the
+        # last, and emits a warning so the silent mis-attribution is
+        # observable.
+        log = tmp_path / "cycle-0100.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(0), [
+                _agent_dispatch("tu-A", "Monitor"),
+                _agent_dispatch("tu-B", "Scout"),
+            ]),
+            _assistant_event(_basic_usage(50)),
+            _tool_result("tu-B"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert len(cyc.dispatches) == 2
+        assert any("Agent blocks in one envelope" in w for w in cyc.warnings)
+        # The 50-token assistant turn lands in the last subagent (Scout).
+        buckets = {b.bucket: b for b in cyc.buckets}
+        assert buckets["scout"].output_tokens == 50
+        assert "monitor" not in buckets
+
+    def test_new_dispatch_in_flight_warns(self, tmp_path: Path) -> None:
+        # Dispatch B fires before A's tool_result returns. Single-pointer
+        # model can't represent the overlap; the walker warns.
+        log = tmp_path / "cycle-0110.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("tu-A", "Monitor")]),
+            _assistant_event(_basic_usage(0), [_agent_dispatch("tu-B", "Scout")]),
+            _tool_result("tu-A"),
+            _tool_result("tu-B"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert any(
+            "new dispatch while another in flight" in w
+            for w in cyc.warnings
+        )
+
+    def test_unmatched_tool_result_for_known_dispatch_warns(
+        self, tmp_path: Path,
+    ) -> None:
+        # tu-A is known but the active pointer is on tu-B (last dispatch).
+        # When tu-A's tool_result arrives it doesn't match the active id;
+        # the walker should warn rather than silently no-op so the
+        # nested/interleaved case is observable.
+        log = tmp_path / "cycle-0120.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(0), [
+                _agent_dispatch("tu-A", "Monitor"),
+                _agent_dispatch("tu-B", "Scout"),
+            ]),
+            _tool_result("tu-A"),
+            _tool_result("tu-B"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert any(
+            "nested/interleaved dispatch suspected" in w
+            for w in cyc.warnings
+        )
+
+    def test_missing_model_falls_back_to_sonnet(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0130.json"
+        # No `model` field on any assistant event.
+        ev = {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "..."}],
+                "usage": _basic_usage(10),
+            },
+        }
+        _write_cycle(log, [ev, {"type": "result", "total_cost_usd": 0.0}])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert cyc.model == "claude-sonnet-4-6"
+
+    def test_unknown_model_appends_warning(self, tmp_path: Path) -> None:
+        log = tmp_path / "cycle-0140.json"
+        ev = {
+            "type": "assistant",
+            "message": {
+                "model": "claude-future-1-0",
+                "content": [{"type": "text", "text": "..."}],
+                "usage": _basic_usage(10),
+            },
+        }
+        _write_cycle(log, [ev, {"type": "result", "total_cost_usd": 0.0}])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert any("unknown model" in w for w in cyc.warnings)
+
+    def test_empty_array_returns_empty_cyclefanout(self, tmp_path: Path) -> None:
+        # Truncated / killed-subprocess shape: valid JSON, empty array.
+        log = tmp_path / "cycle-0150.json"
+        log.write_text("[]")
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert cyc.dispatches == ()
+        assert cyc.buckets == ()
+        assert cyc.total_events == 0
+        assert cyc.total_cost_usd_reported is None
+
+    def test_result_missing_total_cost_keeps_reported_none(
+        self, tmp_path: Path,
+    ) -> None:
+        log = tmp_path / "cycle-0160.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(10)),
+            {"type": "result"},  # no total_cost_usd key
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert cyc.total_cost_usd_reported is None
+
+    def test_result_non_numeric_total_cost_keeps_reported_none(
+        self, tmp_path: Path,
+    ) -> None:
+        log = tmp_path / "cycle-0161.json"
+        _write_cycle(log, [
+            _assistant_event(_basic_usage(10)),
+            {"type": "result", "total_cost_usd": "0.001"},  # string, not number
+        ])
+        cyc = parse_cycle_log(log)
+        assert cyc is not None
+        assert cyc.total_cost_usd_reported is None
+
+
+class TestBuildSummary:
+    def test_aggregates_across_cycles(self, tmp_path: Path) -> None:
+        c1 = tmp_path / "cycle-0001.json"
+        c2 = tmp_path / "cycle-0002.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("a", "Monitor")]),
+            _assistant_event(_basic_usage(10)),
+            _tool_result("a"),
+            {"type": "result", "total_cost_usd": 0.001},
+        ])
+        _write_cycle(c2, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("b", "Monitor")]),
+            _assistant_event(_basic_usage(20)),
+            _tool_result("b"),
+            _assistant_event(_basic_usage(0), [_agent_dispatch("c", "Scout")]),
+            _assistant_event(_basic_usage(5)),
+            _tool_result("c"),
+            {"type": "result", "total_cost_usd": 0.002},
+        ])
+        cycles = [parse_cycle_log(c1), parse_cycle_log(c2)]
+        summary = build_summary([c for c in cycles if c is not None])
+        assert summary.cycles_audited == 2
+        # Reported cost preserved.
+        assert summary.total_cost_usd_reported == 0.003
+        # Monitor: 10 + 20 = 30; Scout: 5
+        totals = {b.bucket: b for b in summary.totals_by_bucket}
+        assert totals["monitor"].output_tokens == 30
+        assert totals["scout"].output_tokens == 5
+        # Dispatch counts
+        assert summary.dispatch_counts_by_type == {"monitor": 2, "scout": 1}
+
+    def test_highest_cost_bucket_excludes_caddie_master(self, tmp_path: Path) -> None:
+        # Pin output_tokens-only usage so cost is monotone in tokens.
+        c1 = tmp_path / "cycle-0001.json"
+        # caddie_master accumulates a lot via top-level turns; monitor a
+        # smaller amount. highest_cost_bucket must still return monitor
+        # because caddie_master is excluded from the "subagent path" view.
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(1000)),
+            _assistant_event(_basic_usage(0), [_agent_dispatch("a", "Monitor")]),
+            _assistant_event(_basic_usage(50)),
+            _tool_result("a"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        summary = build_summary([parse_cycle_log(c1)])
+        highest = summary.highest_cost_bucket()
+        assert highest is not None
+        assert highest.bucket == "monitor"
+
+
+class TestRenderMarkdown:
+    def test_includes_all_three_tables(self, tmp_path: Path) -> None:
+        c1 = tmp_path / "cycle-0001.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("a", "Monitor")]),
+            _assistant_event(_basic_usage(10)),
+            _tool_result("a"),
+            {"type": "result", "total_cost_usd": 0.001},
+        ])
+        summary = build_summary([parse_cycle_log(c1)])
+        md = render_markdown(summary)
+        assert "Table 1" in md
+        assert "Table 2" in md
+        assert "Table 3" in md
+        assert "Highest-cost subagent path" in md
+        assert "monitor" in md.lower()
+
+    def test_render_markdown_deterministic(self, tmp_path: Path) -> None:
+        # The deliverable file should be byte-identical for the same
+        # inputs so two runs over the same cycles diff cleanly.
+        c1 = tmp_path / "cycle-0001.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("a", "Monitor")]),
+            _assistant_event(_basic_usage(10)),
+            _tool_result("a"),
+            _assistant_event(_basic_usage(0), [_agent_dispatch("b", "Scout")]),
+            _assistant_event(_basic_usage(20)),
+            _tool_result("b"),
+            {"type": "result", "total_cost_usd": 0.001},
+        ])
+        s1 = build_summary([parse_cycle_log(c1)])
+        s2 = build_summary([parse_cycle_log(c1)])
+        assert render_markdown(s1) == render_markdown(s2)
+
+    def test_render_markdown_table2_column_order(self, tmp_path: Path) -> None:
+        # Pin the Table 2 header to keep Phase 2's diff readable across
+        # runs even if the ordering of the underlying dict changes.
+        c1 = tmp_path / "cycle-0001.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(0), [_agent_dispatch("a", "Monitor")]),
+            _assistant_event(_basic_usage(10)),
+            _tool_result("a"),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        md = render_markdown(build_summary([parse_cycle_log(c1)]))
+        expected_header = (
+            "| bucket | turns | input_tok | output_tok |"
+            " cache_creation_tok | cache_read_tok | cost_usd |"
+            " % of total |"
+        )
+        assert expected_header in md
+
+    def test_render_markdown_zero_cost_does_not_divide(self, tmp_path: Path) -> None:
+        # Defensive: a cycle whose every assistant event has zero usage
+        # produces total_cost==0; the percentage column must not blow up.
+        c1 = tmp_path / "cycle-0001.json"
+        _write_cycle(c1, [
+            _assistant_event({k: 0 for k in (
+                "input_tokens", "output_tokens",
+                "cache_creation_input_tokens", "cache_read_input_tokens",
+            )}),
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        md = render_markdown(build_summary([parse_cycle_log(c1)]))
+        assert "0.0%" in md  # all rows should report 0.0%
+        assert "Highest-cost" not in md  # no non-master buckets present
+
+
+class TestBuildSummaryMixedModels:
+    def test_mixed_model_cost_summed_per_cycle(self, tmp_path: Path) -> None:
+        # Two cycles on different models. Build_summary must sum each
+        # cycle's per-bucket cost rather than re-pricing aggregated tokens
+        # at one model's rate (the previous bug). With Opus rates ~5×
+        # Sonnet, an Opus cycle's bucket cost should be reflected in the
+        # aggregate even when the first cycle is Sonnet.
+        sonnet = tmp_path / "cycle-0001.json"
+        opus = tmp_path / "cycle-0002.json"
+        sonnet_event = {
+            "type": "assistant",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "..."}],
+                "usage": _basic_usage(1000),
+            },
+        }
+        opus_event = {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "..."}],
+                "usage": _basic_usage(1000),
+            },
+        }
+        _write_cycle(sonnet, [
+            sonnet_event,
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        _write_cycle(opus, [
+            opus_event,
+            {"type": "result", "total_cost_usd": 0.0},
+        ])
+        cs = parse_cycle_log(sonnet)
+        co = parse_cycle_log(opus)
+        assert cs is not None and co is not None
+        # Verify per-cycle bucket cost reflects each cycle's model.
+        sonnet_cost = cs.cost_by_bucket()[CADDIE_MASTER]
+        opus_cost = co.cost_by_bucket()[CADDIE_MASTER]
+        assert opus_cost > sonnet_cost  # opus output rate is 5× sonnet's
+        # Aggregate must equal the sum of per-cycle costs (not a re-price
+        # at cycle 0's rate).
+        summary = build_summary([cs, co])
+        agg = {b.bucket: b.cost_usd for b in summary.totals_by_bucket}
+        assert agg[CADDIE_MASTER] == sonnet_cost + opus_cost

--- a/tests/unit/test_subagent_fanout.py
+++ b/tests/unit/test_subagent_fanout.py
@@ -462,6 +462,60 @@ class TestRenderMarkdown:
         assert "Highest-cost" not in md  # no non-master buckets present
 
 
+class TestSummaryReportedCostCoverage:
+    def test_total_cost_reported_none_when_all_cycles_missing(
+        self, tmp_path: Path,
+    ) -> None:
+        c1 = tmp_path / "cycle-0001.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(10)),
+            {"type": "result"},  # no total_cost_usd
+        ])
+        summary = build_summary([parse_cycle_log(c1)])
+        assert summary.total_cost_usd_reported is None
+        # Markdown shows the "?" sentinel rather than $0.00.
+        md = render_markdown(summary)
+        assert "**?**" in md
+
+    def test_partial_coverage_surfaces_in_markdown(self, tmp_path: Path) -> None:
+        # One cycle reports cost, one does not — the partial sum must
+        # be rendered alongside an explicit "(1 of 2 cycles reported)"
+        # so the gap is visible rather than silently understated.
+        c1 = tmp_path / "cycle-0001.json"
+        c2 = tmp_path / "cycle-0002.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(10)),
+            {"type": "result", "total_cost_usd": 0.005},
+        ])
+        _write_cycle(c2, [
+            _assistant_event(_basic_usage(20)),
+            {"type": "result"},  # missing total
+        ])
+        summary = build_summary([parse_cycle_log(c1), parse_cycle_log(c2)])
+        assert summary.total_cost_usd_reported == 0.005
+        assert summary.cycles_with_reported_cost == 1
+        md = render_markdown(summary)
+        assert "(1 of 2 cycles reported)" in md
+        # Pin the dollar formatting too so a regression in the format
+        # string would fail the test (otherwise only the parenthetical
+        # is fenced).
+        assert "**$0.01**" in md
+        # Cycle 2's per-cycle Table 1 cost cell must render "?" for the
+        # missing reported total, not "$0.00".
+        assert "| 2 | 2 | ? | 0 |" in md
+
+    def test_full_coverage_omits_partial_suffix(self, tmp_path: Path) -> None:
+        # Negative regression-fence: when every cycle reports cost, the
+        # "(N of M cycles reported)" suffix must NOT appear.
+        c1 = tmp_path / "cycle-0001.json"
+        _write_cycle(c1, [
+            _assistant_event(_basic_usage(10)),
+            {"type": "result", "total_cost_usd": 0.005},
+        ])
+        md = render_markdown(build_summary([parse_cycle_log(c1)]))
+        assert "cycles reported" not in md
+
+
 class TestBuildSummaryMixedModels:
     def test_mixed_model_cost_summed_per_cycle(self, tmp_path: Path) -> None:
         # Two cycles on different models. Build_summary must sum each


### PR DESCRIPTION
## Summary

Phase 1 of #571 (parent #546). Walks 6 stratified `cycle-NNNN.json` logs and attributes per-turn token usage to either `caddie_master` (parent) or the active subagent.

**Surprise finding:** monitor is the highest-cost bucket (39%), not Caddie (5%) as the issue body predicted. Caddie is dispatched ≤1×/cycle with bounded turns; monitor averages ~60 turns/dispatch checking each open position. Cost lever is per-dispatch fanout INSIDE Monitor and Scout — not subagent dispatch counts.

Phase 2 recommendation will be posted as a comment on #571. Phase 3 (driving-range A/B + ship/no-ship) gates issue closure — same pattern as PR #569 closing Phase 1 of #553. **Issue #571 stays open.**

## What landed

| File | Purpose |
|---|---|
| `src/gimmes/reporting/subagent_fanout.py` | Analysis module (`parse_cycle_log` + `build_summary` + `render_markdown`). Mirrors `pause_backtest.py` precedent. `build_summary` sums per-cycle bucket costs (handles mixed-model rotations correctly). |
| `tests/research/subagent_fanout.py` | Driver picking 6 cycles from 1340–1373; emits long-form CSVs (deterministic across runs) + markdown to stdout. |
| `tests/research/subagent_fanout.md` | Hand-curated deliverable: Tables 1/2/3, cost-reconciliation caveat (32% over-attribution consistent with #568's parser-vs-Anthropic delta), Phase 2 recommendation rationale. |
| `tests/unit/test_subagent_fanout.py` | 24 unit tests covering attribution, normalization, fail-open, reconciliation, multi-dispatch, in-flight warnings, mixed-model summing, render determinism. |

## Today's tables (audit of cycles 1361, 1366, 1369, 1367, 1373, 1364)

### Table 2 — cost share by bucket (aggregate)

| bucket | turns | cost_usd | % of total |
|:---|---:|---:|---:|
| monitor | 357 | \$13.74 | 39.0% |
| scout | 634 | \$9.42 | 26.8% |
| caddie_master | 351 | \$9.40 | 26.7% |
| caddie | 133 | \$1.75 | 5.0% |
| scorecard | 75 | \$0.70 | 2.0% |
| groundskeeper | 25 | \$0.14 | 0.4% |
| closer | 5 | \$0.05 | 0.1% |

## Phase 2 framing

- **Reject A** (dispatch cap): high-cost agents already dispatched ≤1×/cycle.
- **Reject B** (depth cap): pipeline is depth-1 — no nested dispatches observed.
- **Reject D** (Haiku swap): premature without quality measurement.
- **Recommend C** (per-dispatch fanout cap inside Monitor + Scout): cap top-K positions / candidates per cycle. Phase 3 measures the cost/decision tradeoff before shipping.

If a cap halved Monitor + Scout intra-dispatch turns, projected savings ~\$1.93/cycle (33% of mean). Even a 20% turn reduction would free ~\$0.77/cycle.

## Test plan

- `uv run pytest tests/unit/test_subagent_fanout.py -v` — 24 tests pass
- `uv run pytest tests/unit/` — full unit suite (1276 tests, was 1252 + 24 new) clean
- `uv run ruff check` on changed files — clean
- `uv run python tests/research/subagent_fanout.py` — driver runs in <1s, regenerates CSVs and stdout markdown matching the committed `.md` tables

Refs #571, #546.