### PR TITLE
#574: Coerce null JSON responses to [] in kalshi.markets helpers

### DIFF
--- a/src/gimmes/kalshi/markets.py
+++ b/src/gimmes/kalshi/markets.py
@@ -96,7 +96,8 @@ async def list_markets(
         params["max_close_ts"] = max_close_ts
 
     data = await client.get("/markets", params=params)
-    markets = [parse_market(m) for m in data.get("markets", [])]
+    # `or []` coerces explicit `null` from Kalshi (#574).
+    markets = [parse_market(m) for m in (data.get("markets") or [])]
     next_cursor = data.get("cursor")
     return markets, next_cursor
 
@@ -158,7 +159,8 @@ async def list_series(
     if category:
         params["category"] = category
     data = await client.get("/series", params=params)
-    return data.get("series", [])
+    # `or []` — Kalshi returns `{"series": null}` for empty categories (#574).
+    return data.get("series") or []
 
 
 async def get_event(client: KalshiClient, event_ticker: str) -> dict:  # type: ignore[type-arg]
@@ -180,7 +182,7 @@ async def get_series_fee_changes(
     if series_ticker:
         params["series_ticker"] = series_ticker
     data = await client.get("/series/fee_changes", params=params)
-    return data.get("series_fee_change_arr", [])
+    return data.get("series_fee_change_arr") or []  # null-coerce (#574)
 
 
 async def get_orderbook(client: KalshiClient, ticker: str, depth: int = 10) -> Orderbook:

--- a/tests/unit/test_markets.py
+++ b/tests/unit/test_markets.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from gimmes.kalshi.markets import list_all_markets, list_markets
+from gimmes.kalshi.markets import (
+    get_series_fee_changes,
+    list_all_markets,
+    list_markets,
+    list_series,
+)
 
 
 @pytest.fixture
@@ -40,6 +45,15 @@ class TestListMarketsDateFiltering:
         params = call_args[1]["params"]
         assert "min_close_ts" not in params
         assert "max_close_ts" not in params
+
+    @pytest.mark.asyncio
+    async def test_null_markets_value_coerces_to_empty(
+        self, mock_client: AsyncMock,
+    ) -> None:
+        mock_client.get.return_value = {"markets": None, "cursor": None}
+        markets, cursor = await list_markets(mock_client)
+        assert markets == []
+        assert cursor is None
 
 
 class TestListAllMarketsParams:
@@ -82,3 +96,66 @@ class TestListAllMarketsParams:
         await list_all_markets(mock_client)
 
         assert mock_client.get.call_count == 50
+
+
+class TestListSeries:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "response,expected",
+        [
+            ({"series": None}, []),
+            ({"series": []}, []),
+            ({}, []),
+            ({"series": [{"ticker": "X"}]}, [{"ticker": "X"}]),
+        ],
+    )
+    async def test_normalizes_null_and_missing_series_to_empty_list(
+        self,
+        mock_client: AsyncMock,
+        response: dict,
+        expected: list,
+    ) -> None:
+        mock_client.get.return_value = response
+        result = await list_series(mock_client)
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_threads_category_param(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = {"series": []}
+        await list_series(mock_client, category="Economics")
+        params = mock_client.get.call_args[1]["params"]
+        assert params["category"] == "Economics"
+
+
+class TestGetSeriesFeeChanges:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "response,expected",
+        [
+            ({"series_fee_change_arr": None}, []),
+            ({"series_fee_change_arr": []}, []),
+            ({}, []),
+            (
+                {"series_fee_change_arr": [{"id": 1}]},
+                [{"id": 1}],
+            ),
+        ],
+    )
+    async def test_normalizes_null_and_missing_to_empty_list(
+        self,
+        mock_client: AsyncMock,
+        response: dict,
+        expected: list,
+    ) -> None:
+        mock_client.get.return_value = response
+        result = await get_series_fee_changes(mock_client)
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_threads_series_ticker_param(
+        self, mock_client: AsyncMock,
+    ) -> None:
+        mock_client.get.return_value = {"series_fee_change_arr": []}
+        await get_series_fee_changes(mock_client, series_ticker="KXCPI")
+        params = mock_client.get.call_args[1]["params"]
+        assert params["series_ticker"] == "KXCPI"


### PR DESCRIPTION
## Summary

`gimmes discover <category>` crashed with `TypeError: object of type 'NoneType' has no len()` when Kalshi returned `{"series": null}` for an empty category. Root cause: `data.get("series", [])` returns the explicit None value, not the default `[]` — `dict.get(key, default)` only applies the default when the key is missing, not when the value is null.

Fix: `data.get(key) or []` in three same-pattern call sites in `src/gimmes/kalshi/markets.py`:

| Function | Line | Vulnerability |
|---|---|---|
| `list_series` | 163 | The issue's reported crash site |
| `list_markets` | 100 | Same shape — `[parse_market(m) for m in None]` would TypeError. Found by review pipeline grep. |
| `get_series_fee_changes` | 185 | Same shape on the fee-change list field. Mentioned in #574's investigation. |

Closes #574

## Test plan

- [x] 12 new test cases in `tests/unit/test_markets.py`:
  - `TestListSeries::test_normalizes_null_and_missing_series_to_empty_list` — parametrized over 4 response shapes (`null`, `[]`, missing key, populated)
  - `TestListSeries::test_threads_category_param` — query-param threading
  - `TestGetSeriesFeeChanges` — same 4+1 pattern
  - `TestListMarketsDateFiltering::test_null_markets_value_coerces_to_empty` — single regression for the new `list_markets` coverage
- [x] `uv run pytest tests/unit/test_markets.py` — 16 passed (was 5)
- [x] `uv run ruff check` — clean
- [x] Reviewed by code-reviewer (caught the adjacent `list_markets` vulnerability), silent-failure-hunter (clean — auth/4xx errors flow through `raise_for_status`, not via `null` JSON, so the new `[]` doesn't hide any error signal), pr-test-analyzer (clean), code-simplifier (trimmed verbose comments)