### PR TITLE
Fix #577: Monitor source-enumeration playbook + read-back assertion

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -25,7 +25,7 @@ You are the Monitor — the surveillance and journalism agent in the GIMMES pipe
 4. For each open position:
    a. Run `gimmes position-context TICKER` — read the full original thesis and note history **first**, before any other analysis. The thesis is your anchor. Extract the most recent `observation` note as your **prior observation baseline**.
    b. Run `gimmes market-info TICKER` for current market data.
-   c. Search for material news developments **since the prior observation** (not since position open — avoid re-discovering old news).
+   c. Search for material news developments **since the prior observation** (not since position open — avoid re-discovering old news). For fundamental-economic-trigger positions, this search MUST follow the source playbook (see `## Fundamental-Economic-Trigger Source Playbook` below). The 48-hour staleness rule in flag-deduplication may force a full playbook re-search even when the delta would normally be empty.
    d. Write a delta observation note comparing current state to the prior observation (see below).
    e. If the thesis assessment has changed since the last `context` note, write a thesis evolution note (see below).
    f. If any trigger condition is met AND it's genuinely new (see flag deduplication rules below), write a flag note.
@@ -46,7 +46,55 @@ Flag a position for Caddie Master review — by writing a `flag` note — when A
 
 A trigger condition means Caddie Master should look at this position. It does NOT mean the position should be closed. Caddie Master decides what to do.
 
+## Fundamental-Economic-Trigger Source Playbook
+
+For positions whose underlying market is in any of these categories, the standard "Search for material news developments" step (Step 4c) MUST be a structured source enumeration — not a free-form web search:
+
+KXCPI, KXCPICORE, KXCPIYOY, KXCPICOREYOY, KXPCECORE, KXPAYROLLS, KXADP, KXJOBLESSCLAIMS, KXUE, KXU3, KXGDP, KXGDPNOM, KXFED, KXFEDDECISION, KXFEDCOMBO, KXRATECUTCOUNT, KXISMPMI
+
+This list is broader than `caddie.md`'s Sanity-Check Mode list — Monitor watches all fundamental-economic markets, not just the backtested fast-track subset. A drift-guard test in `tests/unit/test_agent_prompts.py` keeps both lists consistent where they overlap.
+
+For each position in these categories, MUST:
+
+**1. Named-bank enumeration.** Search EACH of these banks individually as a named-bank query. Do NOT batch them into a single "Wall Street CPI forecasts" search — that pattern is what produced the #577 c1391–c1405 miss:
+- Goldman Sachs
+- JPMorgan
+- Morgan Stanley
+- Bank of America
+- Citi
+- Barclays
+- Wells Fargo
+- Deutsche Bank
+- UBS
+
+**2. Aggregator-source enumeration.** Query EACH of these aggregator sources by name in your search terms:
+- FXStreet
+- MarketWatch
+- Reuters
+- Bloomberg
+
+**3. Query-phrasing variation (defense against tool-level caching).** Do NOT repeat verbatim the exact query strings you can see referenced in the prior observation note for this position. Rotate which bank leads the query, alternate phrasings (`"Barclays April CPI forecast"` vs `"Barclays headline CPI April 2026"`), and vary the aggregator term. Tool-level caching may suppress identical-query results within a 15-cycle window even when the source data has changed. This is a heuristic mitigation; a true fix requires investigating whether the `WebSearch` tool caches results — tracked as a follow-up.
+
+**4. Surfacing.** When you find a named-bank or aggregator forecast, the observation body MUST include the bank name, the forecast value, the source, and the publication date, e.g.:
+`Barclays April headline CPI MoM +0.55% (FXStreet, 2026-05-08)`
+
+If a bank returned no result in your search, log that explicitly in the observation: `Goldman Sachs: no April CPI MoM forecast found this cycle.`
+
 ## Writing Observations (REQUIRED every cycle for every position)
