### PR TITLE
#591: Add sibling-strike Kelly rule to Caddie's Sanity-Check Mode

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -82,6 +82,15 @@ For candidates in backtested gimme categories (KXCPICORE, KXCPIYOY, KXCPICOREYOY
 | KXGDP | 85% | 0.85 |
 | KXINX, KXNASDAQ100 | 80% | 0.80 |
 
+4. **Sibling-strike selection (per-event Kelly rule)**: When two or more candidates from the SAME event_ticker (the full prefix before the final `-T<strike>` segment, e.g., `KXADP-26APR-T100000` and `KXADP-26APR-T125000` share event_ticker `KXADP-26APR`; `KXADP-26APR-T100000` and `KXADP-26MAY-T100000` do NOT — different months are different events) pass checks 1–3 in the same review batch on the configured `trading_side` (read from `gimmes config get strategy.side`) and share the same gimme-category base rate, PROCEED ONLY the candidate with the LOWEST price on `trading_side`; PASS the higher-priced siblings.
+   - Rationale: under the fast-track assumption of a constant category base rate, `edge = base_rate − entry_price` is monotonic in entry price alone, so the cheapest entry on the trading side is Kelly-optimal. Picking a higher-priced sibling leaks edge for no informational gain (fixes #591).
+   - PASS rationale MUST cite the dominant sibling ticker and its price on the trading side (e.g., `"PASS — dominated by sibling KXADP-26APR-T125000 NO at \$0.48; this strike NO at \$0.71 has lower edge under the same base rate"`).
+   - When `trading_side` is `both`, this rule does NOT fire — strikes on opposite sides aren't directly comparable; apportion to Caddie Master via PROCEED so each side's Kelly is considered independently.
+   - Tied prices (within \$0.01): PROCEED all tied candidates and let Caddie Master apply the concentration limit (`max_event_exposure_pct`) to pick which fit.
+   - Does NOT apply when the extraordinary-event exception (check 1, CPI carveout above) fires for any sibling — in that case each sibling has its own arithmetic-derived probability and must be flagged for Caddie Master review individually.
+   - **Sibling-price monotonicity check (REQUIRED before applying the rule)**: among the PROCEED candidates in this event, the looser-threshold strike's `trading_side` price MUST be >= the tighter-threshold strike's price. If a looser strike is priced CHEAPER than a tighter sibling on the same side, that is a market mispricing / arbitrage signal — log it in your research memo and PROCEED both anyway (do NOT collapse to the cheapest, which would incorrectly PASS the tighter-strike gimme). The cheapest-sibling rule above assumes monotonically-priced siblings; violations are themselves the signal.
+   - **Cross-cycle limitation (acknowledged)**: this rule applies only within the same review batch. If Scout outputs siblings across multiple cycles, both will PROCEED independently — Caddie Master's `max_event_exposure_pct` concentration limit (`caddie-master.md` Step 4c) provides backstop coverage when both reach review.
+
 **When to use deep research instead:**
 - Candidate is NOT in a gimme category
 - Monitor flagged a position for review (situation changed)

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -154,6 +154,70 @@ def test_caddie_jobless_claims_in_gimme_category_list(caddie_text: str) -> None:
     )
 
 
+def test_caddie_sibling_strike_selection_rule(caddie_text: str) -> None:
+    # Within an event, Caddie must PASS higher-priced sibling strikes
+    # when a cheaper sibling shares the same gimme-category base rate.
+    # Without this rule, the per-strike scoring picks higher-priced
+    # (worse Kelly) strikes — the canonical case from #591.
+    #
+    # Scope assertions to the Sanity-Check Mode block so the rule can't
+    # silently drift into an unrelated section of the prompt while
+    # keeping the keyword in the doc.
+    import re
+
+    sanity_check_match = re.search(
+        r"## Sanity-Check Mode.*?(?=\n## )",
+        caddie_text,
+        flags=re.DOTALL,
+    )
+    assert sanity_check_match is not None, (
+        "caddie.md must contain a '## Sanity-Check Mode' section."
+    )
+    sanity_block = sanity_check_match.group(0)
+
+    assert "Sibling-strike selection" in sanity_block, (
+        "Sanity-Check Mode must contain the per-event sibling-strike"
+        " rule (#591)."
+    )
+    # The rule must pin the cheapest-on-the-trading-side as the
+    # PROCEED winner. Accept either explicit "LOWEST" or "lowest"
+    # paired with a price-on-trading-side reference — the load-bearing
+    # claim is that the rule selects on PRICE, not score or threshold.
+    assert "LOWEST price" in sanity_block or "LOWEST NO price" in sanity_block, (
+        "Sibling-strike rule must pin 'LOWEST price on trading_side' (or"
+        " 'LOWEST NO price' if NO-side hardcoded) — a softening to 'lower'"
+        " or 'preferred' would reintroduce the bias #591 fixes."
+    )
+    assert "same event_ticker" in sanity_block or "SAME event_ticker" in sanity_block, (
+        "Sibling-strike rule must scope to same event_ticker so it"
+        " doesn't accidentally compare strikes across different events."
+    )
+    assert "KXADP-26APR" in sanity_block, (
+        "Sibling-strike rule must cite the canonical KXADP-26APR"
+        " T100000-vs-T125000 anti-pattern so a future drift can't"
+        " quietly remove the evidence."
+    )
+    # Three load-bearing sub-rules from the diff must remain pinned:
+    assert "PASS rationale MUST cite the dominant sibling" in sanity_block, (
+        "Sibling-strike rule must require PASS rationale to cite the"
+        " dominant sibling — auditability anchor."
+    )
+    assert "extraordinary-event exception" in sanity_block, (
+        "Sibling-strike rule must defer to the CPI extraordinary-event"
+        " carveout — if that exception fires for any sibling, each"
+        " sibling needs Caddie Master review individually."
+    )
+    assert "monotonicity" in sanity_block.lower(), (
+        "Sibling-strike rule must address sibling-price monotonicity —"
+        " a looser-strike priced below tighter is the gimme signal, not"
+        " a reason to collapse to the cheapest."
+    )
+    assert "trading_side" in sanity_block, (
+        "Sibling-strike rule must reference `trading_side` (or strategy"
+        " side) so it works on YES, NO, and 'both' configurations."
+    )
+
+
 def test_caddie_jobless_claims_has_base_rate_matching_payrolls(
     caddie_text: str,
 ) -> None:


### PR DESCRIPTION
## Summary

Within a single event with multiple NO-side strikes, Caddie was picking higher-priced (worse Kelly) strikes because each strike was scored in isolation — no per-event comparison. Canonical case: live took **KXADP-26APR-T100000** at \$0.71 (LOST); backtest took **KXADP-26APR-T125000** at \$0.48 (WON +\$1,051). Both were candidates on the same day; T100000 had gimme_score 86 (PROCEED) vs T125000's 64 (PASS) — Caddie's per-candidate scoring favored the higher-priced strike.

Research confirmed (data agent + code agent in Phase 2): Scout DOES fetch all strikes per event (e.g. 6 strikes for KXPAYROLLS-26APR, 7 for KXCPIYOY-26MAY). Caddie scores each independently. Caddie Master's existing "Cross-threshold consistency" rule (`caddie-master.md:316`) only checks probability *monotonicity*, not price — under the fast-track, all siblings share the same flat base rate so that check trivially passes. There was no step in the pipeline that explicitly enumerated strikes within an event and ranked them by edge.

## Changes

Adds **check #4** to Sanity-Check Mode in `.claude/agents/caddie.md`:

> When 2+ same-event candidates pass checks 1-3 on the configured `trading_side` and share the same gimme-category base rate, PROCEED ONLY the candidate with the LOWEST price on `trading_side`; PASS the higher-priced siblings with rationale citing the dominant sibling.

Plus guardrails that emerged from the review pipeline:

- **`trading_side=\"both\"` carveout** — strikes on opposite sides aren't directly comparable; rule does not fire (defer to CM's per-side Kelly).
- **Tied prices** within \$0.01: PROCEED all and let Caddie Master's concentration limit pick.
- **Sibling-price monotonicity** — if a looser strike is cheaper than a tighter sibling on the same side, that IS the gimme signal. PROCEED both with a research-memo note; do NOT collapse to the cheapest (which would incorrectly PASS the gimme).
- **Cross-cycle limitation acknowledged** — rule applies within one review batch; cross-cycle siblings fall back on CM's `max_event_exposure_pct`.
- **CPI extraordinary-event carveout** — rule does not apply when the arithmetic exception fires; each sibling needs CM review individually.

Closes #591

## Test plan

- [x] New drift-guard test `test_caddie_sibling_strike_selection_rule` in `tests/unit/test_agent_prompts.py` — 8 assertions scoped to the Sanity-Check Mode block (slices on `## Sanity-Check Mode` ... next `## `):
  1. Rule presence (\"Sibling-strike selection\")
  2. LOWEST-price keyword
  3. Same-event_ticker scoping
  4. Canonical KXADP-26APR example
  5. PASS rationale cites dominant sibling (auditability anchor)
  6. CPI extraordinary-event deferral
  7. Sibling-price monotonicity handling
  8. `trading_side` parameterization (works on YES, NO, both)
- [x] `uv run pytest tests/unit/test_agent_prompts.py` — 15 passed (was 14)
- [x] `uv run ruff check` — clean
- [x] Reviewed by code-reviewer (caught the dead monotonicity handoff to CM — fixed by moving the check into Caddie itself; flagged NO-side hardcoding — fixed by switching to `trading_side`), silent-failure-hunter (caught cross-cycle gap, event_ticker ambiguity, tied-prices undefined — all addressed in the rule body), pr-test-analyzer (caught full-document `in caddie_text` scoping + missing caveats — both fixed)