### PR TITLE
#580: Fetch CM decisions independently in position-context

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2058,6 +2058,11 @@ def position_context(
             trade = await get_open_trade_for_ticker(db, resolved)
             is_open = await has_open_position(db, resolved)
             notes = await get_position_notes(db, resolved, limit=20)
+            # Fetch decisions separately so chatty observations can't
+            # evict the CM governance trail (#580).
+            decisions = await get_position_notes(
+                db, resolved, limit=25, note_type="decision",
+            )
 
         if not trade or not is_open:
             # Another process (clubhouse server, autonomous loop) may
@@ -2107,7 +2112,6 @@ def position_context(
         else:
             console.print("[dim]No notes yet.[/dim]")
 
-        decisions = [n for n in notes if n["note_type"] == "decision"]
         if decisions:
             console.print("\n[bold yellow]--- CADDIE MASTER DECISIONS ---[/bold yellow]")
             for n in decisions:

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -665,12 +665,23 @@ async def get_position_notes(
     ticker: str,
     *,
     limit: int = 50,
+    note_type: str | None = None,
 ) -> list[dict]:  # type: ignore[type-arg]
-    """Return position notes for a ticker, newest first."""
-    cursor = await db.conn.execute(
-        "SELECT * FROM position_notes WHERE ticker = ? ORDER BY id DESC LIMIT ?",
-        (ticker, limit),
-    )
+    """Return position notes for a ticker, newest first.
+
+    When ``note_type`` is set, the type filter is applied before
+    ``limit`` so chatty notes of other types can't evict matches (#580).
+    """
+    if note_type is None:
+        sql = "SELECT * FROM position_notes WHERE ticker = ? ORDER BY id DESC LIMIT ?"
+        params: tuple = (ticker, limit)
+    else:
+        sql = (
+            "SELECT * FROM position_notes WHERE ticker = ? AND note_type = ?"
+            " ORDER BY id DESC LIMIT ?"
+        )
+        params = (ticker, note_type, limit)
+    cursor = await db.conn.execute(sql, params)
     rows = await cursor.fetchall()
     return [dict(row) for row in rows]
 

--- a/tests/unit/test_thesis_journal.py
+++ b/tests/unit/test_thesis_journal.py
@@ -265,6 +265,82 @@ class TestPositionNotes:
             )
             assert row_id > 0
 
+    async def test_filter_by_note_type_returns_only_that_type(
+        self, db: Database,
+    ) -> None:
+        for nt in ("observation", "flag", "decision", "context"):
+            await insert_position_note(
+                db, ticker="FILTER-T", note_type=nt, body=f"{nt} body",
+            )
+        decisions = await get_position_notes(
+            db, "FILTER-T", note_type="decision",
+        )
+        assert len(decisions) == 1
+        assert decisions[0]["note_type"] == "decision"
+
+    async def test_580_old_path_evicts_decisions_under_chatty_observations(
+        self, db: Database,
+    ) -> None:
+        # 5 decisions then 16 newer observations: the OLD path
+        # (limit=20, filter in Python) evicts the oldest decision;
+        # the NEW path (note_type filter) returns all 5.
+        for i in range(5):
+            await insert_position_note(
+                db, ticker="EVICT-T", note_type="decision",
+                body=f"decision {i}", cycle=100 + i,
+            )
+        for i in range(16):
+            await insert_position_note(
+                db, ticker="EVICT-T", note_type="observation",
+                body=f"obs {i}", cycle=200 + i,
+            )
+        notes = await get_position_notes(db, "EVICT-T", limit=20)
+        old_path_decisions = [n for n in notes if n["note_type"] == "decision"]
+        assert len(old_path_decisions) == 4, "eviction not reproduced"
+        new_path_decisions = await get_position_notes(
+            db, "EVICT-T", limit=20, note_type="decision",
+        )
+        assert len(new_path_decisions) == 5
+
+    async def test_filter_by_note_type_respects_limit_within_type(
+        self, db: Database,
+    ) -> None:
+        # The #580 regression: when limit is applied to ALL notes, a
+        # chatty observation/flag stream evicts older decisions before
+        # the limit is reached. Filtering by note_type must apply the
+        # limit AFTER the type filter, so 5 decisions are returned even
+        # when 15 observations interleave.
+        for i in range(15):
+            await insert_position_note(
+                db, ticker="MIX-T", note_type="observation",
+                body=f"obs {i}",
+            )
+        for i in range(15):
+            await insert_position_note(
+                db, ticker="MIX-T", note_type="decision",
+                body=f"decision {i}",
+            )
+        result = await get_position_notes(
+            db, "MIX-T", limit=5, note_type="decision",
+        )
+        assert len(result) == 5
+        assert all(n["note_type"] == "decision" for n in result)
+        # Newest-first ordering preserved: decision 14 first.
+        assert result[0]["body"] == "decision 14"
+
+    async def test_filter_by_note_type_none_returns_all_types(
+        self, db: Database,
+    ) -> None:
+        # Default behavior must be unchanged (regression guard for the
+        # existing position-notes command at cli.py:2182).
+        for nt in ("observation", "flag", "decision", "context"):
+            await insert_position_note(
+                db, ticker="DEFAULT-T", note_type=nt, body=f"{nt} body",
+            )
+        all_notes = await get_position_notes(db, "DEFAULT-T")
+        types = {n["note_type"] for n in all_notes}
+        assert types == {"observation", "flag", "decision", "context"}
+
 
 # ---------------------------------------------------------------------------
 # get_candidate_for_ticker (#275)


### PR DESCRIPTION
## Summary

`gimmes position-context` displayed stale Caddie Master decision cycles because the "CADDIE MASTER DECISIONS" panel filtered `note_type == "decision"` *after* `get_position_notes` had already applied a 20-row mixed-type limit. For chatty positions (15+ observation/flag notes in the recent window), recent decisions were silently evicted before the Python filter ran.

Reported failures:
- `KXCPIYOY-26APR-T3.7` showed c1403 as the governing hold cycle; DB had c1409
- `KXCPIYOY-26MAY-T4.2` showed c1396; DB had c1407

## Fix

- `get_position_notes` (`src/gimmes/store/queries.py:663-690`) gains an optional `note_type: str | None = None` kwarg. When set, the SQL adds `AND note_type = ?` before the `ORDER BY id DESC LIMIT ?`. Default behavior preserved for the other caller (`gimmes position-notes`).
- `position-context` (`src/gimmes/cli.py:2057-2066`) now issues a second query with `note_type="decision", limit=25` and renders the result directly. The in-Python filter is removed. The "POSITION NOTES (last 20)" section continues to use the mixed-type list (intentional).
- Limit set to 25 to accommodate chatty long-held positions — the GDP-T2.5 case in #586 accumulated 30+ HOLD notes; 25 gives operators most of the governance trail without flooding the terminal.

Closes #580

## Test plan

- [x] 4 new tests under `TestPositionNotes`:
  - `test_580_old_path_evicts_decisions_under_chatty_observations` — literal AC reproduction: inserts 5 decisions + 15+ observations, demonstrates the OLD path's eviction, then verifies the NEW path returns all decisions
  - `test_filter_by_note_type_returns_only_that_type` — basic filter check
  - `test_filter_by_note_type_respects_limit_within_type` — 15 obs + 15 decisions, `note_type="decision", limit=5` returns 5 newest decisions
  - `test_filter_by_note_type_none_returns_all_types` — regression guard for default behavior (the other caller's path)
- [x] `uv run pytest tests/unit/test_thesis_journal.py::TestPositionNotes` — 11 passed (was 7)
- [x] `uv run pytest tests/unit/test_cli_ticker_prefix.py` — 23 passed, no regression in adjacent CLI tests
- [x] `uv run ruff check` — clean
- [x] Reviewed by code-reviewer (clean — confirms SQL-injection-safe parametrization), silent-failure-hunter (caught limit=10 too tight → raised to 25), pr-test-analyzer (caught that the regression test didn't literally satisfy the AC → added the old-path reproduction), code-simplifier (tightened SQL branch + comments + test setup)