### PR TITLE
Fix #582: accept ticker prefix in lookup commands

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -61,6 +61,34 @@ def _extract_ticker_from_url(exc) -> str | None:  # type: ignore[no-untyped-def]
     return ticker or None
 
 
+_AMBIGUOUS_MATCH_DISPLAY_LIMIT = 20
+
+
+def _print_ambiguous_ticker(prefix: str, matches: list[str]) -> None:
+    """Render the candidate list when a ticker prefix is ambiguous.
+
+    Used by ``position-context``, ``position-notes``, and
+    ``market-info``; ``trades`` filters by prefix directly and never
+    errors on multiple matches. When ``matches`` exceeds the display
+    limit, a trailing ``... and N more`` line is appended so a broad
+    prefix doesn't flood the terminal.
+    """
+    console.print(
+        f"[red]Ambiguous ticker prefix '{prefix}'. Matches:[/red]",
+    )
+    shown = matches[:_AMBIGUOUS_MATCH_DISPLAY_LIMIT]
+    for match in shown:
+        console.print(f"  {match}")
+    if len(matches) > _AMBIGUOUS_MATCH_DISPLAY_LIMIT:
+        remaining = len(matches) - _AMBIGUOUS_MATCH_DISPLAY_LIMIT
+        console.print(
+            f"  [dim]... and {remaining} more[/dim]",
+        )
+    console.print(
+        "[dim]Specify a longer prefix or full ticker.[/dim]",
+    )
+
+
 def _run(coro):  # type: ignore[no-untyped-def]
     """Run an async coroutine from sync CLI context with error handling."""
     import logging