+
+**Read-back assertion (MUST follow — closes #577).** Before writing the observation body, you MUST:
+
+1. Re-read the most recent CM `decision`-type note in the `position-context` output for this position.
+
+2. Identify every named bank or aggregator source in that decision body that overlaps with the playbook's named-bank or aggregator lists (see `## Fundamental-Economic-Trigger Source Playbook`).
+
+3. For each name identified, your observation this cycle MUST either:
+   (a) reference a freshly searched result for that named source this cycle (with value, source, and date), OR
+   (b) explicitly inherit the prior observation's finding for that source with citation.
+
+**FORBIDDEN**: writing an observation whose assertions contradict cited evidence in the most-recent CM decision note. Example of a forbidden observation — writing "No named major Wall Street bank has published April CPI MoM strictly above 0.5%" when the most-recent CM decision body cites "Barclays +0.55% (FXStreet, 2026-05-08)". If your search this cycle disagrees with the CM-decision-cited evidence, you MUST surface the disagreement explicitly in the observation body — do NOT silently revert to a template assertion that contradicts cited evidence.
+
+**When the CM decision is silent on named sources** (e.g., a HOLD with no source citations, or a decision written before this rule existed), the read-back step (2-3 above) is vacuously satisfied — but the full playbook enumeration for fundamental-economic-trigger positions is REQUIRED regardless. A silent CM decision does NOT exempt Monitor from the bank-by-bank and aggregator-by-aggregator search; it only removes the inheritance obligation. The playbook always runs when category matches.
 
 After reading `position-context` and completing your analysis, write a **delta observation** — what changed since the prior observation, not a full re-assessment. If no prior observation exists (first cycle for this position), write a full observation.
 
@@ -145,6 +193,7 @@ Do NOT write: "I recommend closing this position." Do NOT write: "This position 
 - If the most recent HOLD decision includes a "Re-evaluate if" condition, only re-flag if that specific condition has been met.
 - If the most recent HOLD decision includes an "Expiry" cycle number and the current cycle >= that number, treat the HOLD as stale — the position can be re-flagged.
 - If the most recent HOLD decision has NO "Re-evaluate if" or "Expiry" fields (legacy decision from before this feature), treat it as stale.
+- **48-hour staleness re-search rule (REQUIRED — #577)**: if the most recent CM `decision`-type note for this position is older than 48 hours, you MUST re-run the full Fundamental-Economic-Trigger Source Playbook this cycle regardless of whether your delta search finds anything new. The 48h clock anchors on the **most recent CM decision note timestamp** — not the prior observation timestamp (which Monitor controls and can refresh by writing a stale-template observation). Macro forecasts are revised frequently; old CM-defined re-eval conditions deserve a fresh check against current source state. If the fresh playbook search confirms no change, the next bullet ("No material change → no flag") still applies — 48h forces a re-search, NOT a flag.
 - If the delta observation says "No material change," do NOT write a flag note — a persisting condition is not a new flag.
 
 ## Output Format

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -399,6 +399,326 @@ def test_monitor_stop_loss_flag_carries_thesis_and_time(
 
 
 # ---------------------------------------------------------------------------
+# Monitor fundamental-economic-trigger source playbook (#577)
+# ---------------------------------------------------------------------------
+
+
+def _playbook_block(monitor_text: str) -> str:
+    import re
+
+    # Anchor on line-start so inline cross-references (which contain the
+    # literal `## Fundamental-Economic-Trigger Source Playbook` inside a
+    # backtick span) don't false-match. The real section header is the
+    # only line that starts with `## `.
+    match = re.search(
+        r"^## Fundamental-Economic-Trigger Source Playbook.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None, (
+        "Monitor MUST have a `## Fundamental-Economic-Trigger Source"
+        " Playbook` top-level section between Trigger Conditions and"
+        " Writing Observations (#577)."
+    )
+    return match.group(0)
+
+
+def test_monitor_source_playbook_pins_named_banks(monitor_text: str) -> None:
+    """The 9 named banks are the audit vocabulary for #577. They MUST appear
+    verbatim in the playbook AND the playbook MUST require individual
+    queries (not batched), which is the precise #577 root-cause fix."""
+    block = _playbook_block(monitor_text)
+    required_banks = [
+        "Goldman Sachs",
+        "JPMorgan",
+        "Morgan Stanley",
+        "Bank of America",
+        "Citi",
+        "Barclays",
+        "Wells Fargo",
+        "Deutsche Bank",
+        "UBS",
+    ]
+    missing = [b for b in required_banks if b not in block]
+    assert not missing, (
+        f"Playbook missing named banks: {missing}. All 9 must appear so"
+        " Monitor enumerates each individually rather than batching into"
+        " a single 'Wall Street CPI' query (#577)."
+    )
+    # The batching prohibition IS the #577 fix — pin it explicitly so a
+    # future edit that kept the names but deleted the instruction would
+    # fail the test.
+    assert "Search EACH of these banks individually" in block, (
+        "Playbook MUST instruct Monitor to search EACH bank"
+        " individually. Without this, an LLM batching all 9 banks into"
+        " one search is what produced #577 c1391-c1405."
+    )
+    assert "Do NOT batch them" in block, (
+        "Playbook MUST explicitly forbid batching the bank list into a"
+        " single 'Wall Street CPI forecasts' query (#577)."
+    )
+
+
+def test_monitor_source_playbook_pins_aggregator_sources(
+    monitor_text: str,
+) -> None:
+    """FXStreet was the aggregator Monitor missed in the c1391-c1405 window
+    (#577). Pin the 4 aggregator sources verbatim AND the per-aggregator
+    enumeration instruction."""
+    block = _playbook_block(monitor_text)
+    required_sources = ["FXStreet", "MarketWatch", "Reuters", "Bloomberg"]
+    missing = [s for s in required_sources if s not in block]
+    assert not missing, (
+        f"Playbook missing aggregator sources: {missing}. FXStreet"
+        " specifically was the missed source in #577."
+    )
+    assert "Query EACH of these aggregator sources by name" in block, (
+        "Playbook MUST instruct Monitor to query EACH aggregator by"
+        " name in search terms. A general 'check aggregators'"
+        " instruction is what allowed FXStreet to be missed (#577)."
+    )
+
+
+def test_monitor_source_playbook_lists_economic_categories(
+    monitor_text: str,
+) -> None:
+    """The playbook must list the Kalshi category prefixes that trigger
+    bank/aggregator enumeration. Pin the minimal subset overlapping with
+    Caddie's Sanity-Check Mode list (caddie.md:55)."""
+    block = _playbook_block(monitor_text)
+    required_categories = [
+        "KXCPI",
+        "KXCPICORE",
+        "KXCPIYOY",
+        "KXPAYROLLS",
+        "KXJOBLESSCLAIMS",
+        "KXADP",
+        "KXGDP",
+    ]
+    missing = [c for c in required_categories if c not in block]
+    assert not missing, (
+        f"Playbook missing economic categories: {missing}. These overlap"
+        " with caddie.md's Sanity-Check Mode list and MUST trigger"
+        " Monitor's source-enumeration playbook (#577)."
+    )
+
+
+def test_monitor_48h_staleness_rule_pinned(monitor_text: str) -> None:
+    """The 48-hour CM-decision staleness rule is the core defense against
+    a stale baseline observation persisting across cycles (#577)."""
+    import re
+
+    dedup_match = re.search(
+        r"\*\*Flag deduplication rules.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL,
+    )
+    assert dedup_match is not None, "Flag deduplication block must exist"
+    block = dedup_match.group(0)
+    assert "48 hours" in block, (
+        "Dedup block must include the exact phrase `48 hours` so the"
+        " staleness threshold is unambiguous (#577)."
+    )
+    assert "most recent CM `decision`-type note" in block, (
+        "Staleness rule must anchor on the CM decision-note timestamp,"
+        " not the prior observation timestamp (which Monitor controls"
+        " and can refresh by writing a stale-template observation)"
+        " (#577)."
+    )
+    assert "48h forces a re-search, NOT a flag" in block, (
+        "The 48h rule must clarify that re-search is required but flag"
+        " suppression still applies if the re-search confirms no change."
+    )
+
+
+def test_monitor_48h_does_not_bypass_no_material_change_rule(
+    monitor_text: str,
+) -> None:
+    """The existing 'No material change → no flag' bullet must remain
+    AFTER the 48h staleness bullet, so 48h forces a re-search but doesn't
+    cause spurious flags when the re-search confirms no change (#577)."""
+    idx_48h = monitor_text.find(
+        "48-hour staleness re-search rule (REQUIRED — #577)",
+    )
+    idx_no_change = monitor_text.find(
+        'If the delta observation says "No material change," do NOT write',
+    )
+    assert idx_48h != -1, "48h staleness bullet not found (#577)"
+    assert idx_no_change != -1, "No-material-change bullet not found (#577)"
+    assert idx_48h < idx_no_change, (
+        "48h staleness bullet must come BEFORE the No-material-change"
+        " bullet so the dedup ordering is: check staleness first, then"
+        " skip flag if no material change. Inverting this ordering"
+        " breaks the dedup contract."
+    )
+
+
+def test_monitor_read_back_assertion_in_observation_template(
+    monitor_text: str,
+) -> None:
+    """The read-back assertion closes the c1407 regression where Monitor
+    reverted to a stale template even after CM cited the missing data
+    (#577)."""
+    import re
+
+    obs_match = re.search(
+        r"## Writing Observations.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL,
+    )
+    assert obs_match is not None, "Writing Observations section must exist"
+    block = obs_match.group(0)
+    assert "Read-back assertion" in block, (
+        "Writing Observations must open with a `Read-back assertion`"
+        " block that requires Monitor to surface CM-cited sources in"
+        " its observation (#577)."
+    )
+    assert "FORBIDDEN" in block, (
+        "Read-back assertion must use the uppercase token `FORBIDDEN`"
+        " to flag template assertions that contradict cited evidence."
+    )
+    assert "contradict cited evidence" in block, (
+        "FORBIDDEN clause must reference `contradict cited evidence` so"
+        " future prompts can't soften the contract via paraphrase."
+    )
+    assert "#577" in block, (
+        "Read-back assertion must cite #577 inline so the rationale is"
+        " preserved when the prompt is read in isolation."
+    )
+    # The (a) freshly searched OR (b) inherited enumeration is the
+    # behaviorally specific piece of the rule. Without it, a watered-down
+    # version of the read-back ("just check the CM decision") still
+    # passes — but doesn't force surfaceable per-source evidence.
+    assert "freshly search" in block.lower(), (
+        "Read-back must require option (a): freshly searched this cycle"
+        " for each CM-cited source (#577)."
+    )
+    assert "inherit" in block.lower() and "citation" in block.lower(), (
+        "Read-back must require option (b): explicitly inherit the prior"
+        " observation's finding with citation. Without (b) Monitor has"
+        " no audit-friendly way to handle sources it can't re-search"
+        " this cycle (#577)."
+    )
+
+
+def test_monitor_playbook_positioned_between_triggers_and_observations(
+    monitor_text: str,
+) -> None:
+    """Playbook section MUST sit between `## What You Look For (Trigger
+    Conditions)` and `## Writing Observations` — the read-back assertion
+    references the playbook by name, so the playbook has to load first.
+    Reordering would break the implicit forward-reference (#577).
+
+    Anchored on `\\n## ` (line-start) so inline cross-references inside
+    backtick spans (which contain the literal heading text) don't
+    false-match before the real section header."""
+    triggers_idx = monitor_text.find(
+        "\n## What You Look For (Trigger Conditions)",
+    )
+    playbook_idx = monitor_text.find(
+        "\n## Fundamental-Economic-Trigger Source Playbook",
+    )
+    observations_idx = monitor_text.find("\n## Writing Observations")
+    assert triggers_idx != -1, "Trigger Conditions section must exist"
+    assert playbook_idx != -1, "Playbook section must exist"
+    assert observations_idx != -1, "Writing Observations section must exist"
+    assert triggers_idx < playbook_idx < observations_idx, (
+        "Playbook MUST be positioned between Trigger Conditions and"
+        " Writing Observations sections. The read-back assertion"
+        " forward-references the playbook by name (#577)."
+    )
+
+
+def test_monitor_playbook_pins_query_phrasing_variation(
+    monitor_text: str,
+) -> None:
+    """The cache-mitigation rule (playbook §3) is one of three numbered
+    MUSTs in the playbook. Without it, tool-level caching could re-create
+    the c1391-c1405 stuck-result pattern (#577)."""
+    block = _playbook_block(monitor_text)
+    assert "Query-phrasing variation" in block, (
+        "Playbook MUST contain a `Query-phrasing variation` rule against"
+        " tool-level caching of identical search queries (#577)."
+    )
+    assert "Do NOT repeat" in block, (
+        "Query-phrasing variation rule MUST explicitly forbid repeating"
+        " the exact query string used in the prior observation (#577)."
+    )
+
+
+def test_monitor_playbook_pins_surfacing_format(monitor_text: str) -> None:
+    """When a bank/aggregator forecast is found, the observation MUST
+    surface it with bank name, forecast value, source, and publication
+    date — the four fields needed for CM audit. Vague surfacing is what
+    let c1407 revert to a stale template (#577)."""
+    block = _playbook_block(monitor_text)
+    assert "bank name" in block, (
+        "Surfacing rule MUST require the bank name field (#577)."
+    )
+    assert "forecast value" in block, (
+        "Surfacing rule MUST require the forecast value field (#577)."
+    )
+    assert "source" in block and "publication date" in block, (
+        "Surfacing rule MUST require source and publication date so CM"
+        " can audit which aggregator surfaced the forecast and when"
+        " (#577)."
+    )
+
+
+def test_monitor_playbook_pins_no_result_logging(monitor_text: str) -> None:
+    """Silent omission (no log entry when a bank search returned empty)
+    was the c1391-c1405 failure mode — Monitor never said 'Barclays:
+    not found' so CM couldn't tell whether the search ran (#577)."""
+    block = _playbook_block(monitor_text)
+    assert "no" in block.lower() and "found this cycle" in block, (
+        "Playbook MUST require Monitor to explicitly log when a bank"
+        " returned no result in its search this cycle. Silent omission"
+        " is what produced #577."
+    )
+
+
+def test_caddie_and_monitor_economic_category_lists_stay_in_sync(
+    monitor_text: str,
+    caddie_text: str,
+) -> None:
+    """Monitor's playbook must contain every fundamental-economic-trigger
+    category from Caddie's Sanity-Check Mode list. Equity-index categories
+    (KXINX S&P 500, KXNASDAQ100) are tracked by Caddie but legitimately
+    out of scope for Monitor's bank-enumeration playbook — there are no
+    "Goldman April S&P 500 forecast" sources to enumerate. The test pins
+    the economic overlap and explicitly excludes index categories so
+    drift in either direction (Caddie or Monitor) is caught (#577)."""
+    import re
+
+    block = _playbook_block(monitor_text)
+    sanity_match = re.search(
+        r"backtested gimme categories \(([^)]+)\)",
+        caddie_text,
+    )
+    assert sanity_match is not None, (
+        "caddie.md must contain the `backtested gimme categories"
+        " (...)` line for sanity-check fast-track (this test depends"
+        " on it)."
+    )
+    caddie_cats = [c.strip() for c in sanity_match.group(1).split(",")]
+    # Equity indices use intraday price moves, not economist forecasts;
+    # bank enumeration does not apply.
+    non_economic = {"KXINX", "KXNASDAQ100"}
+    economic_caddie_cats = [
+        c for c in caddie_cats if c and c not in non_economic
+    ]
+    missing_from_monitor = [
+        c for c in economic_caddie_cats if c not in block
+    ]
+    assert not missing_from_monitor, (
+        f"Caddie's fundamental-economic sanity-check categories not in"
+        f" Monitor's playbook: {missing_from_monitor}. Monitor MUST"
+        " cover everything Caddie fast-tracks in the economic-trigger"
+        " space (#577)."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Groundskeeper GitHub dedup pre-flight (#600)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #577 — Monitor missed Wall Street bank CPI forecasts across 15 cycles (c1391–c1405), allowing Caddie Master to HOLD a losing position on an incorrect premise. Position settled May 12 at **-$133.67** realized loss.

**The smoking gun:** c1407 observation regressed to the stale template AFTER c1406 surfaced the correct data. Search-narrowness alone doesn't explain that — the agent was following a semantic template that overrode cited evidence in the position-context.

## What changed

**`.claude/agents/monitor.md`** — 3 substantive edits:

1. **New `## Fundamental-Economic-Trigger Source Playbook` section** (between Trigger Conditions and Writing Observations). Lists 17 Kalshi categories that trigger the playbook (KXCPI, KXPCECORE, KXPAYROLLS, KXJOBLESSCLAIMS, KXFED\*, KXISMPMI, …), 9 named banks that MUST be queried individually (not batched — that batching was the #577 root cause), 4 aggregator sources (FXStreet/MarketWatch/Reuters/Bloomberg), a query-phrasing variation rule (heuristic defense against tool-level caching), and a per-finding surfacing format requiring bank name + forecast value + source + publication date.

2. **New Read-back assertion** at the top of Writing Observations. Before writing, Monitor MUST list every CM-cited bank/aggregator from the most-recent `decision` note and either (a) reference a freshly searched result OR (b) explicitly inherit with citation. `FORBIDDEN` clause for template assertions that contradict cited evidence. When CM is silent on sources, the read-back is vacuously satisfied but playbook enumeration STILL runs.

3. **New 48-hour staleness re-search rule** in the flag-dedup block. Anchored on the most-recent CM `decision`-type note timestamp — NOT the observation timestamp (which Monitor controls and can refresh by writing a stale-template observation). Forces a full playbook re-search but explicitly does NOT auto-flag.

**`tests/unit/test_agent_prompts.py`** — 11 new drift-guard tests pinning every load-bearing rule above.

## Known limitations (follow-ups to file as separate issues)

Static drift-guards pin prompt content, not runtime behavior. Follow-ups: (1) CLI-side validator for read-back; (2) observation footer for playbook audit; (3) runtime scenario test for Monitor; (4) Caddie-Master citation requirement; (5) WebSearch tool cache investigation.

## Test plan

- [x] `uv run pytest tests/unit/` — 1404 passed (incl. 11 new drift-guards)
- [x] `uv run ruff check tests/unit/test_agent_prompts.py` — clean
