### PR TITLE
#600: Add Step 2.5 GitHub dedup pre-flight to Groundskeeper

### DIFF
--- a/.claude/agents/groundskeeper.md
+++ b/.claude/agents/groundskeeper.md
@@ -46,21 +46,34 @@ If there are no unresolved errors, report "No issues to escalate" and exit.
 
 **Suppress (MUST NOT escalate):**
 - `debug` or `info` severity errors
-- Errors whose `(error_code, component)` tuple matches an open GitHub issue filed by Groundskeeper (see Step 2.5 — query GitHub directly, do NOT rely on the local `github_issue_url` field alone, which lags newly-arriving rows).
 - Transient rate limiting (HTTP 429 / `KALSHI_429`) unless 3+ occurrences in 1 hour
+
+(GitHub-issue dedup is a separate concern — handled by Step 2.5 below, NOT this suppress list. Step 2's suppress list is only for severity/category-based filters.)
 
 ### Step 2.5: GitHub dedup pre-flight check (REQUIRED before Step 3)
 
 For each error group surviving Step 2, query GitHub for an existing issue with the same `(error_code, component)` tuple BEFORE filing. This closes the recurrence-noise pattern documented in #600, where the same `(error_code, component)` produced #597 → #598 → #599 in <4 hours because the local `github_issue_url` field was only set after filing and newly-arriving rows tripped the threshold in isolation.
 
+**CRITICAL handling (REQUIRED, applies before any dedup):** For `critical` severity errors and `risk_breach` category errors, the safety rule "MUST file in current cycle" from Step 2 must hold — but unconditional re-filing across multiple cycles would recreate the #597 → #598 → #599 noise pattern scoped to criticals. Run the dedup query (below) first, then:
+- **If a matching issue is OPEN**: comment on it (Step 2.5's OPEN-match branch) so the recurrence is documented on the live incident thread.
+- **If no match OR matching issue is CLOSED (any age)**: file a new issue regardless of the 24h cooldown — never suppress a fresh critical/risk_breach. CLOSED + within-24h does NOT apply the suppress path for these severities.
+
+For all OTHER escalating errors (warning/error severity, non-risk_breach categories), the normal Step 2.5 branching applies.
+
+For all other escalating errors, query:
+
 ```bash
-gh issue list --state all --label bug --search 'in:title "ERROR_CODE" "COMPONENT"' --json number,title,state,closedAt --limit 10
+gh issue list --state all --label bug --search 'in:title "ERROR_CODE" in:body "COMPONENT"' --json number,title,state,createdAt,closedAt,url --limit 100
 ```
 
-Note the **quoted** terms in the search — GitHub search tokenizes on `_`/`-`/`.`, so unquoted `position_not_found` would split into substring tokens and false-match unrelated issues. The `in:title` scope restricts matching to the title field (where Groundskeeper writes the error_code) rather than body — body matching pulls in noise from unrelated issues that incidentally reference the tokens.
+Search-query notes:
+- **Quoted terms.** GitHub search tokenizes on `_`/`-`/`.`, so unquoted `position_not_found` would split into substring tokens and false-match unrelated issues. Quote both terms.
+- **`in:title` + `in:body` semantics.** GitHub treats multiple `in:` qualifiers as a UNION of search scopes applied to ALL free terms — i.e. both ERROR_CODE and COMPONENT are searched across title OR body, ANDed. The query returns POTENTIAL matches; some may be false positives where COMPONENT appears in an unrelated issue's body (e.g., in a stack-trace or suggested-action template). MUST verify each result by reading its title + body before treating it as a real match — only count a result if it represents Groundskeeper's own prior filing of the same `(error_code, component)` pattern, not a tangential mention.
+- **`--limit 100`, not 10.** A small limit risks missing an OPEN match if many stale CLOSED matches sort ahead. 100 is generous for any realistic dedup scope; if the actual return exceeds 100 the operator should narrow the search manually.
+- **`--json` fields.** `createdAt` is needed for the OPEN selection rule below; `url` is needed for `gimmes resolve-error --issue-url ...` in the OPEN branch; `closedAt` is needed for the CLOSED branches. All four (plus `number`, `title`, `state`) are required.
 
 **Match selection rule (REQUIRED).** When the query returns multiple matches:
-1. If ANY match has `state: OPEN`, take the most recently-created OPEN match. Skip the CLOSED branches.
+1. If ANY match has `state: OPEN`, take the most recently-created OPEN match (sort by `createdAt` descending, pick first). Skip the CLOSED branches.
 2. If ALL matches are `state: CLOSED`, take the one with the most recent `closedAt`.
 3. If `closedAt` is null on a CLOSED match (rare gh edge case), treat as stale (file new with a note that closedAt was missing).
 
@@ -68,13 +81,13 @@ Branch on the selected match:
 
 - **No match** → proceed to Step 3 (file new issue as before).
 - **Match with `state: OPEN`** → MUST NOT file a new issue. In this order:
-  1. FIRST run `gimmes resolve-error ERROR_ID --issue-url EXISTING_URL` for EACH new error row, so the local `github_issue_url` field is synced BEFORE the comment lands. If resolve-error fails, note the failure and SKIP the comment for that row — never comment without successful resolve, or the next cycle will re-comment indefinitely.
+  1. FIRST run `gimmes resolve-error ERROR_ID --issue-url EXISTING_URL` for EACH new error row, using the `url` field from the JSON query (NOT a constructed URL). If resolve-error fails for a row, note the failure and SKIP the comment for that row — never comment without successful resolve, or the next cycle will re-comment indefinitely.
   2. After all rows are successfully resolved, post ONE consolidated comment on the existing open issue:
      ```bash
      gh issue comment NUMBER --body "Recurred at TIMESTAMP — error_log row ID(s) [IDS] — [N] occurrences in last 24h for (ERROR_CODE, COMPONENT)."
      ```
-  This ordering provides idempotency: a re-running Groundskeeper sees the rows are already resolved (`github_issue_url` populated) and Step 2's existing suppress-list filter catches them BEFORE they reach Step 2.5 — no duplicate comment.
-- **Match with `state: CLOSED` AND `closedAt` within last 24h** → suppress. Resolve new rows against the closed issue URL. Rationale: allow the fix to propagate before re-escalating; recurrence within 24h of close usually means the agent context still holds the broken state.
+  3. **If the comment fails after the resolves succeeded**, log the comment failure to the activity log with `phase=warn` and message `"Recurrence comment failed for issue #N — local rows resolved against URL but comment not posted; operator audit required"`. The rows stay resolved (so the next cycle doesn't re-trip), but the recurrence notification is lost from the issue thread. Operators monitoring open issues should re-check for new error_log activity manually.
+- **Match with `state: CLOSED` AND `closedAt` within last 24h** → suppress (UNLESS severity is critical or category is risk_breach — see exception above). Resolve new rows against the closed issue URL. Rationale: allow the fix to propagate before re-escalating; recurrence within 24h of close usually means the agent context still holds the broken state.
 - **Match with `state: CLOSED` AND `closedAt` older than 24h BUT within last 30 days** → file a new issue (Step 3) whose body cites the prior closed issue: "Pattern previously resolved in #N closed at CLOSED_AT — recurrence after 24h cooldown."
 - **Match with `state: CLOSED` AND `closedAt` older than 30 days** → treat as no match; do NOT cite (the prior issue is too stale to be operationally relevant). Proceed to Step 3 with no citation.
 

--- a/.claude/agents/groundskeeper.md
+++ b/.claude/agents/groundskeeper.md
@@ -46,8 +46,41 @@ If there are no unresolved errors, report "No issues to escalate" and exit.
 
 **Suppress (MUST NOT escalate):**
 - `debug` or `info` severity errors
-- Errors already linked to an **open** GitHub issue (non-empty `github_issue_url`). If the linked issue is closed, treat the error as unlinked and re-apply escalation rules.
+- Errors whose `(error_code, component)` tuple matches an open GitHub issue filed by Groundskeeper (see Step 2.5 — query GitHub directly, do NOT rely on the local `github_issue_url` field alone, which lags newly-arriving rows).
 - Transient rate limiting (HTTP 429 / `KALSHI_429`) unless 3+ occurrences in 1 hour
+
+### Step 2.5: GitHub dedup pre-flight check (REQUIRED before Step 3)
+
+For each error group surviving Step 2, query GitHub for an existing issue with the same `(error_code, component)` tuple BEFORE filing. This closes the recurrence-noise pattern documented in #600, where the same `(error_code, component)` produced #597 → #598 → #599 in <4 hours because the local `github_issue_url` field was only set after filing and newly-arriving rows tripped the threshold in isolation.
+
+```bash
+gh issue list --state all --label bug --search 'in:title "ERROR_CODE" "COMPONENT"' --json number,title,state,closedAt --limit 10
+```
+
+Note the **quoted** terms in the search — GitHub search tokenizes on `_`/`-`/`.`, so unquoted `position_not_found` would split into substring tokens and false-match unrelated issues. The `in:title` scope restricts matching to the title field (where Groundskeeper writes the error_code) rather than body — body matching pulls in noise from unrelated issues that incidentally reference the tokens.
+
+**Match selection rule (REQUIRED).** When the query returns multiple matches:
+1. If ANY match has `state: OPEN`, take the most recently-created OPEN match. Skip the CLOSED branches.
+2. If ALL matches are `state: CLOSED`, take the one with the most recent `closedAt`.
+3. If `closedAt` is null on a CLOSED match (rare gh edge case), treat as stale (file new with a note that closedAt was missing).
+
+Branch on the selected match:
+
+- **No match** → proceed to Step 3 (file new issue as before).
+- **Match with `state: OPEN`** → MUST NOT file a new issue. In this order:
+  1. FIRST run `gimmes resolve-error ERROR_ID --issue-url EXISTING_URL` for EACH new error row, so the local `github_issue_url` field is synced BEFORE the comment lands. If resolve-error fails, note the failure and SKIP the comment for that row — never comment without successful resolve, or the next cycle will re-comment indefinitely.
+  2. After all rows are successfully resolved, post ONE consolidated comment on the existing open issue:
+     ```bash
+     gh issue comment NUMBER --body "Recurred at TIMESTAMP — error_log row ID(s) [IDS] — [N] occurrences in last 24h for (ERROR_CODE, COMPONENT)."
+     ```
+  This ordering provides idempotency: a re-running Groundskeeper sees the rows are already resolved (`github_issue_url` populated) and Step 2's existing suppress-list filter catches them BEFORE they reach Step 2.5 — no duplicate comment.
+- **Match with `state: CLOSED` AND `closedAt` within last 24h** → suppress. Resolve new rows against the closed issue URL. Rationale: allow the fix to propagate before re-escalating; recurrence within 24h of close usually means the agent context still holds the broken state.
+- **Match with `state: CLOSED` AND `closedAt` older than 24h BUT within last 30 days** → file a new issue (Step 3) whose body cites the prior closed issue: "Pattern previously resolved in #N closed at CLOSED_AT — recurrence after 24h cooldown."
+- **Match with `state: CLOSED` AND `closedAt` older than 30 days** → treat as no match; do NOT cite (the prior issue is too stale to be operationally relevant). Proceed to Step 3 with no citation.
+
+The tuple `(error_code, component)` is the dedup key. NEVER dedup on `error_code` alone (over-suppresses unrelated components) or `category` alone (too broad).
+
+If the `gh issue list` query fails, note the failure in your output and proceed to Step 3 (fail-open — better to file a possible duplicate than miss a recurring pattern silently). Operators relying on this dedup should monitor `gh auth status` and GitHub API rate limits; sustained fail-open will recreate the #600 pattern.
 
 ### Step 3: File GitHub Issues
 
@@ -143,7 +176,9 @@ Substitute actual values: total unresolved errors reviewed and number of GitHub 
 
 - NEVER modify code — you review and escalate only
 - NEVER suppress `critical` or `risk_breach` errors — no exceptions
-- NEVER close or modify existing GitHub issues — only create new ones
+- NEVER close existing GitHub issues or edit their titles/bodies — only create new issues OR add comments
+- MAY add comments to existing open issues as part of Step 2.5 dedup (the only sanctioned modification)
+- MUST run Step 2.5 GitHub dedup pre-flight check before every `gh issue create` — NEVER skip
 - MUST use CLI commands exclusively — NEVER query the database directly
 - MUST be concise in issue titles — they should be scannable
 - MUST group related errors into a single issue when they share the same root cause

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -417,11 +417,14 @@ def test_groundskeeper_has_github_dedup_preflight(
         "Step 2.5 must use `gh issue list --state all --label bug"
         " --search ...` to find both open and closed matching issues."
     )
-    assert "--json number,title,state,closedAt" in groundskeeper_text, (
-        "Step 2.5 must request JSON output with state + closedAt so"
-        " the branching logic has structured input rather than parsing"
-        " text (unstable across `gh` versions)."
-    )
+    # JSON fields: must request createdAt (for OPEN selection rule),
+    # url (for resolve-error sync), closedAt (for CLOSED branches).
+    # Missing any of these makes a downstream branch unimplementable.
+    for field in ("number", "title", "state", "createdAt", "closedAt", "url"):
+        assert field in groundskeeper_text, (
+            f"Step 2.5 --json must include `{field}` field — without"
+            f" it, the agent can't apply a downstream branch correctly."
+        )
     assert "(error_code, component)" in groundskeeper_text, (
         "Step 2.5 must name the dedup key as the tuple"
         " `(error_code, component)`, not error_code alone or category"
@@ -483,12 +486,22 @@ def test_groundskeeper_rules_pin_preflight_requirement(
     # If the Rules section doesn't pin the requirement, a future edit
     # could quietly drop the Step 2.5 invocation from the Step 3 flow
     # while leaving the Step 2.5 description intact — silently
-    # reverting #600.
+    # reverting #600. Scope to the Rules block so we catch removals
+    # from there even if the phrase appears elsewhere in the prompt.
     import re
 
+    rules_block = re.search(
+        r"## Rules\s*\n(.*?)(?=\n## |\Z)",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    )
+    assert rules_block is not None, (
+        "groundskeeper.md must contain a `## Rules` section."
+    )
+    rules_body = rules_block.group(1)
     assert re.search(
         r"MUST run Step 2\.5.*before every `gh issue create`",
-        groundskeeper_text,
+        rules_body,
     ), (
         "Rules section must contain a 'MUST run Step 2.5 ... before"
         " every gh issue create' line to enforce the pre-flight check."
@@ -501,8 +514,19 @@ def test_groundskeeper_permits_commenting_on_existing_issues(
     # The old rule "NEVER close or modify existing GitHub issues" was
     # too broad — it forbade the Step 2.5 commenting path. The new
     # rule must explicitly permit comments as the only sanctioned
-    # modification.
-    assert "MAY add comments to existing open issues" in groundskeeper_text, (
+    # modification. Scope to the Rules block.
+    import re
+
+    rules_block = re.search(
+        r"## Rules\s*\n(.*?)(?=\n## |\Z)",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    )
+    assert rules_block is not None, (
+        "groundskeeper.md must contain a `## Rules` section."
+    )
+    rules_body = rules_block.group(1)
+    assert "MAY add comments to existing open issues" in rules_body, (
         "Rules section must permit commenting on open issues as the"
         " only sanctioned modification (#600 Step 2.5 enforcement)."
     )
@@ -522,11 +546,14 @@ def test_groundskeeper_search_query_uses_quoted_terms(
         groundskeeper_text,
         flags=re.DOTALL,
     ).group(0)
-    assert '\'in:title "ERROR_CODE" "COMPONENT"\'' in block, (
-        "Step 2.5 search must use quoted terms scoped to title:"
-        " `'in:title \"ERROR_CODE\" \"COMPONENT\"'`. Unquoted body"
-        " matching pulls in noise that silently suppresses legitimate"
-        " new issues."
+    # ERROR_CODE lives in the title (Step 3 title template), COMPONENT
+    # lives in the body. Both must be quoted so GitHub search doesn't
+    # tokenize on `_`/`-`/`.`.
+    assert '\'in:title "ERROR_CODE" in:body "COMPONENT"\'' in block, (
+        "Step 2.5 search must use quoted terms with `in:title` for"
+        " ERROR_CODE and `in:body` for COMPONENT — the title template"
+        " puts the error_code in the title and the component in the"
+        " body, so the search needs both scopes."
     )
 
 
@@ -605,4 +632,139 @@ def test_groundskeeper_closed_recency_cap_at_30_days(
         "Step 2.5 must define a stale-CLOSED branch (older than 30"
         " days) that treats the match as no-match — otherwise stale"
         " unrelated issues get cited as 'previously resolved'."
+    )
+
+
+def test_groundskeeper_critical_handling_preserves_safety_rule(
+    groundskeeper_text: str,
+) -> None:
+    # Step 2's hard rule says critical + risk_breach MUST file in the
+    # current cycle. The CLOSED-within-24h suppress branch would
+    # violate that for recurring critical incidents. Step 2.5 must
+    # explicitly handle critical/risk_breach: comment-on-existing-
+    # OPEN to avoid duplicates, but always file when CLOSED (any
+    # age) — never suppress.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert "CRITICAL handling" in block, (
+        "Step 2.5 must contain a 'CRITICAL handling' block that"
+        " preserves the file-in-current-cycle safety rule for"
+        " critical/risk_breach."
+    )
+    assert "critical" in block.lower() and "risk_breach" in block, (
+        "CRITICAL handling must name both `critical` severity and"
+        " `risk_breach` category so the safety rule can't be evaded."
+    )
+    assert "never suppress a fresh critical/risk_breach" in block, (
+        "CRITICAL handling must explicitly forbid suppressing fresh"
+        " critical/risk_breach — closing a prior issue should not"
+        " allow a 24h suppression window on the next critical."
+    )
+
+
+def test_groundskeeper_fail_open_behavior_pinned(
+    groundskeeper_text: str,
+) -> None:
+    # The fail-open posture (file possible duplicate on `gh issue
+    # list` failure rather than silently suppress) is load-bearing.
+    # A future edit changing it to fail-closed would silently drop
+    # escalations during GitHub outages.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert "fail-open" in block, (
+        "Step 2.5 must explicitly name the fail-open posture so a"
+        " future edit can't quietly flip to fail-closed."
+    )
+    assert (
+        "proceed to Step 3" in block or "file a possible duplicate" in block.lower()
+    ), (
+        "Fail-open behavior must instruct the agent to proceed to"
+        " Step 3 (file new) when `gh issue list` fails — silent"
+        " suppression is worse than possible-duplicate."
+    )
+
+
+def test_groundskeeper_title_template_includes_error_code(
+    groundskeeper_text: str,
+) -> None:
+    # Step 2.5's `in:title "ERROR_CODE"` search relies on the title
+    # actually carrying the error code. Step 3's title template must
+    # match the exact form `[SEVERITY] Error: ERROR_CODE — ...` so
+    # the literal-substring search hits.
+    import re
+
+    # Pin the full title-template shape so a future edit that
+    # restructures the title (e.g. "Error in COMPONENT: ERROR_CODE")
+    # but keeps the ERROR_CODE substring somewhere doesn't pass
+    # vacuously.
+    assert re.search(
+        r"\[SEVERITY\] Error: ERROR_CODE",
+        groundskeeper_text,
+    ), (
+        "Step 3 issue-title template must use the exact form"
+        " `[SEVERITY] Error: ERROR_CODE — ...` so Step 2.5's literal"
+        " `in:title \"ERROR_CODE\"` search can match"
+        " Groundskeeper-filed issues."
+    )
+
+
+def test_groundskeeper_critical_open_match_comments_not_files(
+    groundskeeper_text: str,
+) -> None:
+    # Without this rule, a sustained risk_breach over multiple cycles
+    # would re-file every cycle — recreating the #597 → #598 → #599
+    # pattern scoped to criticals. Critical+OPEN must comment, not
+    # file new.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    # Must explicitly cover the "critical + matching issue OPEN" case
+    # and route it to the OPEN-match comment branch.
+    assert "matching issue is OPEN" in block and "comment on it" in block, (
+        "CRITICAL handling must route critical/risk_breach with an"
+        " OPEN matching issue to the comment branch, not to file-new"
+        " — otherwise sustained critical incidents spawn duplicates."
+    )
+
+
+def test_groundskeeper_comment_failure_handling_pinned(
+    groundskeeper_text: str,
+) -> None:
+    # The "rows stay resolved + log phase=warn" comment-failure
+    # handling prevents re-comment loops AND prevents silent loss of
+    # the recurrence notification by surfacing it to operator audit.
+    # Drop either half and the failure mode reappears.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert "If the comment fails after the resolves succeeded" in block, (
+        "Step 2.5 must explicitly handle the case where comment fails"
+        " after resolves succeeded — without it, the recurrence is"
+        " silently dropped."
+    )
+    assert "phase=warn" in block, (
+        "Comment-failure handling must log to activity_log with"
+        " `phase=warn` so operators can audit unfiled recurrences."
+    )
+    assert "operator audit required" in block, (
+        "Comment-failure handling must surface the audit requirement"
+        " in the warn message itself."
     )

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -14,6 +14,7 @@ AGENTS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "agents"
 CADDIE_MASTER = AGENTS_DIR / "caddie-master.md"
 CADDIE = AGENTS_DIR / "caddie.md"
 MONITOR = AGENTS_DIR / "monitor.md"
+GROUNDSKEEPER = AGENTS_DIR / "groundskeeper.md"
 
 
 @pytest.fixture(scope="module")
@@ -29,6 +30,11 @@ def caddie_text() -> str:
 @pytest.fixture(scope="module")
 def monitor_text() -> str:
     return MONITOR.read_text()
+
+
+@pytest.fixture(scope="module")
+def groundskeeper_text() -> str:
+    return GROUNDSKEEPER.read_text()
 
 
 def test_caddie_master_reads_cm_min_edge_after_fees(caddie_master_text: str) -> None:
@@ -389,4 +395,214 @@ def test_monitor_stop_loss_flag_carries_thesis_and_time(
         "Stop-loss bullet must instruct Monitor to use the exact"
         " spelling `Stop-loss breach` for the Trigger value, else step"
         " 4c's literal lockout match can miss case/spacing variants."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Groundskeeper GitHub dedup pre-flight (#600)
+# ---------------------------------------------------------------------------
+
+
+def test_groundskeeper_has_github_dedup_preflight(
+    groundskeeper_text: str,
+) -> None:
+    # Without the pre-flight, Groundskeeper re-files the same
+    # (error_code, component) pattern every time new rows trip the
+    # threshold — the #597 → #598 → #599 cascade on 2026-05-12.
+    assert "Step 2.5" in groundskeeper_text, (
+        "groundskeeper.md must contain a 'Step 2.5' GitHub dedup"
+        " pre-flight section between Step 2 and Step 3 (#600)."
+    )
+    assert "gh issue list --state all --label bug --search" in groundskeeper_text, (
+        "Step 2.5 must use `gh issue list --state all --label bug"
+        " --search ...` to find both open and closed matching issues."
+    )
+    assert "--json number,title,state,closedAt" in groundskeeper_text, (
+        "Step 2.5 must request JSON output with state + closedAt so"
+        " the branching logic has structured input rather than parsing"
+        " text (unstable across `gh` versions)."
+    )
+    assert "(error_code, component)" in groundskeeper_text, (
+        "Step 2.5 must name the dedup key as the tuple"
+        " `(error_code, component)`, not error_code alone or category"
+        " alone."
+    )
+
+
+def test_groundskeeper_dedup_branches_all_three_states(
+    groundskeeper_text: str,
+) -> None:
+    # The Step 2.5 block must explicitly handle all three branches:
+    # OPEN match → comment, CLOSED-recent → suppress, CLOSED-stale →
+    # file new with citation. Scope assertions to the Step 2.5 block
+    # so a future edit can't pass vacuously by mentioning these
+    # keywords in an unrelated section.
+    import re
+
+    block_match = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    )
+    assert block_match is not None, (
+        "Step 2.5 section must exist as a level-3 heading between"
+        " other level-3 headings or before the next level-2 heading."
+    )
+    block = block_match.group(0)
+
+    assert "state: OPEN" in block and "gh issue comment" in block, (
+        "OPEN-match branch must instruct Groundskeeper to comment on"
+        " the existing issue rather than file a new one."
+    )
+    assert "state: CLOSED" in block and "within last 24h" in block, (
+        "CLOSED-within-24h branch must suppress (allow fix to"
+        " propagate)."
+    )
+    assert "older than 24h" in block and "cooldown" in block, (
+        "CLOSED-older-than-24h branch must file new with cooldown"
+        " framing so recurrence after fix is operationally"
+        " distinguishable from initial discovery."
+    )
+
+
+def test_groundskeeper_forbids_dedup_on_error_code_alone(
+    groundskeeper_text: str,
+) -> None:
+    # error_code alone over-suppresses unrelated components (e.g.,
+    # `position_not_found` from cli.position-context vs from the
+    # autonomous-loop order path are different bugs but share the
+    # error_code). Tuple-keyed dedup is load-bearing.
+    assert "NEVER dedup on `error_code` alone" in groundskeeper_text, (
+        "Step 2.5 must explicitly forbid error_code-alone dedup."
+    )
+
+
+def test_groundskeeper_rules_pin_preflight_requirement(
+    groundskeeper_text: str,
+) -> None:
+    # If the Rules section doesn't pin the requirement, a future edit
+    # could quietly drop the Step 2.5 invocation from the Step 3 flow
+    # while leaving the Step 2.5 description intact — silently
+    # reverting #600.
+    import re
+
+    assert re.search(
+        r"MUST run Step 2\.5.*before every `gh issue create`",
+        groundskeeper_text,
+    ), (
+        "Rules section must contain a 'MUST run Step 2.5 ... before"
+        " every gh issue create' line to enforce the pre-flight check."
+    )
+
+
+def test_groundskeeper_permits_commenting_on_existing_issues(
+    groundskeeper_text: str,
+) -> None:
+    # The old rule "NEVER close or modify existing GitHub issues" was
+    # too broad — it forbade the Step 2.5 commenting path. The new
+    # rule must explicitly permit comments as the only sanctioned
+    # modification.
+    assert "MAY add comments to existing open issues" in groundskeeper_text, (
+        "Rules section must permit commenting on open issues as the"
+        " only sanctioned modification (#600 Step 2.5 enforcement)."
+    )
+
+
+def test_groundskeeper_search_query_uses_quoted_terms(
+    groundskeeper_text: str,
+) -> None:
+    # GitHub search tokenizes on `_`, `-`, `.` — unquoted error_codes
+    # like `position_not_found` split into substring tokens and
+    # false-match unrelated issues. The search MUST use quoted terms
+    # restricted to `in:title` to suppress this fuzz.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert '\'in:title "ERROR_CODE" "COMPONENT"\'' in block, (
+        "Step 2.5 search must use quoted terms scoped to title:"
+        " `'in:title \"ERROR_CODE\" \"COMPONENT\"'`. Unquoted body"
+        " matching pulls in noise that silently suppresses legitimate"
+        " new issues."
+    )
+
+
+def test_groundskeeper_selection_rule_prefers_open_over_closed(
+    groundskeeper_text: str,
+) -> None:
+    # If a stale CLOSED match is newer than an OPEN match, the agent
+    # must still pick the OPEN one (and comment), not the CLOSED one
+    # (and re-file). Without this rule, a reopen-then-close history
+    # silently breaks the dedup.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert "Match selection rule" in block, (
+        "Step 2.5 must define a 'Match selection rule' for the"
+        " multiple-match case."
+    )
+    assert (
+        "ANY match has `state: OPEN`" in block
+        and "take the most recently-created OPEN match" in block
+    ), (
+        "Selection rule must give OPEN matches priority over CLOSED"
+        " regardless of which was more recently created/closed."
+    )
+
+
+def test_groundskeeper_open_match_resolves_before_commenting(
+    groundskeeper_text: str,
+) -> None:
+    # If `gh issue comment` runs before `gimmes resolve-error` and the
+    # resolve fails, the next cycle re-trips the threshold (because
+    # the row is still unresolved locally), finds the same open
+    # issue, and posts a duplicate comment. Idempotency requires
+    # resolve-error FIRST, then comment only after success.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert "FIRST run `gimmes resolve-error" in block, (
+        "OPEN-match branch must run `gimmes resolve-error` FIRST"
+        " before posting the comment, so the local field is synced"
+        " before the comment lands."
+    )
+    assert (
+        "SKIP the comment for that row" in block
+        or "never comment without successful resolve" in block
+    ), (
+        "OPEN-match branch must explicitly skip the comment if"
+        " resolve-error fails — otherwise the next cycle re-comments"
+        " indefinitely."
+    )
+
+
+def test_groundskeeper_closed_recency_cap_at_30_days(
+    groundskeeper_text: str,
+) -> None:
+    # Without a recency cap, the "CLOSED older than 24h" branch fires
+    # on months-old unrelated issues that happen to token-match. New
+    # issue body would cite a stale unrelated issue as "previously
+    # resolved" — misleading audit trail. Cap at 30 days.
+    import re
+
+    block = re.search(
+        r"### Step 2\.5:.*?(?=\n### |\n## )",
+        groundskeeper_text,
+        flags=re.DOTALL,
+    ).group(0)
+    assert "older than 30 days" in block, (
+        "Step 2.5 must define a stale-CLOSED branch (older than 30"
+        " days) that treats the match as no-match — otherwise stale"
+        " unrelated issues get cited as 'previously resolved'."
     )


### PR DESCRIPTION
## Summary

Closes the recurrence-noise pattern where the same `(error_code, component)` tuple produced #597 → #598 → #599 in <4 hours on 2026-05-12. Root cause: Groundskeeper's existing "suppress if already linked to an open issue" check relied on the local `error_log.github_issue_url` field, which is only set AFTER filing. Newly-arriving rows always carry an empty `github_issue_url` and trip the threshold in isolation, with no way to know an existing issue covers the pattern.

## Fix

Adds a new **Step 2.5: GitHub dedup pre-flight check** between Step 2 and Step 3 in `.claude/agents/groundskeeper.md`. Before any `gh issue create`, Groundskeeper queries GitHub directly for an existing matching issue:

```bash
gh issue list --state all --label bug --search 'in:title "ERROR_CODE" "COMPONENT"' --json number,title,state,closedAt --limit 10
```

Branches on the match:

| Match state | Action |
|---|---|
| None | File new (Step 3 unchanged) |
| OPEN | `gimmes resolve-error` first, then ONE consolidated comment on the existing issue |
| CLOSED within 24h | Suppress + resolve against closed URL (let the fix propagate) |
| CLOSED 24h–30d | File new with citation to prior closed issue |
| CLOSED >30d | No citation (too stale to be operationally relevant) |

**Guardrails from review pipeline:**

- **Match selection rule** — if ANY match is OPEN, take it (don't get fooled by a stale CLOSED match that's created-newer)
- **Idempotency** — resolve-error runs FIRST so the local field is synced before the comment lands; if resolve-error fails, skip the comment for that row (next cycle Step 2 will catch it)
- **Quoted search terms scoped to `in:title`** — GitHub search tokenizes on `_`/`-`/`.`, so unquoted `position_not_found` would split into substring tokens and false-match unrelated issues
- **30-day recency cap on CLOSED matches** — prevents months-old unrelated issues from being cited as "previously resolved"
- **Fail-open** on `gh issue list` failure — file possibly-duplicate rather than miss a recurring pattern; documented as a trade-off

**Rules section updated** (`.claude/agents/groundskeeper.md`):
- Explicitly permits commenting on open issues (the only sanctioned modification — the prior "NEVER close or modify" rule was too broad)
- Adds "MUST run Step 2.5 before every `gh issue create`"

Closes #600

## Test plan

- [x] **9 new drift-guard tests** in `tests/unit/test_agent_prompts.py`:
  1. Pre-flight invocation + JSON fields + (error_code, component) tuple naming
  2. Three-branch coverage (OPEN comment / CLOSED-recent suppress / CLOSED-stale file-new) — regex-scoped to Step 2.5 block
  3. Forbids error_code-alone dedup
  4. Rules section pins "MUST run Step 2.5 before every gh issue create"
  5. Rules section permits commenting on open issues
  6. Search query uses quoted terms scoped to `in:title`
  7. Selection rule prefers OPEN over CLOSED
  8. resolve-error runs before commenting (idempotency)
  9. 30-day recency cap on CLOSED matches
- [x] `uv run pytest tests/unit/test_agent_prompts.py` — 24 passed (was 15)
- [x] `uv run ruff check` — clean
- [x] Reviewed by code-reviewer (caught selection-rule under-specification — fixed with "ANY OPEN takes priority"), silent-failure-hunter (caught 4 silent failures: search tokenization, comment-resolve sequencing, stale CLOSED citations, fail-open recreating #600 — all addressed inline), pr-test-analyzer (caught untested branches and string-brittleness — added 4 of the additional tests)