### PR TITLE
#587: Pin wrong-suffix misread behavior in ticker_resolver

### DIFF
--- a/tests/unit/test_ticker_resolver.py
+++ b/tests/unit/test_ticker_resolver.py
@@ -80,6 +80,16 @@ class TestOpenPositionsSource:
             db, "ZZZ", source="open_positions",
         ) == []
 
+    async def test_wrong_suffix_misread_returns_empty(self, db: Database) -> None:
+        # Pin current behavior: a misread suffix (agent guesses ``-21-250``
+        # from a wrapped ``-210000``) must NOT silently resolve via prefix
+        # LIKE. If a fuzzy-match fallback is added later, this test should
+        # fail and force a deliberate decision. See #581 / #587.
+        await upsert_position(db, _pos("KXJOBLESSCLAIMS-26MAY14-210000"))
+        assert await resolve_ticker(
+            db, "KXJOBLESSCLAIMS-26MAY14-21-250", source="open_positions",
+        ) == []
+
     async def test_excludes_closed_positions(self, db: Database) -> None:
         # Closed position (count=0) must not match.
         await upsert_position(db, _pos("KXCLOSED-26APR-T0.5", count=0))


### PR DESCRIPTION
## Summary

Adds a regression test (`test_wrong_suffix_misread_returns_empty`) to `TestOpenPositionsSource` in `tests/unit/test_ticker_resolver.py`. Pins the current behavior that a misread of a wrap-displayed canonical ticker — e.g. an agent guessing `KXJOBLESSCLAIMS-26MAY14-21-250` from a wrapped `-210000` — does **not** silently resolve via prefix LIKE.

This was the failure mode behind #581. PR #584's resolver returns an empty list for such inputs, which the existing `test_no_match_returns_empty` covers generically. The new test names the specific motivating scenario and acts as a regression fence: if a future fuzzy-match fallback is added, this test should fail and force a deliberate decision rather than a silent UX shift.

Closes #587

## Test plan

- [x] `uv run pytest tests/unit/test_ticker_resolver.py` — all 15 tests pass (was 14, now 15)
- [x] `uv run ruff check tests/unit/test_ticker_resolver.py` — clean
- [x] New test uses existing `db` fixture and `_pos` helper — no new infrastructure
- [x] Reviewed by code-reviewer, silent-failure-hunter, pr-test-analyzer, code-simplifier (all clean)