### PR TITLE
Fix #617: Caddie Master Cited sources field

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -65,6 +65,37 @@ gimmes positions
   If the command fails, note the failure in your output and continue. Do not retry.
 - Otherwise → proceed with full cycle.
 
+### Decision-note required field: Cited sources (REQUIRED — closes #617)
+
+Every `decision`-type note you write in Steps 2c, 2d, 4c (APPROVE), and 4c (REJECT) MUST end with a `Cited sources:` field. This field exists so Monitor's read-back assertion (introduced in #577) can verify that subsequent observations either inherit or contradict the sources you actually relied on — without this field, the read-back rule is "vacuously satisfied" on most decisions and the structural defense against stale-template regressions is defanged.
+
+**Format (one of these two forms, exact):**
+
+Form A — bulleted list of sources. Each bullet matches Monitor's playbook surfacing format at the same shape:
+```
+Cited sources:
+- Barclays April headline CPI MoM +0.55% (FXStreet, 2026-05-08)
+- Wells Fargo April headline CPI MoM +0.63% (FXStreet, 2026-05-08)
+```
+
+Form B — explicit empty case:
+```
+Cited sources:
+None — decision based on price + thesis only
+```
+
+The em-dash in Form B is a literal U+2014 character (`—`), not a hyphen-minus. The drift-guard test pins the exact byte.
+
+**Derivation rule (REQUIRED — guards against fabricated citations).** A source is only allowed in `Cited sources:` if it appears verbatim in the input you relied on for THIS decision:
+- For Step 2c HOLD/CLOSE and Step 2d SIZE UP: the source MUST appear in Monitor's flag body (which you read via `gimmes position-context TICKER`).
+- For Step 4c APPROVE and Step 4c REJECT: the source MUST appear in Caddie's research memo (read via `gimmes candidates --ticker TICKER --limit 1`) OR in `gimmes market-info TICKER` output.
+
+You MAY cite a source that appears in a prior `position-context` note (e.g., the most-recent observation) — that constitutes inheritance. You MAY NOT introduce a source that does not appear in any input you actually consulted this cycle. If your decision was based on price action + thesis only (no named-source input), use Form B.
+
+**Step 4c edge-pre-filter REJECT path** (the immediate-reject branch that skips Caddie conferral): use Form B by default — there's no Caddie memo to draw on. If you read `gimmes candidates` output and a named source appears there, you MAY cite it.
+
+This rule applies regardless of ticker category. For fundamental-economic-trigger tickers (see Monitor's `## Fundamental-Economic-Trigger Source Playbook`), Form A with multiple bullets is expected when CM reviewed flags carrying bank/aggregator forecasts; Form B is acceptable when the decision genuinely turned only on price + thesis.
+
 ### Step 2: Monitor Review (if positions exist)
 
 **If there are no open positions, skip to Step 3.**
@@ -142,6 +173,7 @@ After Monitor returns, review its report. For each position Monitor flagged:
    Thesis assessment: [was the new information already in the thesis, or does it genuinely change the picture?].
    Re-evaluate if: [for HOLD only — specific condition, e.g. 'price moves another 8pp adverse' or 'after next CPI release Apr 10' or 'thesis-changing news emerges'].
    Expiry: [for HOLD only — REQUIRED cycle number to reconsider regardless, use current cycle + 10].
+   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -181,6 +213,7 @@ If Monitor flags a position where the current edge has *increased* since entry (
    Decision: SIZE UP.
    Reasoning: [specific reasoning referencing original thesis and Monitor's flag].
    Edge assessment: [entry edge vs current edge].
+   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -344,6 +377,7 @@ For each PROCEED candidate:
    Signal independence: [confirmed independent or not — explain].
    Portfolio correlation: [none, or describe overlap with existing positions].
    Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — pass.
+   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -360,6 +394,7 @@ For each PROCEED candidate:
    Reasoning: [specific reasoning — what failed scrutiny].
    Key concern: [the issue that could not be resolved in conferral].
    Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — [pass/fail].
+   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \

--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -71,7 +71,7 @@ Every `decision`-type note you write in Steps 2c, 2d, 4c (APPROVE), and 4c (REJE
 
 **Format (one of these two forms, exact):**
 
-Form A — bulleted list of sources. Each bullet matches Monitor's playbook surfacing format at the same shape:
+Form A — bulleted list of sources. Each bullet matches Monitor's playbook surfacing format in the same shape:
 ```
 Cited sources:
 - Barclays April headline CPI MoM +0.55% (FXStreet, 2026-05-08)
@@ -173,7 +173,9 @@ After Monitor returns, review its report. For each position Monitor flagged:
    Thesis assessment: [was the new information already in the thesis, or does it genuinely change the picture?].
    Re-evaluate if: [for HOLD only — specific condition, e.g. 'price moves another 8pp adverse' or 'after next CPI release Apr 10' or 'thesis-changing news emerges'].
    Expiry: [for HOLD only — REQUIRED cycle number to reconsider regardless, use current cycle + 10].
-   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
+   Cited sources:
+   [Form A: a bulleted list of "- Source — metric value (publisher, YYYY-MM-DD)" lines, OR
+    Form B (literal): None — decision based on price + thesis only]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -213,7 +215,9 @@ If Monitor flags a position where the current edge has *increased* since entry (
    Decision: SIZE UP.
    Reasoning: [specific reasoning referencing original thesis and Monitor's flag].
    Edge assessment: [entry edge vs current edge].
-   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
+   Cited sources:
+   [Form A: a bulleted list of "- Source — metric value (publisher, YYYY-MM-DD)" lines, OR
+    Form B (literal): None — decision based on price + thesis only]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -377,7 +381,9 @@ For each PROCEED candidate:
    Signal independence: [confirmed independent or not — explain].
    Portfolio correlation: [none, or describe overlap with existing positions].
    Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — pass.
-   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
+   Cited sources:
+   [Form A: a bulleted list of "- Source — metric value (publisher, YYYY-MM-DD)" lines, OR
+    Form B (literal): None — decision based on price + thesis only]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \
@@ -394,7 +400,9 @@ For each PROCEED candidate:
    Reasoning: [specific reasoning — what failed scrutiny].
    Key concern: [the issue that could not be resolved in conferral].
    Edge vs CM floor: net edge [X.Xpp] vs cm_min_edge_after_fees [Y.Ypp] — [pass/fail].
-   Cited sources: [bulleted list per "Decision-note required field: Cited sources" rule above, or "None — decision based on price + thesis only"]
+   Cited sources:
+   [Form A: a bulleted list of "- Source — metric value (publisher, YYYY-MM-DD)" lines, OR
+    Form B (literal): None — decision based on price + thesis only]
    GIMMES_EOF
    gimmes position-note TICKER \
      --cycle $GIMMES_CYCLE \

--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -92,7 +92,7 @@ The em-dash in Form B is a literal U+2014 character (`—`), not a hyphen-minus.
 
 You MAY cite a source that appears in a prior `position-context` note (e.g., the most-recent observation) — that constitutes inheritance. You MAY NOT introduce a source that does not appear in any input you actually consulted this cycle. If your decision was based on price action + thesis only (no named-source input), use Form B.
 
-**Step 4c edge-pre-filter REJECT path** (the immediate-reject branch that skips Caddie conferral): use Form B by default — there's no Caddie memo to draw on. If you read `gimmes candidates` output and a named source appears there, you MAY cite it.
+**Step 4c edge-pre-filter REJECT path** (the immediate-reject branch that skips Caddie conferral): use Form B by default — the Caddie conferral memo is unavailable. The `gimmes candidates --ticker TICKER` output and `gimmes market-info TICKER` output ARE both already read at this point (sub-steps 1-2 of Step 4c), so if a named source appears in either of those outputs, you MAY cite it via Form A.
 
 This rule applies regardless of ticker category. For fundamental-economic-trigger tickers (see Monitor's `## Fundamental-Economic-Trigger Source Playbook`), Form A with multiple bullets is expected when CM reviewed flags carrying bank/aggregator forecasts; Form B is acceptable when the decision genuinely turned only on price + thesis.
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -383,6 +383,20 @@ def test_caddie_master_decision_templates_all_require_cited_sources(
         " end with the field — Monitor's read-back assertion (#577)"
         " is defanged otherwise (#617)."
     )
+    # Order check: `Cited sources:` MUST appear AFTER `Decision:` in
+    # each body — i.e., it's positioned as the closing field, not
+    # interleaved with the leading fields. Catches drift where the
+    # field is moved earlier and other fields drop below it.
+    out_of_order = [
+        i for i, body in enumerate(decision_heredocs)
+        if body.find("Cited sources:") <= body.find("Decision:")
+    ]
+    assert not out_of_order, (
+        f"Decision-note heredoc blocks at index {out_of_order} have"
+        " `Cited sources:` appearing BEFORE the `Decision:` line."
+        " The field must be the closing audit footer, not"
+        " interleaved (#617)."
+    )
 
 
 def test_caddie_master_edge_pre_filter_reject_path_uses_form_b(

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -338,6 +338,132 @@ def test_caddie_master_4c_lockout_requires_both_markers(
     )
 
 
+# ---------------------------------------------------------------------------
+# Caddie Master: Cited sources field (#617 — closes the gap that defangs
+# Monitor's read-back assertion from #577)
+# ---------------------------------------------------------------------------
+
+
+def test_caddie_master_decision_templates_all_require_cited_sources(
+    caddie_master_text: str,
+) -> None:
+    """Each of the 4 decision-note templates (HOLD/CLOSE, SIZE UP,
+    APPROVE, REJECT) MUST end with a `Cited sources:` line. Without it,
+    Monitor's read-back assertion (#577) is vacuously satisfied on most
+    decisions and the structural defense against stale-template
+    regressions is defanged (#617)."""
+    occurrences = caddie_master_text.count("Cited sources:")
+    assert occurrences >= 5, (
+        f"Expected >= 5 occurrences of 'Cited sources:' in"
+        f" caddie-master.md (4 templates + 1 in the shared rule"
+        f" block), found {occurrences}. Every decision template MUST"
+        " end with the Cited sources field (#617)."
+    )
+
+
+def test_caddie_master_cited_sources_allows_none_carveout(
+    caddie_master_text: str,
+) -> None:
+    """When a decision turns purely on price + thesis (no named-source
+    input), Form B 'None — decision based on price + thesis only' is
+    the allowed empty case. The em-dash is U+2014, not a hyphen-minus
+    — pin the exact byte (#617)."""
+    assert "None — decision based on price + thesis only" in caddie_master_text, (
+        "Cited sources rule must include the literal 'None — decision"
+        " based on price + thesis only' carve-out (Form B). Em-dash"
+        " is U+2014, not a hyphen-minus — this exact byte sequence is"
+        " what the drift-guard pins."
+    )
+
+
+def test_caddie_master_cited_sources_format_matches_monitor_surfacing(
+    caddie_master_text: str,
+) -> None:
+    """The example bullet format must match Monitor's playbook surfacing
+    format (#577) so a single regex can parse citations from both CM
+    decisions and Monitor observations (#617)."""
+    # Monitor's exemplar (monitor.md:78-79):
+    # `Barclays April headline CPI MoM +0.55% (FXStreet, 2026-05-08)`
+    # CM's exemplar must follow the same shape — pin the bracketed
+    # `(publisher, YYYY-MM-DD)` portion specifically since that's the
+    # parser-relevant structure.
+    assert "(FXStreet, 2026-05-08)" in caddie_master_text, (
+        "Cited sources rule must show an example bullet using the"
+        " same `(publisher, YYYY-MM-DD)` format as Monitor's"
+        " surfacing rule. Mismatched formats break read-back"
+        " parseability (#617)."
+    )
+    assert "Barclays April headline CPI MoM +0.55%" in caddie_master_text, (
+        "Cited sources example must reproduce Monitor's exemplar"
+        " verbatim so the two prompts can't drift on format (#617)."
+    )
+
+
+def test_caddie_master_forbids_uncited_source_fabrication(
+    caddie_master_text: str,
+) -> None:
+    """The derivation rule prevents agents from satisfying the Cited
+    sources field by fabricating citations. A source is only allowed
+    if it appears in the input CM actually consulted this cycle (#617)."""
+    assert "Derivation rule (REQUIRED — guards against fabricated citations)" in caddie_master_text, (
+        "Cited sources section MUST include a derivation rule that"
+        " forbids citing sources not present in the input consulted"
+        " this cycle. Without it, an agent can satisfy the field with"
+        " plausible-looking fabrications (#617)."
+    )
+    assert "MUST appear in Monitor's flag body" in caddie_master_text, (
+        "Derivation rule MUST anchor Step 2 citations on Monitor's"
+        " flag body — that's where the bank/aggregator forecasts CM"
+        " relied on are written (#617)."
+    )
+    assert (
+        "MUST appear in Caddie's research memo" in caddie_master_text
+        or "appear in Caddie's research memo" in caddie_master_text
+    ), (
+        "Derivation rule MUST anchor Step 4c citations on Caddie's"
+        " research memo or market-info output — that's where the"
+        " sources CM relied on for APPROVE/REJECT are written (#617)."
+    )
+
+
+def test_caddie_master_cited_sources_references_monitor_playbook(
+    caddie_master_text: str,
+    monitor_text: str,
+) -> None:
+    """Cross-file invariant: CM's cited-sources rule must reference
+    Monitor's `Fundamental-Economic-Trigger Source Playbook` by name
+    so future playbook additions (new bank, new aggregator) are
+    naturally covered by CM's derivation rule (#617)."""
+    assert "Fundamental-Economic-Trigger Source Playbook" in caddie_master_text, (
+        "Caddie Master's cited-sources rule MUST reference Monitor's"
+        " `Fundamental-Economic-Trigger Source Playbook` section by"
+        " name. Without the cross-reference, a future addition to"
+        " Monitor's bank list (e.g., HSBC) would require a separate"
+        " CM edit — guaranteed drift (#617)."
+    )
+    # And the playbook section itself must still exist in monitor.md
+    # (regression pin against accidentally deleting it from monitor).
+    assert "## Fundamental-Economic-Trigger Source Playbook" in monitor_text, (
+        "monitor.md MUST still have the playbook section that CM's"
+        " cross-reference points at (#577)."
+    )
+
+
+def test_monitor_readback_vacuous_clause_still_present(
+    monitor_text: str,
+) -> None:
+    """Regression pin: #617 must NOT inadvertently break Monitor's
+    backward-compatibility clause for pre-existing decision notes that
+    lack a Cited sources field. The 'vacuously satisfied' clause covers
+    pre-#617 decisions during the migration window (#617)."""
+    assert "vacuously satisfied" in monitor_text, (
+        "monitor.md's read-back assertion must retain the 'vacuously"
+        " satisfied' clause so pre-#617 decision notes (which lack"
+        " Cited sources) don't trip the FORBIDDEN rule during the"
+        " migration window (#577 + #617)."
+    )
+
+
 def test_monitor_template_body_carries_conditional_fields(
     monitor_text: str,
 ) -> None:

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -405,7 +405,10 @@ def test_caddie_master_forbids_uncited_source_fabrication(
     """The derivation rule prevents agents from satisfying the Cited
     sources field by fabricating citations. A source is only allowed
     if it appears in the input CM actually consulted this cycle (#617)."""
-    assert "Derivation rule (REQUIRED — guards against fabricated citations)" in caddie_master_text, (
+    derivation_marker = (
+        "Derivation rule (REQUIRED — guards against fabricated citations)"
+    )
+    assert derivation_marker in caddie_master_text, (
         "Cited sources section MUST include a derivation rule that"
         " forbids citing sources not present in the input consulted"
         " this cycle. Without it, an agent can satisfy the field with"

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -348,16 +348,67 @@ def test_caddie_master_decision_templates_all_require_cited_sources(
     caddie_master_text: str,
 ) -> None:
     """Each of the 4 decision-note templates (HOLD/CLOSE, SIZE UP,
-    APPROVE, REJECT) MUST end with a `Cited sources:` line. Without it,
-    Monitor's read-back assertion (#577) is vacuously satisfied on most
-    decisions and the structural defense against stale-template
-    regressions is defanged (#617)."""
-    occurrences = caddie_master_text.count("Cited sources:")
-    assert occurrences >= 5, (
-        f"Expected >= 5 occurrences of 'Cited sources:' in"
-        f" caddie-master.md (4 templates + 1 in the shared rule"
-        f" block), found {occurrences}. Every decision template MUST"
-        " end with the Cited sources field (#617)."
+    APPROVE, REJECT) MUST end with a `Cited sources:` line inside its
+    own heredoc body. Scoped per-template rather than substring-counted
+    so a future field-rename can't satisfy the count spuriously (#617)."""
+    import re
+
+    # Each decision-note template lives inside a `<<'GIMMES_EOF' ...
+    # GIMMES_EOF` block whose body contains `Decision:`. Require the
+    # opening delimiter to be followed by a newline (i.e. a REAL heredoc
+    # opener) so inline backtick mentions of the delimiter literal in
+    # explanatory prose don't false-match (`<<'GIMMES_EOF'\n` is a real
+    # opener; `<<'GIMMES_EOF'` inside backticks is prose).
+    heredoc_pattern = re.compile(
+        r"<<'GIMMES_EOF'\n(.*?)\n\s*GIMMES_EOF\b",
+        flags=re.DOTALL,
+    )
+    decision_heredocs = [
+        m.group(1) for m in heredoc_pattern.finditer(caddie_master_text)
+        if "Decision:" in m.group(1)
+    ]
+    assert len(decision_heredocs) >= 4, (
+        f"Expected >= 4 decision-note heredoc blocks in caddie-master.md"
+        f" (HOLD/CLOSE, SIZE UP, APPROVE, REJECT); found"
+        f" {len(decision_heredocs)}. A template-block dropout would"
+        " silently bypass the cited-sources contract (#617)."
+    )
+    missing = [
+        i for i, body in enumerate(decision_heredocs)
+        if "Cited sources:" not in body
+    ]
+    assert not missing, (
+        f"Decision-note heredoc blocks at index {missing} are missing"
+        " the `Cited sources:` field. Every decision template MUST"
+        " end with the field — Monitor's read-back assertion (#577)"
+        " is defanged otherwise (#617)."
+    )
+
+
+def test_caddie_master_edge_pre_filter_reject_path_uses_form_b(
+    caddie_master_text: str,
+) -> None:
+    """Step 4c's edge-pre-filter REJECT branch skips Caddie conferral but
+    DOES read `gimmes candidates` and `gimmes market-info`. The rule must
+    explicitly explain how to populate Cited sources in this branch —
+    without that guidance, agents either default to Form B silently
+    (losing valid citations) or fabricate sources (#617)."""
+    assert "Step 4c edge-pre-filter REJECT path" in caddie_master_text, (
+        "Cited-sources rule MUST explicitly call out the Step 4c"
+        " edge-pre-filter REJECT branch — it's a third context (along"
+        " with Step 2 and Step 4c regular APPROVE/REJECT) and skipping"
+        " it leaves the immediate-reject branch with no citation"
+        " guidance (#617)."
+    )
+    # The carve-out must mention BOTH candidates output and market-info
+    # are still available, even though Caddie conferral memo isn't.
+    assert "gimmes candidates" in caddie_master_text, (
+        "Edge-pre-filter REJECT rule must reference `gimmes candidates`"
+        " as a still-available source of citations in this branch."
+    )
+    assert "gimmes market-info" in caddie_master_text, (
+        "Edge-pre-filter REJECT rule must reference `gimmes market-info`"
+        " as a still-available source of citations in this branch."
     )
 
 


### PR DESCRIPTION
## Summary

Closes #617, follow-up to #577 (PR #613). Adds a `Cited sources:` field to all 4 Caddie Master decision-note templates so Monitor's read-back assertion (introduced in #577) actually fires — previously most CM decisions had no source citations, making the read-back rule vacuously satisfied and the structural defense against stale-template regressions defanged.

## What changed

**`.claude/agents/caddie-master.md`**:
- New shared `Decision-note required field: Cited sources` rule block before Step 2 covering: required field name, two allowed forms (bulleted source list matching Monitor's surfacing format, OR explicit `None — decision based on price + thesis only` with U+2014 em-dash), derivation rule forbidding fabricated citations (sources must appear in CM's actual inputs — Monitor's flag body for Step 2, Caddie memo / market-info for Step 4c), explicit Step 4c edge-pre-filter REJECT carve-out, and cross-reference to Monitor's playbook so future bank/aggregator additions are naturally covered.
- `Cited sources: [...]` field appended to all 4 decision templates (HOLD/CLOSE, SIZE UP, APPROVE, REJECT).

**`tests/unit/test_agent_prompts.py`** — 7 new drift-guards:
1. Per-template regex extraction (>= 4 heredoc bodies containing `Decision:` AND `Cited sources:`)
2. Form B em-dash carve-out (U+2014, not hyphen-minus) verbatim
3. Format match with Monitor surfacing (`(FXStreet, 2026-05-08)` exemplar pinned)
4. Derivation rule presence (Monitor flag body + Caddie memo / market-info)
5. Cross-file invariant: `Fundamental-Economic-Trigger Source Playbook` referenced in both files
6. Monitor `vacuously satisfied` clause regression pin (backward compat for pre-#617 decisions)
7. Step 4c edge-pre-filter REJECT path carve-out pinned

## Test plan
- [x] `uv run pytest tests/unit/test_agent_prompts.py` — 48 passed
- [x] `uv run ruff check tests/unit/test_agent_prompts.py` — clean
- [x] Review pipeline (3 agents parallel) APPROVED with 2 findings addressed in fixup commit

## Known limitations (follow-ups, not in this PR)
1. Em-dash drift in runtime notes — drift-guard pins prompt only; no CLI-side validation that note bodies use U+2014 vs hyphen-minus
2. Unbounded inheritance recency — derivation rule permits citing from any prior `position-context` note; could be tightened to "current cycle or most-recent observation"
3. CLI-side validator (already tracked as #614) — would deterministically enforce both the cited-sources contract and the read-back assertion
