### PR TITLE
Fix #589: file-input variants for prose CLI args

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -133,19 +133,24 @@ After Monitor returns, review its report. For each position Monitor flagged:
 
    Canonical anti-pattern to avoid: KXGDP-26APR30-T2.5 (cycles 1199-1200), where a thesis-intact position was force-closed on a 104%-of-stop-loss breach and re-opened 26 minutes later on the same ticker — a round-trip that realized a \$58 loss plus fees plus worse cost basis.
 
-5. **Log your decision to the database BEFORE dispatching Closer** (crash-recovery anchor):
+5. **Log your decision to the database BEFORE dispatching Closer** (crash-recovery anchor). Use the `--body-file` variant via a single-quoted heredoc so prices like `$0.41` and `$VAR` references in the reasoning survive verbatim (#589). The quoted delimiter `<<'GIMMES_EOF'` is load-bearing — it suppresses ALL parameter expansion inside the body:
    ```bash
+   BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+   cat > "$BODY_FILE" <<'GIMMES_EOF'
+   Decision: [HOLD or CLOSE].
+   Reasoning: [your specific reasoning referencing the original thesis and what Monitor reported].
+   Thesis assessment: [was the new information already in the thesis, or does it genuinely change the picture?].
+   Re-evaluate if: [for HOLD only — specific condition, e.g. 'price moves another 8pp adverse' or 'after next CPI release Apr 10' or 'thesis-changing news emerges'].
+   Expiry: [for HOLD only — REQUIRED cycle number to reconsider regardless, use current cycle + 10].
+   GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
      --agent caddie-master \
      --type decision \
-     --body "Decision: [HOLD or CLOSE].
-   Reasoning: [your specific reasoning referencing the original thesis and what Monitor reported].
-   Thesis assessment: [was the new information already in the thesis, or does it genuinely change the picture?].
-   Re-evaluate if: [for HOLD only — specific condition, e.g. 'price moves another 8pp adverse' or 'after next CPI release Apr 10' or 'thesis-changing news emerges'].
-   Expiry: [for HOLD only — REQUIRED cycle number to reconsider regardless, use current cycle + 10]."
+     --body-file "$BODY_FILE"
+   rm -f "$BODY_FILE"
    ```
-   If this command fails, do not proceed with a close — log the failure and move on. For SIZE UP decisions, skip this step — Step 2d has its own decision logging.
+   If this command fails, do not proceed with a close — log the failure and move on. If `mktemp` or the heredoc write itself fails, treat as a logging failure and skip — never fall back to inline `--body`. For SIZE UP decisions, skip this step — Step 2d has its own decision logging.
 
 6. **If the decision is CLOSE**, dispatch Closer after writing the decision note:
    - Cancel any resting orders first: `gimmes cancel ORDER_ID`
@@ -169,15 +174,20 @@ If Monitor flags a position where the current edge has *increased* since entry (
 
 **Execution flow** (mirrors the CLOSE pattern):
 
-1. **Log decision to the database BEFORE dispatching Closer** (crash-recovery anchor):
+1. **Log decision to the database BEFORE dispatching Closer** (crash-recovery anchor). Use the `--body-file` heredoc pattern so prices and `$VAR` references survive verbatim (#589):
    ```bash
+   BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+   cat > "$BODY_FILE" <<'GIMMES_EOF'
+   Decision: SIZE UP.
+   Reasoning: [specific reasoning referencing original thesis and Monitor's flag].
+   Edge assessment: [entry edge vs current edge].
+   GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
      --agent caddie-master \
      --type decision \
-     --body "Decision: SIZE UP.
-   Reasoning: [specific reasoning referencing original thesis and Monitor's flag].
-   Edge assessment: [entry edge vs current edge]."
+     --body-file "$BODY_FILE"
+   rm -f "$BODY_FILE"
    ```
    If this command fails, do not proceed with the size up — log the failure and move on.
 
@@ -219,11 +229,15 @@ Evaluate the output using these rules (where `gimme_threshold` is from Step 0.5,
 **Time-based expiry (check first):** If the prior research `Scanned` timestamp is more than 48 hours ago, treat the candidate as having no prior research — send to Caddie for fresh evaluation regardless of score. The macro environment may have changed significantly since the original assessment.
 
 1. **No prior research** (no records found, or expired per above) → send to Caddie
-2. **Prior score < cooldown_cutoff** (clear PASS) → skip re-research, log the skip:
+2. **Prior score < cooldown_cutoff** (clear PASS) → skip re-research, log the skip via the `--rationale-file` heredoc pattern (#589):
    ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   Cooldown: prior score SCORE (below cutoff), skipping re-research
+   GIMMES_EOF
    gimmes log-trade TICKER --action skip --price 0 --prob 0 --score 0 \
-     --rationale "Cooldown: prior score SCORE (below cutoff), skipping re-research" \
-     --agent caddie-master
+     --rationale-file "$RATIONALE_FILE" --agent caddie-master
+   rm -f "$RATIONALE_FILE"
    ```
 3. **Prior score between cooldown_cutoff and (gimme_threshold - 1)** (borderline) → re-research ONLY if the current market price (from the Scout's shortlist) differs from the prior `Price` by more than 5 cents. Otherwise skip with rationale noting price unchanged.
 4. **Prior score >= gimme_threshold with open position** (check `gimmes positions` for the ticker) → skip, already traded
@@ -251,10 +265,15 @@ Launch the Caddie agent (`caddie.md`) to:
 4. Produce a GimmeScore and research memo
 5. Recommend PROCEED, PASS, or NEEDS MORE RESEARCH
 
-**Verification:** After the Caddie returns (or fails entirely — treat a crash/timeout as zero candidates completed), verify completeness by checking that every ticker from the Scout's shortlist has a "Logged candidate" confirmation in the Caddie's output. If any tickers are missing, re-dispatch the Caddie for the missing tickers only (maximum 1 re-dispatch). If still missing after the retry, log a skip for each remaining ticker so the decision is auditable:
+**Verification:** After the Caddie returns (or fails entirely — treat a crash/timeout as zero candidates completed), verify completeness by checking that every ticker from the Scout's shortlist has a "Logged candidate" confirmation in the Caddie's output. If any tickers are missing, re-dispatch the Caddie for the missing tickers only (maximum 1 re-dispatch). If still missing after the retry, log a skip for each remaining ticker so the decision is auditable (use the `--rationale-file` heredoc pattern, #589):
 ```bash
+RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+Caddie failed to research after retry
+GIMMES_EOF
 gimmes log-trade TICKER --action skip --price 0 --prob 0 --score 0 \
-  --rationale "Caddie failed to research after retry" --agent caddie-master
+  --rationale-file "$RATIONALE_FILE" --agent caddie-master
+rm -f "$RATIONALE_FILE"
 ```
 If a fallback `log-trade` command fails, note the failure in your output and continue. Do not retry failed log commands.
 
@@ -315,36 +334,51 @@ For each PROCEED candidate:
 
    **Cross-threshold consistency (when multiple PROCEED candidates share the same event):** Verify that probability estimates are monotonic — P(metric > low threshold) >= P(metric > high threshold). If probabilities are inconsistent, REJECT ALL candidates from that event and log the inconsistency. When approving multiple thresholds, verify total proposed deployment fits within the event concentration limit (max_event_exposure_pct). Approve only the highest-edge thresholds that fit.
 
-5. **Log the decision BEFORE dispatching Closer** (audit trail):
+5. **Log the decision BEFORE dispatching Closer** (audit trail). Use the `--body-file` heredoc pattern — net-edge citations like "3.2pp" are safe but other prose may contain `$` characters (#589):
    ```bash
-   gimmes position-note TICKER \
-     --cycle $GIMMES_CYCLE \
-     --agent caddie-master \
-     --type decision \
-     --body "Decision: APPROVE for open.
+   BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+   cat > "$BODY_FILE" <<'GIMMES_EOF'
+   Decision: APPROVE for open.
    Reasoning: [specific reasoning referencing the Caddie's research and your conferral].
    Thesis robustness: [survived or did not survive scrutiny — cite the key exchange].
    Signal independence: [confirmed independent or not — explain].
    Portfolio correlation: [none, or describe overlap with existing positions].
-   Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — pass."
-   ```
-   For REJECT decisions:
-   ```bash
+   Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — pass.
+   GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
      --agent caddie-master \
      --type decision \
-     --body "Decision: REJECT for open.
+     --body-file "$BODY_FILE"
+   rm -f "$BODY_FILE"
+   ```
+   For REJECT decisions:
+   ```bash
+   BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+   cat > "$BODY_FILE" <<'GIMMES_EOF'
+   Decision: REJECT for open.
    Reasoning: [specific reasoning — what failed scrutiny].
    Key concern: [the issue that could not be resolved in conferral].
-   Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — [pass/fail]."
+   Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — [pass/fail].
+   GIMMES_EOF
+   gimmes position-note TICKER \
+     --cycle $GIMMES_CYCLE \
+     --agent caddie-master \
+     --type decision \
+     --body-file "$BODY_FILE"
+   rm -f "$BODY_FILE"
    ```
-   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with rationale "Decision note failed to write" and move to the next candidate.
+   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate.
 
-6. **Log rejected candidates as skips** so the decision is auditable:
+6. **Log rejected candidates as skips** so the decision is auditable (use the `--rationale-file` heredoc pattern, #589):
    ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   Caddie Master review: REJECT — [brief reason]
+   GIMMES_EOF
    gimmes log-trade TICKER --action skip --price 0 --prob P --score S \
-     --rationale "Caddie Master review: REJECT — [brief reason]" --agent caddie-master
+     --rationale-file "$RATIONALE_FILE" --agent caddie-master
+   rm -f "$RATIONALE_FILE"
    ```
    If the log-trade command fails, note the failure in your output and continue. Do not retry failed log commands.
 

--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -224,25 +224,36 @@ MUST produce this exact format for each candidate:
 
 ## Logging
 
-For EVERY candidate researched (PROCEED, PASS, and NEEDS MORE RESEARCH), MUST log to the candidates table:
+For EVERY candidate researched (PROCEED, PASS, and NEEDS MORE RESEARCH), MUST log to the candidates table. **Prose arguments must use the `--memo-file` variant via a quoted heredoc** — inline `--memo "..."` exposes dollar-prefixed prices (`$0.41`) and `$VAR` references to shell expansion (#589). The single-quoted heredoc delimiter (`<<'GIMMES_EOF'`) is load-bearing: it suppresses ALL parameter expansion inside the body.
 
 ```bash
+MEMO_FILE=$(mktemp -t gimmes-memo.XXXXXX)
+cat > "$MEMO_FILE" <<'GIMMES_EOF'
+Brief research summary. Prose may contain $0.41, $VAR, `cmd`, or any
+other shell-special characters — none are expanded inside this heredoc.
+GIMMES_EOF
 gimmes log-candidate TICKER \
   --title "Event title" --price 0.XX --prob 0.XX --score NN \
-  --memo "Brief research summary" \
+  --memo-file "$MEMO_FILE" \
   --edge-size NN --signal-strength NN --liquidity-depth NN \
   --settlement-clarity NN --time-to-resolution NN \
   --recommendation "proceed|pass|needs_more_research"
+rm -f "$MEMO_FILE"
 ```
 
-If a `log-candidate` command fails, note the failure in your output and continue. Do not retry.
+If a `log-candidate` command fails, note the failure in your output and continue. Do not retry. If `mktemp` or the heredoc write itself fails, treat as a logging failure and skip — never fall back to inline `--memo`.
 
-Additionally, for each candidate that receives PASS or that remains at NEEDS MORE RESEARCH after re-scoring, MUST log the skip:
+Additionally, for each candidate that receives PASS or that remains at NEEDS MORE RESEARCH after re-scoring, MUST log the skip. Use `--rationale-file` for the same reason:
 
 ```bash
+RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+Caddie: [reason]
+GIMMES_EOF
 gimmes log-trade TICKER --action skip \
   --price 0.XX --prob 0.XX --score NN \
-  --rationale "Caddie: [reason]" --agent caddie
+  --rationale-file "$RATIONALE_FILE" --agent caddie
+rm -f "$RATIONALE_FILE"
 ```
 
 If a `log-trade` skip command fails, note the failure in your output and continue. Do not retry failed log commands.

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -21,8 +21,21 @@ For each approved candidate (GimmeScore >= configured `strategy.gimme_threshold`
 2. **Size**: `gimmes size TICKER --prob P` — MUST run only after validate passes.
 3. **Order**: `gimmes order TICKER --prob P --yes --agent closer` — MUST run only after steps 1-2 pass.
 4. **Log success**: The order command logs the trade and syncs positions atomically — no separate log-trade needed.
-5. **Log rejection** (if steps 1-2 failed): `gimmes log-trade TICKER --action skip --prob P --score S --rationale "[which check failed and why]" --agent closer`. If the command fails, note the failure in your output and continue. Do not retry.
+5. **Log rejection** (if steps 1-2 failed): use the `--rationale-file` variant — see "Writing rationale prose" below — to avoid shell expansion of `$0`, `$VAR`, backticks in the failure reason (#589):
+   ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   [which check failed and why]
+   GIMMES_EOF
+   gimmes log-trade TICKER --action skip --prob P --score S --rationale-file "$RATIONALE_FILE" --agent closer
+   rm -f "$RATIONALE_FILE"
+   ```
+   If the command fails, note the failure in your output and continue. Do not retry.
 6. **Log completion** (see Activity Logging below)
+
+## Writing rationale prose — REQUIRED pattern
+
+The `--rationale-file` variant reads prose from a file path, bypassing argv. The single-quoted heredoc delimiter (`<<'GIMMES_EOF'`) is load-bearing — it suppresses ALL parameter expansion inside the body, so `$0.41`, `$VAR`, and backticks survive verbatim. Never fall back to inline `--rationale "..."` for prose that includes captured CLI output, prices, or any text you didn't author yourself. If `mktemp` or the heredoc write fails, treat as a logging failure and skip — never fall back to the inline form.
 
 ## SIZE UP Execution
 
@@ -32,7 +45,15 @@ When Caddie Master dispatches you for a SIZE UP (adding to an existing position)
 2. **Size**: `gimmes size TICKER --prob P`
 3. **Order**: `gimmes order TICKER --prob P --size-up --yes --agent closer`
 4. **Log success**: The order command logs the trade atomically.
-5. **Log rejection** (if steps 1-2 failed): `gimmes log-trade TICKER --action skip --prob P --score 0 --rationale "SIZE UP rejected: [which check failed]" --agent closer`
+5. **Log rejection** (if steps 1-2 failed): use the `--rationale-file` heredoc pattern (see "Writing rationale prose" above):
+   ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   SIZE UP rejected: [which check failed]
+   GIMMES_EOF
+   gimmes log-trade TICKER --action skip --prob P --score 0 --rationale-file "$RATIONALE_FILE" --agent closer
+   rm -f "$RATIONALE_FILE"
+   ```
 
 All safety checks except the duplicate position check and position count check are still enforced (SIZE UP adds to an existing position, not a new one).
 
@@ -40,11 +61,28 @@ All safety checks except the duplicate position check and position count check a
 
 When Caddie Master dispatches you to CLOSE a position (sell all held contracts), execute this sequence:
 
-1. **Look up position**: Run `gimmes positions` and find the position for TICKER. Note the side and count. If no position exists (already settled or closed), log a skip: `gimmes log-trade TICKER --action skip --rationale "Close skipped: no open position found" --agent closer` and report — do not proceed.
+1. **Look up position**: Run `gimmes positions` and find the position for TICKER. Note the side and count. If no position exists (already settled or closed), log a skip and report — do not proceed:
+   ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   Close skipped: no open position found
+   GIMMES_EOF
+   gimmes log-trade TICKER --action skip --rationale-file "$RATIONALE_FILE" --agent closer
+   rm -f "$RATIONALE_FILE"
+   ```
 2. **Cancel resting orders**: If any resting orders exist for TICKER, cancel them first with `gimmes cancel ORDER_ID --yes`.
 3. **Order**: `gimmes order TICKER --action sell --side SIDE --count COUNT --yes --agent closer` — sell the full held count.
 4. **Log success**: The order command logs the close trade and syncs positions atomically.
-5. **Log failure** (if order fails): `gimmes log-trade TICKER --action skip --rationale "Close order failed: [error from CLI output]" --agent closer`. If the command fails, note the failure in your output and continue. Do not retry.
+5. **Log failure** (if order fails): use the `--rationale-file` heredoc pattern — the `[error from CLI output]` may contain `$` or backticks that would corrupt under inline `--rationale`:
+   ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   Close order failed: [error from CLI output]
+   GIMMES_EOF
+   gimmes log-trade TICKER --action skip --rationale-file "$RATIONALE_FILE" --agent closer
+   rm -f "$RATIONALE_FILE"
+   ```
+   If the command fails, note the failure in your output and continue. Do not retry.
 
 No validate or size step is needed — the order command validates that the position exists and the count is valid. No risk checks apply to sells.
 
@@ -62,7 +100,15 @@ No validate or size step is needed — the order command validates that the posi
 ## Order Failure Protocol
 
 If the order command fails (non-zero exit code or error output), MUST:
-1. Log the failure: `gimmes log-trade TICKER --action skip --prob P --score S --rationale "Order failed: [error from CLI output]" --agent closer`
+1. Log the failure via the `--rationale-file` heredoc pattern — captured CLI output may contain `$` or backticks (#589):
+   ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   Order failed: [error from CLI output]
+   GIMMES_EOF
+   gimmes log-trade TICKER --action skip --prob P --score S --rationale-file "$RATIONALE_FILE" --agent closer
+   rm -f "$RATIONALE_FILE"
+   ```
 2. If the log-trade command itself fails, note the failure in your output and continue. Do not retry failed log commands.
 3. Report the failure in the Execution Report
 4. NEVER retry in this cycle

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -50,33 +50,45 @@ A trigger condition means Caddie Master should look at this position. It does NO
 
 After reading `position-context` and completing your analysis, write a **delta observation** — what changed since the prior observation, not a full re-assessment. If no prior observation exists (first cycle for this position), write a full observation.
 
+Use the `--body-file` variant via a single-quoted heredoc so dollar-prefixed prices like `$0.41` survive verbatim (#589). The quoted delimiter `<<'GIMMES_EOF'` is load-bearing — it suppresses ALL parameter expansion inside the body:
+
 ```bash
-gimmes position-note TICKER \
-  --cycle $GIMMES_CYCLE \
-  --agent monitor \
-  --type observation \
-  --body "Delta since cycle [N from prior observation note]:
+BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+cat > "$BODY_FILE" <<'GIMMES_EOF'
+Delta since cycle [N from prior observation note]:
 Price: $X.XX (was $X.XX, moved +/-Npp since last observation).
 News delta: [new developments since last observation, or 'No new developments'].
 Thesis delta: [any change in thesis assessment, or 'Unchanged'].
 Trigger conditions: [NEW triggers only — not triggers already flagged and decided on].
-Overall: [Material change / No material change]."
+Overall: [Material change / No material change].
+GIMMES_EOF
+gimmes position-note TICKER \
+  --cycle $GIMMES_CYCLE \
+  --agent monitor \
+  --type observation \
+  --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
 ```
 
-If the command fails, note the failure in your output and continue. Do not retry.
+If the command fails, note the failure in your output and continue. Do not retry. If `mktemp` or the heredoc write itself fails, treat as a logging failure and skip — never fall back to inline `--body`.
 
 ## Writing Thesis Evolution Notes (when assessment has changed)
 
-After writing the delta observation, compare your current thesis assessment against the most recent `context` note in the position history. If your assessment has changed (strengthened, weakened, or shifted), write a context note:
+After writing the delta observation, compare your current thesis assessment against the most recent `context` note in the position history. If your assessment has changed (strengthened, weakened, or shifted), write a context note (same `--body-file` heredoc pattern, #589):
 
 ```bash
+BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+cat > "$BODY_FILE" <<'GIMMES_EOF'
+Thesis evolution: [strengthened/weakened] since cycle [N].
+What changed: [specific data point or development].
+Current thesis confidence: [high/medium/low].
+GIMMES_EOF
 gimmes position-note TICKER \
   --cycle $GIMMES_CYCLE \
   --agent monitor \
   --type context \
-  --body "Thesis evolution: [strengthened/weakened] since cycle [N].
-What changed: [specific data point or development].
-Current thesis confidence: [high/medium/low]."
+  --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
 ```
 
 Do NOT write a context note if the assessment is unchanged. Track inflection points, not steady state. If the command fails, note the failure and continue.
@@ -103,21 +115,26 @@ When a trigger condition is met, write a flag note in addition to the observatio
 | `Price:` | `Price movement` (adverse only), `Stop-loss breach` | `entry $X -> current $Y (D Npp)` |
 | `TimeToResolution:` | `Stop-loss breach` | integer hours followed by `h` (e.g. `18h`, `2h`). No fractions, no `1d 2h`, no other units. Caddie Master compares this against `< 24` numerically. |
 
-**Template** (replace bracketed placeholders with real values; OMIT entire lines for fields not required by your trigger per the table above):
+**Template** (replace bracketed placeholders with real values; OMIT entire lines for fields not required by your trigger per the table above). The quoted heredoc means dollar-prefixed prices survive literally — no backslash escapes needed (#589):
 
 ```bash
-gimmes position-note TICKER \
-  --cycle $GIMMES_CYCLE \
-  --agent monitor \
-  --type flag \
-  --body "Trigger: [exact name from the trigger-name vocabulary above].
+BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
+cat > "$BODY_FILE" <<'GIMMES_EOF'
+Trigger: [exact name from the trigger-name vocabulary above].
 What changed: [specific price, news, or data point].
 Original thesis said: [quote the relevant portion of the thesis].
 Assessment: [Is this new information the thesis did not account for? Or is this the same data viewed differently? Be precise and honest].
 Thesis: [intact or degraded].
-Price: [entry \$X -> current \$Y (D Npp)].
+Price: [entry $X -> current $Y (D Npp)].
 TimeToResolution: [Nh].
-For Caddie Master: [factual summary of the situation — no recommendation]."
+For Caddie Master: [factual summary of the situation — no recommendation].
+GIMMES_EOF
+gimmes position-note TICKER \
+  --cycle $GIMMES_CYCLE \
+  --agent monitor \
+  --type flag \
+  --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
 ```
 
 Do NOT write: "I recommend closing this position." Do NOT write: "This position should be held." Write what you observed and why you are flagging it. Caddie Master decides what to do.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -42,12 +42,17 @@ Preferred (not required):
 
 ## Skip Logging
 
-**MUST log every skipped candidate** — every candidate evaluated but not shortlisted MUST get a skip log entry. Zero exceptions. Candidates with a quick score below the configured `gimme_threshold` (from step 0) MUST be logged as skips:
+**MUST log every skipped candidate** — every candidate evaluated but not shortlisted MUST get a skip log entry. Zero exceptions. Candidates with a quick score below the configured `gimme_threshold` (from step 0) MUST be logged as skips. Use the `--rationale-file` heredoc pattern so prose containing dollar amounts or `$VAR` references stays intact (#589):
 
 ```bash
+RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+reason for skipping
+GIMMES_EOF
 gimmes log-trade TICKER --action skip \
   --price 0.XX --prob 0.XX --score NN \
-  --rationale "reason for skipping" --agent scout
+  --rationale-file "$RATIONALE_FILE" --agent scout
+rm -f "$RATIONALE_FILE"
 ```
 
 MUST include `--price` (market price), `--prob` (estimated probability if available, else 0), and `--score` (quick score). This data feeds the Missed Opportunity Audit analysis.

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -64,6 +64,71 @@ def _extract_ticker_from_url(exc) -> str | None:  # type: ignore[no-untyped-def]
 _AMBIGUOUS_MATCH_DISPLAY_LIMIT = 20
 
 
+_MAX_PROSE_BYTES = 64 * 1024
+
+
+def _read_prose_file(path: Path, option_name: str) -> str:
+    """Read prose content from a file for --memo-file/--body-file/--rationale-file.
+
+    Bypasses argv entirely so shell expansion of ``$0``, ``$VAR``, backticks,
+    etc. cannot corrupt the stored text (#589). Validates path, size (max
+    64 KiB), and UTF-8 encoding; strips one trailing newline so heredoc-fed
+    files round-trip cleanly. Empty content is treated as a contract
+    violation since the file variant means "I have content to write."
+    """
+    if not path.exists():
+        console.print(f"[red]{option_name}: file not found: {path}[/red]")
+        raise typer.Exit(1)
+    if path.is_dir():
+        console.print(f"[red]{option_name}: path is a directory: {path}[/red]")
+        raise typer.Exit(1)
+    size = path.stat().st_size
+    if size > _MAX_PROSE_BYTES:
+        console.print(
+            f"[red]{option_name}: file too large ({size} bytes,"
+            f" max {_MAX_PROSE_BYTES})[/red]"
+        )
+        raise typer.Exit(1)
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        console.print(f"[red]{option_name}: file is not valid UTF-8: {path}[/red]")
+        raise typer.Exit(1)
+    if content.endswith("\n"):
+        content = content[:-1]
+    if not content.strip():
+        console.print(f"[red]{option_name}: file is empty[/red]")
+        raise typer.Exit(1)
+    return content
+
+
+def _resolve_prose_arg(
+    inline: str,
+    file_path: Path | None,
+    inline_name: str,
+    file_name: str,
+) -> str:
+    """Mutex-resolve inline string vs file-path variants for prose CLI args.
+
+    Both being set is a hard error rather than silent precedence — for an
+    autonomous agent emitting both simultaneously, surfacing the conflict to
+    Groundskeeper is more useful than masking it. Returns the resolved value
+    (may be empty if neither variant was supplied; callers must enforce any
+    "required" semantics themselves).
+    """
+    has_file = file_path is not None
+    has_inline = bool(inline)
+    if has_file and has_inline:
+        console.print(
+            f"[red]{inline_name} and {file_name} are mutually exclusive;"
+            f" specify only one[/red]"
+        )
+        raise typer.Exit(1)
+    if has_file:
+        return _read_prose_file(file_path, file_name)
+    return inline
+
+
 async def _log_cli_error(db, entry) -> None:  # type: ignore[no-untyped-def]
     """Best-effort write to error_log; never raises into the caller.
 
@@ -1873,10 +1938,22 @@ def log_trade(
     prob: float | None = typer.Option(None, "--prob", "-p"),
     score_val: float = typer.Option(0, "--score"),
     rationale: str = typer.Option("", "--rationale", "-r"),
+    rationale_file: Path | None = typer.Option(
+        None, "--rationale-file",
+        help=(
+            "Read rationale from a file (avoids shell expansion of $0, $VAR,"
+            " backticks). Mutually exclusive with --rationale. Use for any"
+            " prose containing dollar amounts or shell-special characters"
+            " (#589)."
+        ),
+    ),
     agent: str = typer.Option("manual", "--agent"),
 ) -> None:
     """Log a trade decision to the database."""
     config = load_config()
+    rationale_val = _resolve_prose_arg(
+        rationale, rationale_file, "--rationale", "--rationale-file",
+    )
 
     async def _log() -> None:
         from gimmes.models.trade import TradeDecision
@@ -1895,7 +1972,7 @@ def log_trade(
             model_probability=0.0 if prob is None else prob,
             gimme_score=score_val,
             edge=(prob - eff) if prob is not None else 0.0,
-            rationale=rationale,
+            rationale=rationale_val,
             agent=agent,
         )
 
@@ -1914,6 +1991,14 @@ def log_candidate(
     prob: float = typer.Option(0, "--prob", "-p", help="Model probability estimate"),
     score_val: float = typer.Option(0, "--score", help="GimmeScore (0-100)"),
     memo: str = typer.Option("", "--memo", "-m", help="Research memo summary"),
+    memo_file: Path | None = typer.Option(
+        None, "--memo-file",
+        help=(
+            "Read memo from a file (avoids shell expansion of $0, $VAR,"
+            " backticks). Mutually exclusive with --memo. Use for any prose"
+            " containing dollar amounts or shell-special characters (#589)."
+        ),
+    ),
     edge_size: float = typer.Option(0, "--edge-size", help="Edge size score"),
     signal_strength: float = typer.Option(0, "--signal-strength", help="Signal strength score"),
     liquidity_depth: float = typer.Option(0, "--liquidity-depth", help="Liquidity depth score"),
@@ -1929,6 +2014,7 @@ def log_candidate(
 ) -> None:
     """Log a scanned candidate to the candidates table."""
     config = load_config()
+    memo_val = _resolve_prose_arg(memo, memo_file, "--memo", "--memo-file")
 
     async def _log() -> None:
         from gimmes.store.database import Database
@@ -1940,7 +2026,7 @@ def log_candidate(
 
         async with Database(config.db_path) as db:
             row_id = await _insert(
-                db, ticker, title, price_val, prob, edge, score_val, memo,
+                db, ticker, title, price_val, prob, edge, score_val, memo_val,
                 edge_size_score=edge_size,
                 signal_strength_score=signal_strength,
                 liquidity_depth_score=liquidity_depth,
@@ -2130,12 +2216,25 @@ def position_note(
         "observation", "--type", "-t",
         help="Note type: observation, flag, decision, context",
     ),
-    body: str = typer.Option(..., "--body", "-b", help="Note content"),
+    body: str = typer.Option("", "--body", "-b", help="Note content"),
+    body_file: Path | None = typer.Option(
+        None, "--body-file",
+        help=(
+            "Read body from a file (avoids shell expansion of $0, $VAR,"
+            " backticks). Mutually exclusive with --body. Use for any prose"
+            " containing dollar amounts or shell-special characters (#589)."
+        ),
+    ),
 ) -> None:
     """Append a note to the position journal."""
     valid_types = ("observation", "flag", "decision", "context")
     if note_type not in valid_types:
         console.print(f"[red]Invalid type '{note_type}': must be one of {valid_types}[/red]")
+        raise typer.Exit(1)
+
+    body_val = _resolve_prose_arg(body, body_file, "--body", "--body-file")
+    if not body_val.strip():
+        console.print("[red]--body or --body-file is required[/red]")
         raise typer.Exit(1)
 
     config = load_config()
@@ -2147,7 +2246,7 @@ def position_note(
         async with Database(config.db_path) as db:
             row_id = await insert_position_note(
                 db, ticker=ticker, cycle=cycle, agent=agent,
-                note_type=note_type, body=body,
+                note_type=note_type, body=body_val,
             )
         console.print(
             f"[green]Logged position note #{row_id}"

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -71,18 +71,27 @@ def _read_prose_file(path: Path, option_name: str) -> str:
     """Read prose content from a file for --memo-file/--body-file/--rationale-file.
 
     Bypasses argv entirely so shell expansion of ``$0``, ``$VAR``, backticks,
-    etc. cannot corrupt the stored text (#589). Validates path, size (max
-    64 KiB), and UTF-8 encoding; strips one trailing newline so heredoc-fed
-    files round-trip cleanly. Empty content is treated as a contract
-    violation since the file variant means "I have content to write."
+    etc. cannot corrupt the stored text (#589). Validates path is a regular
+    file (rejects FIFOs/sockets/devices that could bypass the size check or
+    block indefinitely), size (max 64 KiB), and UTF-8 encoding; strips one
+    trailing newline so heredoc-fed files round-trip cleanly. Empty content
+    is treated as a contract violation since the file variant means "I have
+    content to write."
     """
     if not path.exists():
         console.print(f"[red]{option_name}: file not found: {path}[/red]")
         raise typer.Exit(1)
-    if path.is_dir():
-        console.print(f"[red]{option_name}: path is a directory: {path}[/red]")
+    if not path.is_file():
+        console.print(
+            f"[red]{option_name}: not a regular file: {path}"
+            " (FIFOs, sockets, and device files are rejected)[/red]"
+        )
         raise typer.Exit(1)
-    size = path.stat().st_size
+    try:
+        size = path.stat().st_size
+    except OSError as e:
+        console.print(f"[red]{option_name}: cannot stat {path}: {e}[/red]")
+        raise typer.Exit(1) from e
     if size > _MAX_PROSE_BYTES:
         console.print(
             f"[red]{option_name}: file too large ({size} bytes,"
@@ -91,9 +100,12 @@ def _read_prose_file(path: Path, option_name: str) -> str:
         raise typer.Exit(1)
     try:
         content = path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
+    except UnicodeDecodeError as e:
         console.print(f"[red]{option_name}: file is not valid UTF-8: {path}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
+    except OSError as e:
+        console.print(f"[red]{option_name}: cannot read {path}: {e}[/red]")
+        raise typer.Exit(1) from e
     if content.endswith("\n"):
         content = content[:-1]
     if not content.strip():

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -768,3 +768,54 @@ def test_groundskeeper_comment_failure_handling_pinned(
         "Comment-failure handling must surface the audit requirement"
         " in the warn message itself."
     )
+
+
+def test_no_agent_uses_inline_memo_body_rationale_for_prose() -> None:
+    """Drift-guard for #589: agent prompts must use the `--*-file` variant
+    for the three prose-bearing gimmes CLI args (log-candidate --memo,
+    log-trade --rationale, position-note --body). Inline string variants
+    are vulnerable to shell expansion of $0, $VAR, backticks — corrupts
+    stored agent text at storage time.
+
+    Each forbidden pattern requires the gimmes subcommand to appear in
+    the same logical command before the inline arg — that way ``gh issue
+    create --body "..."`` (which writes to GitHub, not the gimmes DB) and
+    doc text that quotes the forbidden form as a warning don't trip the
+    test. Multi-line bash commands with backslash continuation are
+    collapsed to one line before searching.
+    """
+    import re
+
+    # The `[^`\n]{0,400}?` window bounds the match within a single logical
+    # bash command so a `gimmes log-candidate` in one code block can't
+    # falsely pair with a `--memo "..."` later in the file. The `(?:\s+|=)`
+    # alternation catches both `--memo "x"` and `--memo="x"` forms.
+    forbidden = [
+        (
+            re.compile(r"gimmes\s+log-candidate\b[^`\n]{0,400}?--memo(?:\s+|=)\""),
+            "log-candidate --memo (use --memo-file)",
+        ),
+        (
+            re.compile(
+                r"gimmes\s+log-trade\b[^`\n]{0,400}?--rationale(?:\s+|=)\"",
+            ),
+            "log-trade --rationale (use --rationale-file)",
+        ),
+        (
+            re.compile(r"gimmes\s+position-note\b[^`\n]{0,400}?--body(?:\s+|=)\""),
+            "position-note --body (use --body-file)",
+        ),
+    ]
+    offenders: list[str] = []
+    for agent_file in sorted(AGENTS_DIR.glob("*.md")):
+        text = agent_file.read_text()
+        collapsed = re.sub(r"\\\n\s*", " ", text)
+        for pattern, label in forbidden:
+            if pattern.search(collapsed):
+                offenders.append(f"{agent_file.name}: {label}")
+    assert not offenders, (
+        "Inline prose CLI args are vulnerable to shell expansion of $N"
+        " tokens (#589). Use the *-file variant via a single-quoted"
+        " heredoc instead. Offending sites:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -788,21 +788,32 @@ def test_no_agent_uses_inline_memo_body_rationale_for_prose() -> None:
 
     # The `[^`\n]{0,400}?` window bounds the match within a single logical
     # bash command so a `gimmes log-candidate` in one code block can't
-    # falsely pair with a `--memo "..."` later in the file. The `(?:\s+|=)`
-    # alternation catches both `--memo "x"` and `--memo="x"` forms.
+    # falsely pair with a `--memo "..."` later in the file.
+    #
+    # Each forbidden arg is matched by `--<arg>\b(?!-file)` — the negative
+    # lookahead lets `--memo-file` / `--rationale-file` / `--body-file`
+    # through while forbidding bare `--memo` / `--rationale` / `--body` in
+    # any form: double-quoted (`--memo "x"`), single-quoted (`--memo 'x'`),
+    # equals (`--memo=x`), or unquoted (`--memo x`). Single-quoted bash is
+    # technically $-safe, but the file-input variant is the only sanctioned
+    # path — anything else can regress under future quoting refactors.
     forbidden = [
         (
-            re.compile(r"gimmes\s+log-candidate\b[^`\n]{0,400}?--memo(?:\s+|=)\""),
+            re.compile(
+                r"gimmes\s+log-candidate\b[^`\n]{0,400}?--memo\b(?!-file)",
+            ),
             "log-candidate --memo (use --memo-file)",
         ),
         (
             re.compile(
-                r"gimmes\s+log-trade\b[^`\n]{0,400}?--rationale(?:\s+|=)\"",
+                r"gimmes\s+log-trade\b[^`\n]{0,400}?--rationale\b(?!-file)",
             ),
             "log-trade --rationale (use --rationale-file)",
         ),
         (
-            re.compile(r"gimmes\s+position-note\b[^`\n]{0,400}?--body(?:\s+|=)\""),
+            re.compile(
+                r"gimmes\s+position-note\b[^`\n]{0,400}?--body\b(?!-file)",
+            ),
             "position-note --body (use --body-file)",
         ),
     ]

--- a/tests/unit/test_data_collection.py
+++ b/tests/unit/test_data_collection.py
@@ -560,6 +560,7 @@ class TestShellTokenizationE2E:
         import os
         import sqlite3
         import subprocess
+        import sys
 
         memo_file = tmp_path / "memo.txt"
         memo_file.write_text("Market prices YES at $0.41")
@@ -571,15 +572,17 @@ class TestShellTokenizationE2E:
         env["GIMMES_HOME"] = str(tmp_path)
         env.pop("GIMMES_CONFIG", None)
 
-        repo_root = Path(__file__).resolve().parents[2]
+        # Invoke via `sys.executable -m gimmes` rather than `uv run gimmes`:
+        # avoids nested uv overhead, no external binary dependency, and
+        # still goes through a real /bin/sh so argv tokenization happens
+        # in a real shell — the exact failure mode from #589.
         cmd = (
-            f"uv run gimmes log-candidate REPRO-589-E2E "
+            f'"{sys.executable}" -m gimmes log-candidate REPRO-589-E2E '
             f"--price 0.41 --prob 0.50 --score 78 "
             f'--memo-file "{memo_file}"'
         )
         result = subprocess.run(
             ["/bin/sh", "-c", cmd],
-            cwd=repo_root,
             env=env,
             capture_output=True,
             text=True,

--- a/tests/unit/test_data_collection.py
+++ b/tests/unit/test_data_collection.py
@@ -289,3 +289,318 @@ class TestLogCandidateCommand:
         _, ticker, title, price, prob, edge, score, memo = mock_insert.call_args[0]
         assert ticker == "EDGE-TEST"
         assert abs(edge - 0.20) < 1e-9
+
+    def test_memo_file_preserves_dollar_zero(self, tmp_path: Path) -> None:
+        """Regression test for #589: --memo-file content with `$0.41` reaches
+        the DB literally, not shell-expanded to `/bin/zsh.41`."""
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        memo_file = tmp_path / "memo.txt"
+        memo_file.write_text(
+            "Market prices YES at $0.41 even though base rate is 38%.\n"
+            "Includes $VAR and `cmd` characters that should survive.",
+        )
+
+        mock_insert = AsyncMock(return_value=1)
+        runner = CliRunner()
+        with (
+            patch("gimmes.cli.load_config") as mock_cfg,
+            patch("gimmes.store.queries.insert_candidate", mock_insert),
+        ):
+            mock_cfg.return_value.db_path = tmp_path / "test.db"
+            result = runner.invoke(app, [
+                "log-candidate", "REPRO-589",
+                "--price", "0.41", "--prob", "0.50", "--score", "78",
+                "--memo-file", str(memo_file),
+            ])
+
+        assert result.exit_code == 0, result.output
+        _, _ticker, _title, _price, _prob, _edge, _score, memo = (
+            mock_insert.call_args[0]
+        )
+        assert "$0.41" in memo
+        assert "$VAR" in memo
+        assert "`cmd`" in memo
+        assert "/bin/zsh" not in memo
+
+    def test_memo_and_memo_file_mutex(self, tmp_path: Path) -> None:
+        """Specifying both --memo and --memo-file is a hard error (#589)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        memo_file = tmp_path / "memo.txt"
+        memo_file.write_text("file content")
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "log-candidate", "MUTEX-TEST",
+            "--price", "0.50", "--prob", "0.60", "--score", "70",
+            "--memo", "inline content",
+            "--memo-file", str(memo_file),
+        ])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_memo_file_not_found(self, tmp_path: Path) -> None:
+        """Missing --memo-file path raises a clear error (#589)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "log-candidate", "MISSING-FILE",
+            "--price", "0.50", "--prob", "0.60", "--score", "70",
+            "--memo-file", str(tmp_path / "does-not-exist.txt"),
+        ])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_memo_file_empty_rejected(self, tmp_path: Path) -> None:
+        """An empty --memo-file is a contract violation (#589)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        memo_file = tmp_path / "empty.txt"
+        memo_file.write_text("")
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "log-candidate", "EMPTY-FILE",
+            "--price", "0.50", "--prob", "0.60", "--score", "70",
+            "--memo-file", str(memo_file),
+        ])
+        assert result.exit_code == 1
+        assert "empty" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# log-trade --rationale-file (mirror tests for #589 — same risk surface as
+# --memo-file but distinct wiring in log_trade)
+# ---------------------------------------------------------------------------
+
+
+class TestLogTradeRationaleFile:
+    def test_rationale_file_preserves_dollar_zero(self, tmp_path: Path) -> None:
+        """Regression for #589: --rationale-file content with `$0.41` reaches
+        the trades.rationale column literally."""
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        rationale_file = tmp_path / "rationale.txt"
+        rationale_file.write_text(
+            "Close order failed: error at $0.41 with `cmd` substitution\n"
+            "Includes $VAR reference that should survive.",
+        )
+
+        mock_insert = AsyncMock(return_value=1)
+        runner = CliRunner()
+        with (
+            patch("gimmes.cli.load_config") as mock_cfg,
+            patch("gimmes.store.queries.insert_trade", mock_insert),
+        ):
+            mock_cfg.return_value.db_path = tmp_path / "test.db"
+            mock_cfg.return_value.strategy.side = "no"
+            result = runner.invoke(app, [
+                "log-trade", "REPRO-589",
+                "--action", "skip",
+                "--price", "0.41", "--prob", "0.50", "--score", "78",
+                "--rationale-file", str(rationale_file),
+            ])
+
+        assert result.exit_code == 0, result.output
+        trade_arg = mock_insert.call_args[0][1]
+        assert "$0.41" in trade_arg.rationale
+        assert "$VAR" in trade_arg.rationale
+        assert "`cmd`" in trade_arg.rationale
+        assert "/bin/zsh" not in trade_arg.rationale
+
+    def test_rationale_and_rationale_file_mutex(self, tmp_path: Path) -> None:
+        """Both --rationale and --rationale-file → exit 1 (#589)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        rationale_file = tmp_path / "rationale.txt"
+        rationale_file.write_text("file content")
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "log-trade", "MUTEX",
+            "--action", "skip",
+            "--price", "0.50", "--prob", "0.60", "--score", "70",
+            "--rationale", "inline content",
+            "--rationale-file", str(rationale_file),
+        ])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# position-note --body-file (mirror tests for #589 — distinct wiring in
+# position_note including the relaxed-required check)
+# ---------------------------------------------------------------------------
+
+
+class TestPositionNoteBodyFile:
+    def test_body_file_preserves_dollar_zero(self, tmp_path: Path) -> None:
+        """Regression for #589: --body-file content with `$0.41` reaches
+        the position_notes.body column literally."""
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        body_file = tmp_path / "body.txt"
+        body_file.write_text(
+            "Decision: HOLD.\n"
+            "Reasoning: price moved to $0.41 but thesis intact.\n"
+            "Includes $VAR and `cmd` characters that should survive.",
+        )
+
+        mock_insert = AsyncMock(return_value=1)
+        runner = CliRunner()
+        with (
+            patch("gimmes.cli.load_config") as mock_cfg,
+            patch("gimmes.store.queries.insert_position_note", mock_insert),
+        ):
+            mock_cfg.return_value.db_path = tmp_path / "test.db"
+            result = runner.invoke(app, [
+                "position-note", "REPRO-589",
+                "--cycle", "1",
+                "--agent", "caddie-master",
+                "--type", "decision",
+                "--body-file", str(body_file),
+            ])
+
+        assert result.exit_code == 0, result.output
+        body_arg = mock_insert.call_args.kwargs["body"]
+        assert "$0.41" in body_arg
+        assert "$VAR" in body_arg
+        assert "`cmd`" in body_arg
+        assert "/bin/zsh" not in body_arg
+
+    def test_body_and_body_file_mutex(self, tmp_path: Path) -> None:
+        """Both --body and --body-file → exit 1 (#589)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        body_file = tmp_path / "body.txt"
+        body_file.write_text("file content")
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "position-note", "MUTEX",
+            "--cycle", "1",
+            "--body", "inline content",
+            "--body-file", str(body_file),
+        ])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_neither_body_nor_body_file_required(self, tmp_path: Path) -> None:
+        """When neither --body nor --body-file is given, exit 1 with a
+        clear error (#589 — replaces the old required-Option contract)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "position-note", "NEITHER",
+            "--cycle", "1",
+        ])
+        assert result.exit_code == 1
+        assert "required" in result.output.lower()
+
+    def test_whitespace_only_body_rejected(self, tmp_path: Path) -> None:
+        """`--body "   "` (whitespace-only) must NOT silently write — the
+        in-function check strips before checking (#589)."""
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, [
+            "position-note", "WHITESPACE",
+            "--cycle", "1",
+            "--body", "   \n  ",
+        ])
+        assert result.exit_code == 1
+        assert "required" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end shell-tokenization regression (#589 — the strongest possible
+# proof: invoke the actual CLI binary through a real shell with the value
+# inside double quotes, verify $0 expansion does NOT corrupt the stored
+# memo).
+# ---------------------------------------------------------------------------
+
+
+class TestShellTokenizationE2E:
+    def test_memo_file_survives_real_shell_with_dollar_zero(
+        self, tmp_path: Path,
+    ) -> None:
+        """Invoke `gimmes log-candidate --memo-file ...` through /bin/sh so
+        argv tokenization happens in a real shell — the exact failure mode
+        from #589. Asserts the stored memo contains literal `$0.41`.
+
+        Strongest possible regression: if some future change re-routes the
+        memo through a shell command line, this test would catch the
+        corruption because the value is read from the production CLI binary,
+        not the in-process CliRunner."""
+        import os
+        import sqlite3
+        import subprocess
+
+        memo_file = tmp_path / "memo.txt"
+        memo_file.write_text("Market prices YES at $0.41")
+
+        # GIMMES_HOME steers the default db_path to tmp_path/gimmes.db
+        # (see config.py:18 + 975). The CLI's `Database(...)` context
+        # manager auto-creates the schema on first connect.
+        env = os.environ.copy()
+        env["GIMMES_HOME"] = str(tmp_path)
+        env.pop("GIMMES_CONFIG", None)
+
+        repo_root = Path(__file__).resolve().parents[2]
+        cmd = (
+            f"uv run gimmes log-candidate REPRO-589-E2E "
+            f"--price 0.41 --prob 0.50 --score 78 "
+            f'--memo-file "{memo_file}"'
+        )
+        result = subprocess.run(
+            ["/bin/sh", "-c", cmd],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, (
+            f"CLI failed: stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+        db_path = tmp_path / "gimmes.db"
+        assert db_path.exists(), f"DB not created at {db_path}"
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT research_memo FROM candidates WHERE ticker = ?",
+                ("REPRO-589-E2E",),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None, "candidate row not written"
+        stored_memo = row[0]
+        assert "$0.41" in stored_memo, f"got: {stored_memo!r}"
+        assert "/bin/zsh" not in stored_memo, f"got: {stored_memo!r}"


### PR DESCRIPTION
## Summary

Closes #589 — autonomous agents emitting `gimmes log-candidate --memo "Market at \$0.41"` had their `$0` expanded to the shell name (`/bin/zsh`) before the CLI ever ran, corrupting stored memos, rationales, and decision-note bodies. The DB literally contained `/bin/zsh.41` for affected rows. Same risk on `log-trade --rationale` and `position-note --body`.

This PR closes the storage-time corruption by taking the prose value out of `argv` entirely.

## What changed

**CLI (`src/gimmes/cli.py`)**
- Added `_read_prose_file()` and `_resolve_prose_arg()` helpers near line 67. Validates path, size (≤64 KiB), UTF-8, non-empty (after stripping one trailing newline so heredocs round-trip cleanly). Mutex with the inline variant is a hard error rather than silent precedence.
- Added `--memo-file` to `log-candidate`, `--rationale-file` to `log-trade`, `--body-file` to `position-note`.
- Relaxed `position-note --body` from required to "at least one of --body / --body-file" with `.strip()` to reject whitespace-only.

**Agent prompts** (`caddie`, `caddie-master`, `closer`, `monitor`, `scout`) — all 16+ prose-arg sites now use:
```bash
VAR_FILE=$(mktemp -t gimmes-foo.XXXXXX)
cat > "$VAR_FILE" <<'GIMMES_EOF'
prose containing $0.41, $VAR, \`cmd\` — all survive literally
GIMMES_EOF
gimmes ... --foo-file "$VAR_FILE"
rm -f "$VAR_FILE"
```
The single-quoted heredoc delimiter (`<<'GIMMES_EOF'`) is load-bearing: it suppresses ALL parameter expansion inside the body.

**Tests**
- `TestShellTokenizationE2E::test_memo_file_survives_real_shell_with_dollar_zero` — invokes the actual `gimmes` binary via `/bin/sh -c` with `$0.41` in the memo file; reads the SQLite row directly and asserts the literal `$0.41` is stored (and `/bin/zsh` is not). Strongest possible regression.
- In-process `CliRunner` mirror tests for all three commands (`TestLogCandidateCommand`, `TestLogTradeRationaleFile`, `TestPositionNoteBodyFile`): preserves-`\$0`, mutex, file-not-found, empty-file, whitespace-only-body, "neither supplied" branches.
- `test_no_agent_uses_inline_memo_body_rationale_for_prose` drift-guard scans `.claude/agents/*.md` for the gimmes-specific inline pattern (catches both `--memo "x"` and `--memo="x"` forms; bounded match window prevents cross-block false positives; `gh issue --body` and doc-warning text correctly excluded).

## Existing corrupted rows

Not repaired. The corruption was lossy — `$0.41` and `$5.41` both became `/bin/zsh.41`; the digit between `$` and `.` cannot be recovered. Most useful prose is from recent cycles and will be regenerated; older corrupted rows are write-only audit trail.

## Test plan

- [x] `uv run pytest tests/unit/` — all 1386 tests pass (incl. 12 new)
- [x] `uv run ruff check src/gimmes/cli.py tests/unit/...` — clean
- [x] Drift-guard catches inline patterns in any agent .md
- [x] E2E shell test proves `$0.41` survives end-to-end through real `/bin/sh`