@@ -1154,10 +1182,28 @@ def trades(
         from gimmes.reporting.formatter import format_local_timestamp
         from gimmes.store.database import Database
         from gimmes.store.queries import get_trades
+        from gimmes.store.ticker_resolver import resolve_ticker
 
+        # Preserve exact-match semantics when the user types a full
+        # known ticker that's also a prefix of others (e.g. typing
+        # ``KXCPI`` when both ``KXCPI`` and ``KXCPICORE-*`` are in the
+        # trade log). The resolver's exact-match shortcut returns
+        # ``[ticker]`` in that case and we propagate
+        # ``ticker_prefix=False``. Otherwise prefix-match so a partial
+        # input lists the whole family.
         async with Database() as db:
+            use_prefix = ticker is not None
+            ticker_arg = ticker
+            if ticker is not None:
+                exact = await resolve_ticker(
+                    db, ticker, source="known_markets",
+                )
+                if len(exact) == 1 and exact[0] == ticker.strip().upper():
+                    use_prefix = False
+                    ticker_arg = exact[0]
             records = await get_trades(
-                db, ticker=ticker, action=action, limit=limit,
+                db, ticker=ticker_arg, action=action, limit=limit,
+                ticker_prefix=use_prefix,
             )
 
         if not records:
@@ -1671,10 +1717,24 @@ def market_info(
         from gimmes.kalshi.markets import get_market, get_orderbook
         from gimmes.reporting.formatter import format_kv_table
         from gimmes.risk.settlement import scan_settlement_rules
+        from gimmes.store.database import Database
+        from gimmes.store.ticker_resolver import resolve_ticker
+
+        # Resolve prefix against local DB state (positions ∪ candidates
+        # ∪ trades). Falls through to Kalshi with the literal input when
+        # no local match — preserves first-time market-lookup behavior.
+        async with Database(config.db_path) as db:
+            matches = await resolve_ticker(
+                db, ticker, source="known_markets",
+            )
+        if len(matches) > 1:
+            _print_ambiguous_ticker(ticker, matches)
+            raise typer.Exit(1)
+        resolved = matches[0] if matches else ticker
 
         async with KalshiClient(config) as client:
-            market = await get_market(client, ticker)
-            orderbook = await get_orderbook(client, ticker)
+            market = await get_market(client, resolved)
+            orderbook = await get_orderbook(client, resolved)
             settlement = scan_settlement_rules(market.rules_primary)
 
             risk_color = {"low": "green", "medium": "yellow", "high": "red"}.get(
@@ -1849,17 +1909,33 @@ def position_context(
             get_position_notes,
             has_open_position,
         )
+        from gimmes.store.ticker_resolver import resolve_ticker
 
         async with Database(config.db_path) as db:
-            trade = await get_open_trade_for_ticker(db, ticker)
-            is_open = await has_open_position(db, ticker)
-            notes = await get_position_notes(db, ticker, limit=20)
+            matches = await resolve_ticker(
+                db, ticker, source="open_positions",
+            )
+            if not matches:
+                console.print(
+                    f"[yellow]No open position found for {ticker}[/yellow]",
+                )
+                return
+            if len(matches) > 1:
+                _print_ambiguous_ticker(ticker, matches)
+                raise typer.Exit(1)
+            resolved = matches[0]
+            trade = await get_open_trade_for_ticker(db, resolved)
+            is_open = await has_open_position(db, resolved)
+            notes = await get_position_notes(db, resolved, limit=20)
 
         if not trade or not is_open:
+            # Another process (clubhouse server, autonomous loop) may
+            # have closed the position between the resolver's read and
+            # the lookups. Treat it the same as no-match.
             console.print(f"[yellow]No open position found for {ticker}[/yellow]")
             return
 
-        console.print(f"\n[bold]Position Context: {ticker}[/bold]\n")
+        console.print(f"\n[bold]Position Context: {resolved}[/bold]\n")
         console.print("[bold]--- OPEN TRADE ---[/bold]")
         console.print(f"Opened:           {format_local_timestamp(str(trade['timestamp']))}")
         console.print(
@@ -1945,15 +2021,30 @@ def position_notes(
     async def _notes() -> None:
         from gimmes.store.database import Database
         from gimmes.store.queries import get_position_notes
+        from gimmes.store.ticker_resolver import resolve_ticker
 
         async with Database(config.db_path) as db:
-            notes = await get_position_notes(db, ticker, limit=limit)
+            matches = await resolve_ticker(
+                db, ticker, source="open_positions",
+            )
+            if not matches:
+                console.print(
+                    f"[yellow]No notes found for {ticker}[/yellow]",
+                )
+                return
+            if len(matches) > 1:
+                _print_ambiguous_ticker(ticker, matches)
+                raise typer.Exit(1)
+            resolved = matches[0]
+            notes = await get_position_notes(db, resolved, limit=limit)
 
         if not notes:
-            console.print(f"[yellow]No notes found for {ticker}[/yellow]")
+            console.print(f"[yellow]No notes found for {resolved}[/yellow]")
             return
 
-        console.print(f"\n[bold]Position Notes: {ticker} ({len(notes)} notes)[/bold]\n")
+        console.print(
+            f"\n[bold]Position Notes: {resolved} ({len(notes)} notes)[/bold]\n",
+        )
         for n in reversed(notes):
             _print_note(n)
             console.print()

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1182,25 +1182,34 @@ def trades(
         from gimmes.reporting.formatter import format_local_timestamp
         from gimmes.store.database import Database
         from gimmes.store.queries import get_trades
-        from gimmes.store.ticker_resolver import resolve_ticker
+        from gimmes.store.ticker_resolver import validate_ticker_prefix
 
-        # Preserve exact-match semantics when the user types a full
-        # known ticker that's also a prefix of others (e.g. typing
-        # ``KXCPI`` when both ``KXCPI`` and ``KXCPICORE-*`` are in the
-        # trade log). The resolver's exact-match shortcut returns
-        # ``[ticker]`` in that case and we propagate
-        # ``ticker_prefix=False``. Otherwise prefix-match so a partial
-        # input lists the whole family.
+        # Normalize + validate the user's input once. ``trades`` doesn't
+        # call ``resolve_ticker`` (its prefix filter is a single SQL
+        # LIKE, not a multi-source resolution), but it must still
+        # reject wildcard chars (``%``, ``_``) so a stray
+        # ``--ticker "%"`` doesn't silently widen the filter to every
+        # trade in the table.
+        ticker_arg = (
+            validate_ticker_prefix(ticker) if ticker is not None else None
+        )
         async with Database() as db:
-            use_prefix = ticker is not None
-            ticker_arg = ticker
-            if ticker is not None:
-                exact = await resolve_ticker(
-                    db, ticker, source="known_markets",
+            use_prefix = ticker_arg is not None
+            if ticker_arg is not None:
+                # Preserve exact-match semantics when the user types a
+                # full ticker present in the trades table that is also
+                # a prefix of others (``KXCPI`` vs ``KXCPICORE-*``).
+                # Probing the trades table specifically — rather than
+                # the resolver's ``known_markets`` source — avoids
+                # disabling prefix mode when the input only appears in
+                # positions or candidates (which would hide the trade
+                # family the user expected to see).
+                cursor = await db.conn.execute(
+                    "SELECT 1 FROM trades WHERE ticker = ? LIMIT 1",
+                    (ticker_arg,),
                 )
-                if len(exact) == 1 and exact[0] == ticker.strip().upper():
+                if await cursor.fetchone() is not None:
                     use_prefix = False
-                    ticker_arg = exact[0]
             records = await get_trades(
                 db, ticker=ticker_arg, action=action, limit=limit,
                 ticker_prefix=use_prefix,

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -78,13 +78,23 @@ async def get_trades(
     ticker: str | None = None,
     action: str | None = None,
     limit: int = 50,
+    ticker_prefix: bool = False,
 ) -> list[TradeRecord]:
-    """Query trade decisions with optional filters."""
+    """Query trade decisions with optional filters.
+
+    ``ticker_prefix=True`` switches the ticker filter from exact match
+    to prefix match (``LIKE ticker || '%'``) for the CLI's
+    ``gimmes trades --ticker`` command — programmatic callers (P&L
+    reports, etc.) default to exact match to preserve their semantics.
+    """
     query = "SELECT * FROM trades WHERE 1=1"
     params: list[object] = []
 
     if ticker:
-        query += " AND ticker = ?"
+        if ticker_prefix:
+            query += " AND ticker LIKE ? || '%'"
+        else:
+            query += " AND ticker = ?"
         params.append(ticker)
     if action:
         query += " AND action = ?"

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -83,9 +83,10 @@ async def get_trades(
     """Query trade decisions with optional filters.
 
     ``ticker_prefix=True`` switches the ticker filter from exact match
-    to prefix match (``LIKE ticker || '%'``) for the CLI's
-    ``gimmes trades --ticker`` command — programmatic callers (P&L
-    reports, etc.) default to exact match to preserve their semantics.
+    to prefix match (``ticker LIKE <bound_ticker> || '%'``) for the
+    CLI's ``gimmes trades --ticker`` command — programmatic callers
+    (P&L reports, etc.) default to exact match to preserve their
+    semantics.
     """
     query = "SELECT * FROM trades WHERE 1=1"
     params: list[object] = []

--- a/src/gimmes/store/ticker_resolver.py
+++ b/src/gimmes/store/ticker_resolver.py
@@ -57,6 +57,36 @@ _KNOWN_MARKETS_SQL = (
 )
 
 
+def validate_ticker_prefix(prefix: str) -> str:
+    """Normalize and validate a user-supplied ticker prefix.
+
+    Strips surrounding whitespace, uppercases (Kalshi tickers are
+    canonical uppercase), and rejects characters outside
+    ``[A-Z0-9.-]`` so SQL ``LIKE`` wildcards (``%``, ``_``) and
+    SQL-injection-shaped inputs raise ``ValueError`` rather than
+    silently matching unintended rows.
+
+    Used by ``resolve_ticker`` and by the ``gimmes trades --ticker``
+    CLI path, which bypasses the resolver for its exact-match probe
+    but still needs the same input contract.
+
+    Returns the cleaned uppercase prefix. Raises ``ValueError`` on
+    empty/whitespace-only or out-of-charset input.
+    """
+    cleaned = prefix.strip().upper()
+    if not cleaned:
+        raise ValueError("ticker prefix must be non-empty")
+    if not _TICKER_CHARS.match(cleaned):
+        # Don't echo the raw prefix into the error message — the CLI's
+        # ``_run`` formats exceptions through Rich's markup parser, so
+        # a prefix like ``"[red]evil[/red]"`` would alter the rendered
+        # output. The character class is the actionable detail.
+        raise ValueError(
+            "ticker prefix contains characters outside [A-Z0-9.-]",
+        )
+    return cleaned
+
+
 async def resolve_ticker(
     db: Database, prefix: str, *, source: TickerSource,
 ) -> list[str]:
@@ -64,12 +94,8 @@ async def resolve_ticker(
 
     Args:
         db: Async SQLite connection wrapper.
-        prefix: User-supplied ticker or ticker fragment. Stripped of
-            surrounding whitespace and uppercased before matching;
-            Kalshi tickers are canonically uppercase. Raises
-            ``ValueError`` if empty/whitespace-only or if any
-            character falls outside ``[A-Z0-9.-]`` (this rejects SQL
-            ``LIKE`` wildcards in user input).
+        prefix: User-supplied ticker or ticker fragment. Normalized
+            and validated via :func:`validate_ticker_prefix`.
         source:
             - ``"open_positions"``: only positions with ``count > 0``.
               Use for ``gimmes position-context`` and
@@ -84,14 +110,7 @@ async def resolve_ticker(
         to ``[match]`` so a full exact ticker that is also a prefix of
         others does not trigger an ambiguity error.
     """
-    cleaned = prefix.strip().upper()
-    if not cleaned:
-        raise ValueError("ticker prefix must be non-empty")
-    if not _TICKER_CHARS.match(cleaned):
-        raise ValueError(
-            f"ticker prefix {prefix!r} contains characters outside"
-            f" [A-Z0-9.-]",
-        )
+    cleaned = validate_ticker_prefix(prefix)
 
     if source == "open_positions":
         cursor = await db.conn.execute(_OPEN_POSITIONS_SQL, (cleaned,))

--- a/src/gimmes/store/ticker_resolver.py
+++ b/src/gimmes/store/ticker_resolver.py
@@ -1,0 +1,112 @@
+"""Prefix-match ticker resolution for CLI lookup commands (issue #582).
+
+The CLI display layer wraps long tickers across multiple lines (#567's
+fix), making partial copies easy. This module accepts a (possibly
+partial) ticker prefix and returns the matching full ticker(s) from
+local DB state so downstream lookup commands like ``position-context``
+and ``market-info`` can keep using exact-match queries internally.
+
+Behavior:
+- Empty result: the prefix matches no known ticker. Caller decides
+  whether to error or fall through (``market-info`` falls through to
+  Kalshi with the literal input; ``position-context`` errors).
+- Single result: the prefix uniquely resolves; caller substitutes the
+  full ticker for its lookup.
+- Multiple results: the prefix is ambiguous; caller renders a candidate
+  list and exits non-zero.
+
+Exact-match shortcut: when the caller's input is itself a known
+ticker AND it happens to be a prefix of other tickers (e.g.
+``KXCPI`` is a prefix of ``KXCPICORE-26APR-T0.3``), the resolver
+returns ``[input]`` alone rather than the longer list. This preserves
+backward compatibility for callers who type the full short ticker.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from gimmes.store.database import Database
+
+TickerSource = Literal["open_positions", "known_markets"]
+
+
+# Kalshi tickers are canonical uppercase alphanumerics with ``-`` and
+# ``.`` separators (e.g. ``KXCPIYOY-26APR-T3.7``). Rejecting anything
+# outside this charset prevents SQL ``LIKE`` wildcards (``%``, ``_``)
+# in user input from silently matching unintended rows, and gives the
+# resolver a tight contract: input is a literal Kalshi ticker prefix.
+_TICKER_CHARS = re.compile(r"^[A-Z0-9.\-]+$")
+
+
+_OPEN_POSITIONS_SQL = (
+    "SELECT ticker FROM positions "
+    "WHERE ticker LIKE ? || '%' AND count > 0 "
+    "ORDER BY ticker"
+)
+
+_KNOWN_MARKETS_SQL = (
+    "SELECT ticker FROM positions "
+    "WHERE count > 0 AND ticker LIKE ? || '%' "
+    "UNION SELECT ticker FROM candidates "
+    "WHERE ticker LIKE ? || '%' "
+    "UNION SELECT ticker FROM trades "
+    "WHERE ticker LIKE ? || '%' "
+    "ORDER BY ticker"
+)
+
+
+async def resolve_ticker(
+    db: Database, prefix: str, *, source: TickerSource,
+) -> list[str]:
+    """Return tickers from ``source`` whose name starts with ``prefix``.
+
+    Args:
+        db: Async SQLite connection wrapper.
+        prefix: User-supplied ticker or ticker fragment. Stripped of
+            surrounding whitespace and uppercased before matching;
+            Kalshi tickers are canonically uppercase. Raises
+            ``ValueError`` if empty/whitespace-only or if any
+            character falls outside ``[A-Z0-9.-]`` (this rejects SQL
+            ``LIKE`` wildcards in user input).
+        source:
+            - ``"open_positions"``: only positions with ``count > 0``.
+              Use for ``gimmes position-context`` and
+              ``gimmes position-notes``.
+            - ``"known_markets"``: distinct tickers from any of
+              ``positions``, ``candidates``, ``trades``. Use for
+              ``gimmes market-info``.
+
+    Returns:
+        Sorted list of matching tickers (deduplicated). If the cleaned
+        prefix exactly equals one of the matches, the list is truncated
+        to ``[match]`` so a full exact ticker that is also a prefix of
+        others does not trigger an ambiguity error.
+    """
+    cleaned = prefix.strip().upper()
+    if not cleaned:
+        raise ValueError("ticker prefix must be non-empty")
+    if not _TICKER_CHARS.match(cleaned):
+        raise ValueError(
+            f"ticker prefix {prefix!r} contains characters outside"
+            f" [A-Z0-9.-]",
+        )
+
+    if source == "open_positions":
+        cursor = await db.conn.execute(_OPEN_POSITIONS_SQL, (cleaned,))
+    else:
+        cursor = await db.conn.execute(
+            _KNOWN_MARKETS_SQL, (cleaned, cleaned, cleaned),
+        )
+    rows = await cursor.fetchall()
+    matches = [row[0] for row in rows]
+
+    # Exact-match shortcut: if the cleaned input is itself in the match
+    # set, return just that — sidesteps the ambiguous-error branch for
+    # callers who happen to type a short ticker that's a prefix of
+    # longer ones.
+    if cleaned in matches:
+        return [cleaned]
+
+    return matches

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -197,6 +197,36 @@ class TestTradesCommand:
         #  the natural behavior excludes it.)
         assert "KXCPI-26MAY-T0.6" not in ticker_col
 
+    def test_wildcard_in_input_is_rejected(self, seeded_db: Path) -> None:
+        # ``trades`` must apply the same wildcard guard as the other
+        # lookup commands (``%`` and ``_`` are SQL LIKE wildcards that
+        # would silently widen the filter to all trades).
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent):
+            result = runner.invoke(
+                app, ["trades", "--ticker", "%", "-n", "10"],
+            )
+        assert result.exit_code != 0
+        # _run formats ValueError through Rich; assert the actionable
+        # error class is present without depending on Rich's exact
+        # formatting.
+        assert "[A-Z0-9.-]" in result.output
+
+    def test_whitespace_and_lowercase_input_normalized(
+        self, seeded_db: Path,
+    ) -> None:
+        # Copy-paste from another tool can carry surrounding whitespace
+        # or lowercase. Both must normalize before matching so the
+        # prefix filter behaves the same as the canonical-uppercase
+        # input would.
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent):
+            result = runner.invoke(
+                app, ["trades", "--ticker", "  kxcpi  ", "-n", "10"],
+            )
+        assert result.exit_code == 0, result.output
+        ticker_col = _ticker_column_text(result.output)
+        assert "KXCPI-26APR-T0.5" in ticker_col
+        assert "KXCPI-26MAY-T0.6" in ticker_col
+
     def test_exact_match_short_ticker_does_not_pull_in_longer(
         self, seeded_db: Path,
     ) -> None:
@@ -230,6 +260,42 @@ async def _add_extra(db: Database) -> None:
         await insert_trade(db, _trade("KXCPI"))
     finally:
         await db.close()
+
+
+async def _add_position_only(db: Database, ticker: str) -> None:
+    """Helper: seed a position (no trade row) so the trades-table
+    exact-match probe can be verified against positions-only inputs."""
+    await db.connect()
+    try:
+        await upsert_position(db, _pos(ticker))
+    finally:
+        await db.close()
+
+
+class TestTradesExactMatchProbeIsTradesTableOnly:
+    def test_input_only_in_positions_still_uses_prefix_filter(
+        self, seeded_db: Path,
+    ) -> None:
+        # Seed a ticker into ``positions`` only (no matching trade).
+        # If the exact-match probe consulted ``known_markets`` (which
+        # includes positions), it would disable prefix mode and the
+        # user would get an empty trades result. The probe must be
+        # trades-only so the user still sees the trade family that
+        # shares the prefix.
+        asyncio.run(_add_position_only(
+            Database(seeded_db), "KXCPI",
+        ))
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent):
+            result = runner.invoke(
+                app, ["trades", "--ticker", "KXCPI", "-n", "10"],
+            )
+        assert result.exit_code == 0, result.output
+        ticker_col = _ticker_column_text(result.output)
+        # ``KXCPI`` itself was only seeded into positions; ``trades``
+        # rows are only the ``KXCPI-*`` sisters from the fixture, so
+        # prefix mode must surface them.
+        assert "KXCPI-26APR-T0.5" in ticker_col
+        assert "KXCPI-26MAY-T0.6" in ticker_col
 
 
 def _stub_market(ticker: str) -> MagicMock:

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -1,0 +1,324 @@
+"""CLI integration tests for ticker prefix resolution (#582).
+
+Verifies the three lookup commands (``position-context``,
+``trades``, ``market-info``) accept prefix arguments and surface the
+expected ambiguous/no-match/exact-match branches.
+
+Each test seeds a temp SQLite DB, points ``load_config`` at it, mocks
+the Kalshi client for ``market-info``, and invokes the CLI through
+``typer.testing.CliRunner``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes.cli import app
+from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import insert_trade, upsert_position
+
+runner = CliRunner()
+
+
+def _pos(ticker: str, *, count: int = 100) -> Position:
+    return Position(
+        ticker=ticker, side="yes", count=count, avg_price=0.50,
+        market_price=0.50, cost_basis=50.0,
+    )
+
+
+def _trade(ticker: str) -> TradeDecision:
+    return TradeDecision(
+        ticker=ticker,
+        action=TradeDecision.Action.OPEN,
+        side="yes",
+        count=10,
+        price=0.5,
+        model_probability=0.6,
+        gimme_score=70.0,
+        edge=0.1,
+        kelly_fraction=0.02,
+        rationale="test",
+        thesis="A multi-line thesis stored at open time.",
+        agent="test-agent",
+        order_id="o1",
+    )
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path) -> Path:
+    """Create a temp DB with three open positions (one with a long
+    ticker and two sharing a ``KXCPI`` prefix) plus matching trades.
+
+    Sync fixture so the CLI tests can call ``CliRunner.invoke`` without
+    being inside a running asyncio event loop (the CLI's ``_run``
+    helper itself drives ``asyncio.run`` and cannot nest).
+    """
+    db_path = tmp_path / "gimmes.db"
+
+    async def _seed() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            for t in (
+                "KXJOBLESSCLAIMS-26MAY14-210000",
+                "KXCPI-26APR-T0.5",
+                "KXCPI-26MAY-T0.6",
+            ):
+                await upsert_position(db, _pos(t))
+                await insert_trade(db, _trade(t))
+        finally:
+            await db.close()
+
+    asyncio.run(_seed())
+    return db_path
+
+
+def _config(db_path: Path) -> MagicMock:
+    c = MagicMock()
+    c.db_path = db_path
+    return c
+
+
+def _ticker_column_text(output: str) -> str:
+    """Concatenate the first (Ticker) column's content across every
+    body row of a Rich table, including fold-continuation rows. Lets
+    tests assert a full ticker appears even when Rich wraps it across
+    cell rows (#567)."""
+    parts: list[str] = []
+    for line in output.splitlines():
+        if not line.startswith("│"):
+            continue
+        segments = line.split("│")
+        if len(segments) < 3:
+            continue
+        parts.append(segments[1].strip())
+    return "".join(parts)
+
+
+class TestPositionContext:
+    def test_unique_prefix_resolves(self, seeded_db: Path) -> None:
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)):
+            result = runner.invoke(app, ["position-context", "KXJOB"])
+        assert result.exit_code == 0, result.output
+        assert "KXJOBLESSCLAIMS-26MAY14-210000" in result.output
+        assert "Position Context" in result.output
+
+    def test_ambiguous_prefix_lists_candidates_and_exits_1(
+        self, seeded_db: Path,
+    ) -> None:
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)):
+            result = runner.invoke(app, ["position-context", "KXCPI"])
+        assert result.exit_code == 1
+        assert "Ambiguous ticker prefix 'KXCPI'" in result.output
+        assert "KXCPI-26APR-T0.5" in result.output
+        assert "KXCPI-26MAY-T0.6" in result.output
+
+    def test_no_match_yellow_message(self, seeded_db: Path) -> None:
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)):
+            result = runner.invoke(app, ["position-context", "ZZZ"])
+        assert result.exit_code == 0
+        assert "No open position found for ZZZ" in result.output
+
+    def test_exact_full_ticker_backcompat(
+        self, seeded_db: Path,
+    ) -> None:
+        # The pre-#582 happy path: full exact ticker still works.
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)):
+            result = runner.invoke(
+                app, ["position-context", "KXJOBLESSCLAIMS-26MAY14-210000"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "KXJOBLESSCLAIMS-26MAY14-210000" in result.output
+
+
+class TestPositionNotes:
+    def test_unique_prefix_resolves(self, seeded_db: Path) -> None:
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)):
+            result = runner.invoke(app, ["position-notes", "KXJOB"])
+        # No notes seeded, but the resolver should fire and the
+        # message should reference the FULL resolved ticker, not the
+        # prefix the user typed.
+        assert result.exit_code == 0, result.output
+        assert "KXJOBLESSCLAIMS-26MAY14-210000" in result.output
+
+    def test_ambiguous_prefix_lists_candidates_and_exits_1(
+        self, seeded_db: Path,
+    ) -> None:
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)):
+            result = runner.invoke(app, ["position-notes", "KXCPI"])
+        assert result.exit_code == 1
+        assert "Ambiguous ticker prefix 'KXCPI'" in result.output
+        assert "Specify a longer prefix" in result.output
+
+
+class TestTradesCommand:
+    # ``gimmes trades`` opens ``Database()`` with no path arg, so it
+    # falls back to ``GIMMES_HOME / "gimmes.db"``. Patching
+    # ``gimmes.config.GIMMES_HOME`` to ``tmp_path`` redirects the
+    # default to our seeded DB. ``Database.__init__`` re-imports the
+    # constant lazily, so this patch takes effect for new instances.
+    def test_prefix_filter_includes_multiple_tickers(
+        self, seeded_db: Path,
+    ) -> None:
+        # Three positions ⇒ three trades. ``trades --ticker KXCPI``
+        # should return both KXCPI-* trades (prefix filter), not error
+        # on ambiguity.
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent):
+            result = runner.invoke(
+                app, ["trades", "--ticker", "KXCPI", "-n", "10"],
+            )
+        assert result.exit_code == 0, result.output
+        ticker_col = _ticker_column_text(result.output)
+        assert "KXCPI-26APR-T0.5" in ticker_col
+        assert "KXCPI-26MAY-T0.6" in ticker_col
+        assert "KXJOBLESSCLAIMS" not in ticker_col
+
+    def test_exact_full_ticker_backcompat(
+        self, seeded_db: Path,
+    ) -> None:
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent):
+            result = runner.invoke(
+                app, ["trades", "--ticker", "KXCPI-26APR-T0.5", "-n", "10"],
+            )
+        assert result.exit_code == 0, result.output
+        ticker_col = _ticker_column_text(result.output)
+        assert "KXCPI-26APR-T0.5" in ticker_col
+        # Sister ticker must NOT appear — exact ticker that's also a
+        # prefix shouldn't accidentally pull the other in.
+        # (KXCPI-26APR-T0.5 is NOT a prefix of KXCPI-26MAY-T0.6, so
+        #  the natural behavior excludes it.)
+        assert "KXCPI-26MAY-T0.6" not in ticker_col
+
+    def test_exact_match_short_ticker_does_not_pull_in_longer(
+        self, seeded_db: Path,
+    ) -> None:
+        # Critical backward-compat test: if a user types ``KXCPI``
+        # (full short ticker) and the DB has both ``KXCPI`` and
+        # ``KXCPI-26APR-T0.5``, the trades command must NOT include
+        # the longer sister. The CLI uses the resolver's exact-match
+        # shortcut to preserve this.
+        db = Database(seeded_db)
+        asyncio.run(_add_extra(db))
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent):
+            result = runner.invoke(
+                app, ["trades", "--ticker", "KXCPI", "-n", "10"],
+            )
+        assert result.exit_code == 0, result.output
+        ticker_col = _ticker_column_text(result.output)
+        assert "KXCPI" in ticker_col
+        # The KXCPI-26* sisters MUST NOT appear because KXCPI is itself
+        # an exact match in the DB.
+        assert "KXCPI-26APR-T0.5" not in ticker_col
+        assert "KXCPI-26MAY-T0.6" not in ticker_col
+
+
+async def _add_extra(db: Database) -> None:
+    """Helper: seed a bare ``KXCPI`` position + trade on top of the
+    standard fixture so the exact-match-short-ticker test has
+    something to disambiguate against."""
+    await db.connect()
+    try:
+        await upsert_position(db, _pos("KXCPI"))
+        await insert_trade(db, _trade("KXCPI"))
+    finally:
+        await db.close()
+
+
+def _stub_market(ticker: str) -> MagicMock:
+    m = MagicMock()
+    m.ticker = ticker
+    m.event_ticker = "EVT"
+    m.title = f"Market {ticker}"
+    m.status = MagicMock()
+    m.status.value = "active"
+    m.yes_bid = 0.50
+    m.yes_ask = 0.55
+    m.last_price = 0.52
+    m.spread = 0.05
+    m.volume = 100
+    m.volume_24h = 50
+    m.open_interest = 30
+    m.close_time = "2026-05-14"
+    m.rules_primary = ""
+    return m
+
+
+def _stub_orderbook() -> MagicMock:
+    ob = MagicMock()
+    ob.best_yes_bid = 0.50
+    ob.best_yes_ask = 0.55
+    ob.yes_bids = [MagicMock()]
+    return ob
+
+
+class TestMarketInfo:
+    def test_unique_prefix_resolves_then_calls_kalshi(
+        self, seeded_db: Path,
+    ) -> None:
+        get_market = AsyncMock(
+            return_value=_stub_market("KXJOBLESSCLAIMS-26MAY14-210000"),
+        )
+        get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXJOB"])
+        assert result.exit_code == 0, result.output
+        # The resolver should have substituted the full ticker before
+        # the Kalshi call; verify get_market was called with the full
+        # ticker rather than the prefix.
+        assert get_market.await_args is not None
+        called_ticker = get_market.await_args.args[1]
+        assert called_ticker == "KXJOBLESSCLAIMS-26MAY14-210000"
+
+    def test_ambiguous_prefix_skips_kalshi_and_exits_1(
+        self, seeded_db: Path,
+    ) -> None:
+        get_market = AsyncMock()  # must NOT be called
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXCPI"])
+        assert result.exit_code == 1
+        assert "Ambiguous ticker prefix 'KXCPI'" in result.output
+        get_market.assert_not_called()
+
+    def test_no_local_match_falls_through_to_kalshi(
+        self, seeded_db: Path,
+    ) -> None:
+        # Prefix matches nothing local — pass through to Kalshi with
+        # the literal input. Preserves first-time-lookup behavior.
+        get_market = AsyncMock(return_value=_stub_market("KXBRANDNEW-26MAY-T1.0"))
+        get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXBRANDNEW-26MAY-T1.0"])
+        assert result.exit_code == 0, result.output
+        assert get_market.await_args is not None
+        assert get_market.await_args.args[1] == "KXBRANDNEW-26MAY-T1.0"
+
+    def test_exact_full_ticker_backcompat(
+        self, seeded_db: Path,
+    ) -> None:
+        get_market = AsyncMock(
+            return_value=_stub_market("KXCPI-26APR-T0.5"),
+        )
+        get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXCPI-26APR-T0.5"])
+        assert result.exit_code == 0, result.output
+        assert get_market.await_args.args[1] == "KXCPI-26APR-T0.5"

