### PR TITLE
#590: Add KXJOBLESSCLAIMS to Caddie's sanity-check gimme-category list

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -52,7 +52,7 @@ When the Scout's shortlist contains **multiple candidates from the same event** 
 
 ## Sanity-Check Mode (Default for Gimme Categories)
 
-For candidates in backtested gimme categories (KXCPICORE, KXCPIYOY, KXCPICOREYOY, KXPAYROLLS, KXADP, KXGDP, KXINX, KXNASDAQ100), run a **fast sanity check** instead of deep research. The structural edge in these categories is proven — deep probability estimation adds noise, not signal.
+For candidates in backtested gimme categories (KXCPICORE, KXCPIYOY, KXCPICOREYOY, KXPAYROLLS, KXADP, KXGDP, KXINX, KXNASDAQ100, KXJOBLESSCLAIMS), run a **fast sanity check** instead of deep research. The structural edge in these categories is proven — deep probability estimation adds noise, not signal.
 
 **Three checks (30 seconds, not 5 minutes):**
 
@@ -78,7 +78,7 @@ For candidates in backtested gimme categories (KXCPICORE, KXCPIYOY, KXCPICOREYOY
 |----------|---------------------|---------------|
 | KXCPIYOY, KXCPICOREYOY | 90% | 0.90 |
 | KXCPICORE | 85% | 0.85 |
-| KXPAYROLLS, KXADP | 85% | 0.85 |
+| KXPAYROLLS, KXADP, KXJOBLESSCLAIMS | 85% | 0.85 |
 | KXGDP | 85% | 0.85 |
 | KXINX, KXNASDAQ100 | 80% | 0.80 |
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -125,6 +125,60 @@ def test_caddie_point_estimate_not_fifty_percent(caddie_text: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Sanity-check gimme-category inclusion (#590)
+# ---------------------------------------------------------------------------
+
+
+def test_caddie_jobless_claims_in_gimme_category_list(caddie_text: str) -> None:
+    # KXJOBLESSCLAIMS must remain in the sanity-check fast-track list —
+    # removing it would re-introduce the live-vs-backtest market-mix
+    # bias documented in #590 (live picker overweighted CPI losers
+    # while JOBLESS, a backtest winner, fell through to deep research
+    # and got under-approved).
+    import re
+
+    # The opening sentence of the Sanity-Check Mode section enumerates
+    # the gimme categories in parentheses. Pin JOBLESS there.
+    sanity_check_section = re.search(
+        r"For candidates in backtested gimme categories \(([^)]+)\),",
+        caddie_text,
+    )
+    assert sanity_check_section is not None, (
+        "Caddie must have a 'For candidates in backtested gimme categories"
+        " (...)' opening sentence in the Sanity-Check Mode section."
+    )
+    series_list = sanity_check_section.group(1)
+    assert "KXJOBLESSCLAIMS" in series_list, (
+        "KXJOBLESSCLAIMS must remain in the Sanity-Check gimme list (#590)."
+        f" Current list: {series_list}"
+    )
+
+
+def test_caddie_jobless_claims_has_base_rate_matching_payrolls(
+    caddie_text: str,
+) -> None:
+    # The base-rate table must include KXJOBLESSCLAIMS with the same
+    # probability (0.85) as its peer employment series KXPAYROLLS/KXADP.
+    # Pin the exact number — a silent drop to a different rate (e.g.
+    # 0.50) would still produce "a numeric probability" and would not
+    # be caught by a loose `0\.\d+` regex, but it would violate the AC
+    # ("same treatment as KXPAYROLLS") and re-introduce the bias #590
+    # was filed to fix.
+    import re
+
+    row_match = re.search(
+        r"\|[^|]*KXJOBLESSCLAIMS[^|]*\|[^|]*\|[^|]*0\.85[^|]*\|",
+        caddie_text,
+    )
+    assert row_match is not None, (
+        "Caddie sanity-check base-rate table must include a row for"
+        " KXJOBLESSCLAIMS with probability 0.85 (peer-matched with"
+        " KXPAYROLLS/KXADP) so the fast-track path has a defined --prob"
+        " consistent with the employment family (#590)."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Stop-loss override rule (#586)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the asymmetric gate that made the live picker systematically prefer KXCPI/CPIYOY (losers in live data) over KXJOBLESSCLAIMS (a backtest winner). Root cause: Caddie's Sanity-Check Mode (`caddie.md:53-88`) routes KXCPI/CPIYOY through a 30-second fast-track at 85-90% base rate, but KXJOBLESSCLAIMS — absent from the gimme list — fell through to the deep-research path requiring 2+ independent signals. Result: ~80-85% approval rate for CPI vs ~56% for JOBLESS.

Backtest data: 6/6 wins on KXJOBLESSCLAIMS. Live data: 0/5 closed losses on KXCPIYOY. The system was routing away from its actual winners.

## Changes

Two edits to `.claude/agents/caddie.md`:

1. **Line 55** — append `KXJOBLESSCLAIMS` to the Sanity-Check Mode gimme-category list.
2. **Line 81** — extend the employment-family row to `KXPAYROLLS, KXADP, KXJOBLESSCLAIMS | 85% | 0.85`.

Treats KXJOBLESSCLAIMS as a peer of KXPAYROLLS/KXADP (same employment family, same 85% base rate) rather than as a deep-research candidate. The sanity-check still catches extraordinary events (government shutdowns, methodology changes, staleness); the deep-research playbook at line 141 remains the fallback when Monitor flags a position or Caddie Master overrides.

Closes #590

## Test plan

- [x] 2 new drift-guard tests in `tests/unit/test_agent_prompts.py`:
  - `test_caddie_jobless_claims_in_gimme_category_list` — regex-pins KXJOBLESSCLAIMS in the opening sentence of the Sanity-Check section
  - `test_caddie_jobless_claims_has_base_rate_matching_payrolls` — pins the exact `0.85` probability per the AC-literal rule (a silent drop to 0.50 would still pass a loose `0\.\d+` regex)
- [x] `uv run pytest tests/unit/test_agent_prompts.py` — 14 passed (was 12)
- [x] `uv run ruff check` — clean
- [x] Reviewed by code-reviewer (clean — 85% peer-matches KXPAYROLLS/KXADP, CPI exception at line 64 doesn't apply to JOBLESS, both drift-guards pin load-bearing claims), silent-failure-hunter (one CONCERN deferred — Wilson lower bound on 6/6 is ~61%, so 85% is aggressive; mitigated by sanity-check still catching extraordinary events and the Monitor + step-2c review path for open positions), pr-test-analyzer (caught the loose-regex GAP — fixed by pinning 0.85 exactly)