### PR TITLE
#592: Apply min_true_probability and min_edge_after_fees in backtest scoring

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -17,7 +17,12 @@ from gimmes.risk.limits import (
     check_series_exposure,
     compute_exposure_for_group,
 )
-from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, fee_for_order
+from gimmes.strategy.fees import (
+    DEFAULT_FEE_MULTIPLIERS,
+    FeeMultipliers,
+    edge_after_fees,
+    fee_for_order,
+)
 from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 from gimmes.strategy.scanner import effective_price, filter_markets
 from gimmes.strategy.scorer import quick_score
@@ -449,12 +454,34 @@ async def run_backtest(
         total_passed += len(passed)
 
         # --- 3. Score ---
-        scored: list[tuple[Market, Market, float]] = []
+        # Mirror live gating (validator.py:152-175): gimme_threshold +
+        # min_true_probability + min_edge_after_fees (#592).
+        min_true_prob = side_cfg.strategy.min_true_probability
+        min_edge = side_cfg.strategy.min_edge_after_fees
+        scored: list[tuple[Market, Market, float, float, float]] = []
         for m in passed:
             s = quick_score(m, side_cfg)
-            if s >= side_threshold:
-                orig = original_by_ticker[m.ticker]
-                scored.append((m, orig, s))
+            if s < side_threshold:
+                continue
+            orig = original_by_ticker[m.ticker]
+            raw_price = (
+                orig.midpoint if orig.midpoint > 0 else orig.last_price
+            )
+            if raw_price <= 0:
+                continue
+            eff_price = effective_price(raw_price, scan_side)
+            true_prob = min(eff_price + config.assumed_edge, 0.99)
+            true_prob = apply_base_rate_floor(
+                true_prob, orig.ticker, side=scan_side,
+            )
+            if true_prob < min_true_prob:
+                continue
+            edge = edge_after_fees(
+                eff_price, true_prob, is_taker=False, fees=fees,
+            )
+            if edge < min_edge:
+                continue
+            scored.append((m, orig, s, eff_price, true_prob))
         total_scored += len(scored)
 
         scored.sort(
@@ -464,22 +491,12 @@ async def run_backtest(
         )
 
         # --- 4. Pass 1: identify qualifying trades ---
-        for _, orig_m, _score in scored:
+        for _, orig_m, _score, eff_price, true_prob in scored:
             if orig_m.ticker in seen_tickers:
                 continue
             if orig_m.close_time is None:
                 continue
 
-            raw_price = (
-                orig_m.midpoint
-                if orig_m.midpoint > 0
-                else orig_m.last_price
-            )
-            if raw_price <= 0:
-                continue
-            eff_price = effective_price(raw_price, scan_side)
-            true_prob = min(eff_price + config.assumed_edge, 0.99)
-            true_prob = apply_base_rate_floor(true_prob, orig_m.ticker, side=scan_side)
             count = position_size(
                 config.starting_balance,
                 eff_price,

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -405,13 +405,17 @@ class TestConcentrationLimits:
 # ---------------------------------------------------------------------------
 
 
+# Fixed close_time inside the BacktestConfig window (Mar 1 — May 11
+# 2026). Hard-coded so tests are deterministic instead of drifting
+# with wall-clock as `datetime.now()` would (#592 / Copilot review).
+_FIXED_CLOSE_TIME = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+
+
 def _settled_market(
     ticker: str, *, yes_bid: float, yes_ask: float, result: str = "no",
-    days_ago: int = 7,
+    close_time: datetime = _FIXED_CLOSE_TIME,
 ):
     """Synthetic settled Market — enough fields for backtest to score it."""
-    from datetime import timedelta
-
     from gimmes.models.market import Market, MarketStatus
     return Market(
         ticker=ticker,
@@ -427,7 +431,7 @@ def _settled_market(
         volume=10_000,
         volume_24h=1_000,
         open_interest=5_000,
-        close_time=datetime.now(UTC) - timedelta(days=days_ago),
+        close_time=close_time,
         result=result,
     )
 

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -398,3 +398,189 @@ class TestConcentrationLimits:
         assert compute_exposure_for_group(
             list(ledger.positions.values()), "KXGDP-26APR30",
         ) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Strategy filters in the scoring loop (#592)
+# ---------------------------------------------------------------------------
+
+
+def _settled_market(
+    ticker: str, *, yes_bid: float, yes_ask: float, result: str = "no",
+    days_ago: int = 7,
+):
+    """Synthetic settled Market — enough fields for backtest to score it."""
+    from datetime import timedelta
+
+    from gimmes.models.market import Market, MarketStatus
+    return Market(
+        ticker=ticker,
+        event_ticker=ticker.rsplit("-", 1)[0],
+        series_ticker=ticker.split("-")[0],
+        title=ticker,
+        status=MarketStatus.FINALIZED,
+        yes_bid=yes_bid,
+        yes_ask=yes_ask,
+        no_bid=1.0 - yes_ask,
+        no_ask=1.0 - yes_bid,
+        last_price=(yes_bid + yes_ask) / 2,
+        volume=10_000,
+        volume_24h=1_000,
+        open_interest=5_000,
+        close_time=datetime.now(UTC) - timedelta(days=days_ago),
+        result=result,
+    )
+
+
+def _backtest_config_with_overrides(**overrides):
+    """BacktestConfig with `gimme_threshold=0` so the new filters can
+    be tested in isolation; pass-through kwargs override strategy
+    fields. side='no' keeps effective_config_for_side from consulting
+    no_overrides, so the flat values are what the engine reads."""
+    import copy
+
+    from gimmes.backtest.engine import BacktestConfig
+    from gimmes.config import load_config
+
+    base = load_config()
+    cfg = copy.deepcopy(base)
+    cfg.strategy.gimme_threshold = 0
+    for key, value in overrides.items():
+        setattr(cfg.strategy, key, value)
+    cfg.strategy.side = "no"
+    cfg.scanner.series = ["KXCPI"]
+    cfg.scanner.no_series = []
+    cfg.scanner.yes_series = []
+    return BacktestConfig(
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 5, 11),
+        starting_balance=10_000.0,
+        gimmes_config=cfg,
+        assumed_edge=0.10,
+    )
+
+
+class TestStrategyFilters:
+    """Verify backtest engine honors min_true_probability and
+    min_edge_after_fees in addition to gimme_threshold (#592)."""
+
+    @pytest.mark.asyncio
+    # Three NO-side midpoints inside the scanner price band
+    # (min=0.40, max=0.75); varying input catches effective_price
+    # inversion and threshold-edge bugs.
+    @pytest.mark.parametrize(
+        "yes_bid,yes_ask",
+        [(0.25, 0.35), (0.40, 0.50), (0.50, 0.60)],
+    )
+    async def test_min_true_probability_filter_reduces_trades(
+        self, monkeypatch, yes_bid: float, yes_ask: float,
+    ) -> None:
+        from gimmes.backtest.engine import run_backtest
+        markets = [
+            _settled_market(
+                f"KXCPI-26MAR-T0.{i}", yes_bid=yes_bid, yes_ask=yes_ask,
+            )
+            for i in range(5)
+        ]
+
+        async def _fake_list(*args, **kwargs):
+            return markets
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+
+        permissive = await run_backtest(
+            client=None,  # fetcher is stubbed
+            config=_backtest_config_with_overrides(
+                min_true_probability=0.0,
+                min_edge_after_fees=-1.0,
+            ),
+        )
+        strict = await run_backtest(
+            client=None,
+            config=_backtest_config_with_overrides(
+                min_true_probability=0.95,
+                min_edge_after_fees=-1.0,
+            ),
+        )
+        assert len(permissive.trades) > 0
+        assert len(strict.trades) < len(permissive.trades)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "yes_bid,yes_ask",
+        [(0.25, 0.35), (0.40, 0.50), (0.50, 0.60)],
+    )
+    async def test_min_edge_after_fees_filter_reduces_trades(
+        self, monkeypatch, yes_bid: float, yes_ask: float,
+    ) -> None:
+        from gimmes.backtest.engine import run_backtest
+        markets = [
+            _settled_market(
+                f"KXCPI-26MAR-T0.{i}", yes_bid=yes_bid, yes_ask=yes_ask,
+            )
+            for i in range(5)
+        ]
+
+        async def _fake_list(*args, **kwargs):
+            return markets
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+
+        permissive = await run_backtest(
+            client=None,
+            config=_backtest_config_with_overrides(
+                min_true_probability=0.0,
+                min_edge_after_fees=0.0,
+            ),
+        )
+        strict = await run_backtest(
+            client=None,
+            config=_backtest_config_with_overrides(
+                min_true_probability=0.0,
+                min_edge_after_fees=0.99,
+            ),
+        )
+        assert len(permissive.trades) > 0
+        assert len(strict.trades) < len(permissive.trades)
+
+    @pytest.mark.asyncio
+    async def test_live_default_thresholds_dont_reject_typical_markets(
+        self, monkeypatch,
+    ) -> None:
+        # Regression-safety (#592 AC3): at live values
+        # (min_true_probability=0.5, min_edge_after_fees=0.01), the
+        # filter rejects nothing in the live-trade universe.
+        from gimmes.backtest.engine import run_backtest
+        markets = [
+            _settled_market(
+                f"KXCPI-26MAR-T0.{i}", yes_bid=0.50, yes_ask=0.55,
+            )
+            for i in range(5)
+        ]
+
+        async def _fake_list(*args, **kwargs):
+            return markets
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+
+        live_defaults = await run_backtest(
+            client=None,
+            config=_backtest_config_with_overrides(
+                min_true_probability=0.5,
+                min_edge_after_fees=0.01,
+            ),
+        )
+        permissive = await run_backtest(
+            client=None,
+            config=_backtest_config_with_overrides(
+                min_true_probability=0.0,
+                min_edge_after_fees=-1.0,
+            ),
+        )
+        assert len(live_defaults.trades) == len(permissive.trades)


### PR DESCRIPTION
## Summary

Closes the backtest fidelity gap where the engine honored only `strategy.gimme_threshold` and silently ignored `strategy.min_true_probability` and `strategy.min_edge_after_fees`. Sweeping either filter over its full configured range produced identical results — proven empirically and now wired in.

The fix lives in the per-candidate scoring loop in `src/gimmes/backtest/engine.py` (around line 451). After the existing `gimme_threshold` gate, it:

1. Computes `eff_price = effective_price(raw_price, scan_side)`
2. Computes `true_prob = min(eff_price + assumed_edge, 0.99)` and applies `apply_base_rate_floor`
3. Rejects if `true_prob < min_true_probability`
4. Computes `edge_after_fees(eff_price, true_prob, is_taker=False, fees=fees)`
5. Rejects if `edge < min_edge_after_fees`

These are the same arithmetic and filter predicates the live validator uses at `risk/validator.py:152-175`. The computed `(eff_price, true_prob)` ride forward in the `scored` tuple so Pass 1 drops its duplicate recomputation.

Closes #592

## Test plan

- [x] Adds `TestStrategyFilters` in `tests/unit/test_backtest_engine.py` with 7 cases:
  - `test_min_true_probability_filter_reduces_trades` — parametrized over 3 NO-side midpoints, asserts strict (0.95) reduces count vs permissive (0.0)
  - `test_min_edge_after_fees_filter_reduces_trades` — same shape, strict 0.99 vs permissive 0.0
  - `test_live_default_thresholds_dont_reject_typical_markets` — at `(min_true_prob=0.5, min_edge=0.01)` behavior matches permissive (#592 AC3, regression-safety)
- [x] Tests stub `gimmes.backtest.engine.list_all_markets` via `monkeypatch` to inject synthetic settled markets with controlled prices
- [x] `uv run pytest tests/unit/test_backtest_engine.py` — 42 passed (35 existing + 7 new)
- [x] `uv run ruff check` — clean
- [x] Live sweep against Mar 1 – May 11 2026 confirms the fix:
  - Default config: **43 trades / +$6,113** (unchanged from pre-fix → regression-safe)
  - `min_true_probability=0.75`: **35 trades / +$6,851** (was 43 / +$6,113, no movement before fix)
  - `min_edge_after_fees=0.10`: **21 trades / +$6,274** (was 43 / +$6,113, no movement before fix)
- [x] Reviewed by code-reviewer, silent-failure-hunter, pr-test-analyzer, code-simplifier