--- a/tests/unit/test_ticker_resolver.py
+++ b/tests/unit/test_ticker_resolver.py
@@ -1,0 +1,197 @@
+"""Unit tests for ``gimmes.store.ticker_resolver`` (#582)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import (
+    insert_candidate,
+    insert_trade,
+    upsert_position,
+)
+from gimmes.store.ticker_resolver import resolve_ticker
+
+
+@pytest.fixture
+async def db(tmp_path: Path) -> AsyncIterator[Database]:
+    db = Database(tmp_path / "test.db")
+    await db.connect()
+    yield db
+    await db.close()
+
+
+def _pos(ticker: str, *, count: int = 100) -> Position:
+    return Position(
+        ticker=ticker, side="yes", count=count, avg_price=0.50,
+        market_price=0.50, cost_basis=50.0,
+    )
+
+
+def _trade(ticker: str) -> TradeDecision:
+    return TradeDecision(
+        ticker=ticker,
+        action=TradeDecision.Action.OPEN,
+        side="yes",
+        count=10,
+        price=0.5,
+        model_probability=0.6,
+        gimme_score=70.0,
+        edge=0.1,
+        kelly_fraction=0.02,
+        rationale="test",
+        thesis="test thesis",
+        agent="test",
+        order_id="o1",
+    )
+
+
+class TestOpenPositionsSource:
+    async def test_unique_prefix_resolves(self, db: Database) -> None:
+        await upsert_position(db, _pos("KXJOBLESSCLAIMS-26MAY14-210000"))
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5"))
+        matches = await resolve_ticker(
+            db, "KXJOB", source="open_positions",
+        )
+        assert matches == ["KXJOBLESSCLAIMS-26MAY14-210000"]
+
+    async def test_ambiguous_prefix_returns_sorted_list(self, db: Database) -> None:
+        for t in (
+            "KXCPI-26APR-T0.5",
+            "KXCPI-26MAY-T0.6",
+            "KXCPIYOY-26APR-T3.7",
+        ):
+            await upsert_position(db, _pos(t))
+        matches = await resolve_ticker(db, "KXCPI", source="open_positions")
+        assert matches == [
+            "KXCPI-26APR-T0.5",
+            "KXCPI-26MAY-T0.6",
+            "KXCPIYOY-26APR-T3.7",
+        ]
+
+    async def test_no_match_returns_empty(self, db: Database) -> None:
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5"))
+        assert await resolve_ticker(
+            db, "ZZZ", source="open_positions",
+        ) == []
+
+    async def test_excludes_closed_positions(self, db: Database) -> None:
+        # Closed position (count=0) must not match.
+        await upsert_position(db, _pos("KXCLOSED-26APR-T0.5", count=0))
+        await upsert_position(db, _pos("KXOPEN-26APR-T0.5", count=50))
+        matches = await resolve_ticker(db, "KX", source="open_positions")
+        assert matches == ["KXOPEN-26APR-T0.5"]
+
+    async def test_exact_match_shortcut_when_prefix_of_others(
+        self, db: Database,
+    ) -> None:
+        # ``KXCPI`` is itself a position AND a prefix of others.
+        # Exact-match shortcut must collapse to just ``KXCPI``.
+        await upsert_position(db, _pos("KXCPI"))
+        await upsert_position(db, _pos("KXCPICORE-26APR-T0.3"))
+        await upsert_position(db, _pos("KXCPIYOY-26APR-T3.7"))
+        matches = await resolve_ticker(db, "KXCPI", source="open_positions")
+        assert matches == ["KXCPI"]
+
+    async def test_empty_prefix_raises(self, db: Database) -> None:
+        with pytest.raises(ValueError):
+            await resolve_ticker(db, "", source="open_positions")
+        with pytest.raises(ValueError):
+            await resolve_ticker(db, "   ", source="open_positions")
+
+    async def test_lowercase_prefix_resolves_to_uppercase_ticker(
+        self, db: Database,
+    ) -> None:
+        # Kalshi tickers are canonical uppercase. The resolver
+        # uppercases input before matching so a lowercase paste from
+        # a non-canonical source still finds the right ticker.
+        await upsert_position(db, _pos("KXJOBLESSCLAIMS-26MAY14-210000"))
+        matches = await resolve_ticker(
+            db, "kxjob", source="open_positions",
+        )
+        assert matches == ["KXJOBLESSCLAIMS-26MAY14-210000"]
+
+    async def test_lowercase_exact_match_takes_shortcut(
+        self, db: Database,
+    ) -> None:
+        # Exact-match shortcut compares the uppercased cleaned input
+        # against the (canonical-uppercase) match set, so a lowercase
+        # full ticker still collapses to a single match.
+        await upsert_position(db, _pos("KXCPI"))
+        await upsert_position(db, _pos("KXCPICORE-26APR-T0.3"))
+        matches = await resolve_ticker(db, "kxcpi", source="open_positions")
+        assert matches == ["KXCPI"]
+
+    async def test_wildcard_in_prefix_raises(self, db: Database) -> None:
+        # ``%`` and ``_`` are SQL LIKE wildcards; reject them so the
+        # resolver doesn't silently match unintended rows.
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5"))
+        with pytest.raises(ValueError):
+            await resolve_ticker(db, "KX%", source="open_positions")
+        with pytest.raises(ValueError):
+            await resolve_ticker(db, "KX_FOO", source="open_positions")
+        # Any other non-charset character (e.g. quote, space-inside)
+        # also rejected.
+        with pytest.raises(ValueError):
+            await resolve_ticker(db, "KX'OR1=1", source="open_positions")
+
+
+class TestKnownMarketsSource:
+    async def test_unions_positions_candidates_trades(
+        self, db: Database,
+    ) -> None:
+        # One ticker per source.
+        await upsert_position(db, _pos("KXFROMPOS-26APR-T0.5"))
+        await insert_candidate(
+            db, "KXFROMCAND-26APR-T0.5",
+            "Candidate", 0.50, 0.80, 0.10, 70, "memo",
+        )
+        await insert_trade(db, _trade("KXFROMTRADE-26APR-T0.5"))
+        matches = await resolve_ticker(db, "KXFROM", source="known_markets")
+        assert matches == [
+            "KXFROMCAND-26APR-T0.5",
+            "KXFROMPOS-26APR-T0.5",
+            "KXFROMTRADE-26APR-T0.5",
+        ]
+
+    async def test_deduplicates_across_tables(self, db: Database) -> None:
+        # Same ticker in positions AND trades AND candidates — appears once.
+        ticker = "KXDUP-26APR-T0.5"
+        await upsert_position(db, _pos(ticker))
+        await insert_candidate(
+            db, ticker, "X", 0.5, 0.8, 0.1, 70, "memo",
+        )
+        await insert_trade(db, _trade(ticker))
+        matches = await resolve_ticker(db, "KXDUP", source="known_markets")
+        assert matches == [ticker]
+
+    async def test_no_match_returns_empty(self, db: Database) -> None:
+        await upsert_position(db, _pos("KXSOMETHING-26APR-T0.5"))
+        assert await resolve_ticker(
+            db, "KXOTHER", source="known_markets",
+        ) == []
+
+    async def test_excludes_closed_positions_but_includes_closed_trades(
+        self, db: Database,
+    ) -> None:
+        # A closed position (count=0) shouldn't surface, but any past
+        # trade on it should still surface via the trades UNION arm —
+        # ``market-info`` should still be resolvable for a market the
+        # user previously traded but no longer holds.
+        await upsert_position(db, _pos("KXCLOSED-26APR-T0.5", count=0))
+        await insert_trade(db, _trade("KXCLOSED-26APR-T0.5"))
+        matches = await resolve_ticker(
+            db, "KXCLOSED", source="known_markets",
+        )
+        assert matches == ["KXCLOSED-26APR-T0.5"]
+
+    async def test_exact_match_shortcut(self, db: Database) -> None:
+        await upsert_position(db, _pos("KXCPI"))
+        await upsert_position(db, _pos("KXCPICORE-26APR-T0.3"))
+        matches = await resolve_ticker(db, "KXCPI", source="known_markets")
+        assert matches == ["KXCPI"]


### PR DESCRIPTION
## Summary

Closes #582. Adds prefix-match ticker resolution to four CLI lookup commands so a user can paste a partial ticker copied from `gimmes positions` (post-#567 wraps long tickers) and have it resolve unambiguously.

| Command | On unique prefix | On ambiguous prefix | On no-match |
|---|---|---|---|
| `position-context PREFIX` | Substitute full ticker | Red list, exit 1 | Yellow "No open position found" |
| `position-notes PREFIX` | Substitute full ticker | Red list, exit 1 | Yellow "No notes found" |
| `market-info PREFIX` | Substitute full ticker before Kalshi call | Red list, exit 1, skip Kalshi | Pass literal input to Kalshi (preserves first-time lookup) |
| `trades --ticker PREFIX` | Exact-match if full ticker is known; otherwise `LIKE prefix || '%'` | N/A — listing the whole family is the feature | "No trade records found" |

## Resolver hardening (review-pass additions)

- Strips + uppercases input before matching (Kalshi tickers are canonical uppercase).
- Rejects chars outside `[A-Z0-9.-]` so SQL `LIKE` wildcards (`%`, `_`) and SQL-injection-shaped inputs raise `ValueError`.
- Exact-match shortcut: if cleaned input equals one of the matches, return just that — preserves backward compat for callers typing a full short ticker that's a prefix of longer ones.

## UX

Ambiguous-prefix list caps at 20 matches with a trailing `... and N more` so broad prefixes (e.g. `KX`) don't flood the terminal.

## Manual verification

```bash
gimmes position-context KXJOB            # → resolves to KXJOBLESSCLAIMS-26MAY14-210000
gimmes position-context KXCPI            # → ambiguous, lists candidates, exits 1
gimmes position-context kxjob            # → lowercase resolves same as uppercase
gimmes position-context "KX%"            # → ValueError (rejected)
gimmes trades --ticker KXCPI-26APR-T0.5  # → only KXCPI-26APR-T0.5 trades (exact-match shortcut)
gimmes trades --ticker KXCPI             # → prefix-filters to all KXCPI-* trades
```

## Test plan

- `uv run pytest tests/unit/test_ticker_resolver.py -v` — 14 resolver unit tests
- `uv run pytest tests/unit/test_cli_ticker_prefix.py -v` — 13 CLI integration tests
- `uv run pytest tests/unit/` — full suite (1326 tests, 1298 prior + 28 new) passes
- `uv run ruff check` on all changed files — clean

## Review pipeline addressed pre-PR

Three review agents flagged ≥80 confidence findings, all addressed in this PR before opening:
- Wired the missed sibling command `position-notes` (was only `position-context`/`market-info` initially).
- Resolver case normalization (LIKE was case-insensitive but exact-match shortcut was case-sensitive — inconsistent).
- Reject wildcard chars in input.
- `trades --ticker` exact-match preservation (previously silently switched semantics for prefix-overlapping tickers).
- Ambiguous-list display cap.

Refs #567, #582.