### PR TITLE
Fix #614: CLI-side validator for Monitor's read-back assertion

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -96,6 +96,8 @@ If a bank returned no result in your search, log that explicitly in the observat
 
 **When the CM decision is silent on named sources** (e.g., a HOLD with no source citations, or a decision written before this rule existed), the read-back step (2-3 above) is vacuously satisfied — but the full playbook enumeration for fundamental-economic-trigger positions is REQUIRED regardless. A silent CM decision does NOT exempt Monitor from the bank-by-bank and aggregator-by-aggregator search; it only removes the inheritance obligation. The playbook always runs when category matches.
 
+**Runtime enforcement (#614).** This contract is enforced at the CLI: `gimmes position-note --type observation` rejects observation writes that contain the canonical stale-template phrase ("No named major Wall Street bank has published") when the most-recent CM `decision` note for the same ticker cites a named bank or aggregator with a numeric percentage value. **On validator rejection: re-write the observation with the surfaced citations and retry. Do NOT use `--force` to bypass** — that flag is reserved for backfill scripts; autonomous Monitor cycles MUST fix the body, not bypass the check. Bypassing the validator constitutes the same regression #577/#614 are designed to prevent.
+
 After reading `position-context` and completing your analysis, write a **delta observation** — what changed since the prior observation, not a full re-assessment. If no prior observation exists (first cycle for this position), write a full observation.
 
 Use the `--body-file` variant via a single-quoted heredoc so dollar-prefixed prices like `$0.41` survive verbatim (#589). The quoted delimiter `<<'GIMMES_EOF'` is load-bearing — it suppresses ALL parameter expansion inside the body:

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2282,12 +2282,24 @@ def position_note(
                 # `KXCPI-26APR-T0.5` would silently miss a CM decision
                 # logged under `KXCPI-26APR-T0.50` (or any other
                 # canonical-form drift), defeating the entire validator.
+                # Ambiguous prefix matches are a hard error: silently
+                # writing the note under an un-resolved prefix would
+                # create an unreachable journal entry — the same class
+                # of bug the validator exists to prevent.
                 resolved_ticker = ticker
                 matches = await resolve_ticker(
                     db, ticker, source="known_markets",
                 )
+                if len(matches) > 1:
+                    _print_ambiguous_ticker(ticker, matches)
+                    raise typer.Exit(1)
                 if len(matches) == 1:
                     resolved_ticker = matches[0]
+                # If matches == [], the ticker is unknown to the
+                # system (no positions/candidates/trades on file). The
+                # validator's "no prior decision" branch handles this
+                # — we use the raw ticker as-passed and the read-back
+                # is vacuously satisfied.
                 prior = await get_position_notes(
                     db, resolved_ticker, note_type="decision", limit=1,
                 )

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2237,6 +2237,15 @@ def position_note(
             " containing dollar amounts or shell-special characters (#589)."
         ),
     ),
+    force: bool = typer.Option(
+        False, "--force",
+        hidden=True,
+        help=(
+            "Bypass the observation read-back validator (#614). Reserved"
+            " for backfill scripts; autonomous Monitor cycles MUST re-write"
+            " the observation rather than --force."
+        ),
+    ),
 ) -> None:
     """Append a note to the position journal."""
     valid_types = ("observation", "flag", "decision", "context")
@@ -2253,9 +2262,52 @@ def position_note(
 
     async def _note() -> None:
         from gimmes.store.database import Database
-        from gimmes.store.queries import insert_position_note
+        from gimmes.store.observation_validator import validate
+        from gimmes.store.queries import (
+            get_position_notes,
+            insert_position_note,
+        )
+        from gimmes.store.ticker_resolver import resolve_ticker
 
         async with Database(config.db_path) as db:
+            if note_type == "observation" and not force:
+                # Read-back validator (#614): reject observation writes
+                # that contradict cited evidence in the most-recent CM
+                # decision note for this ticker. Scoped to
+                # fundamental-economic-trigger tickers; equity-index
+                # tickers pass through unconditionally.
+                #
+                # Canonicalize the ticker via resolve_ticker before the
+                # decision lookup — otherwise a Monitor invocation with
+                # `KXCPI-26APR-T0.5` would silently miss a CM decision
+                # logged under `KXCPI-26APR-T0.50` (or any other
+                # canonical-form drift), defeating the entire validator.
+                resolved_ticker = ticker
+                matches = await resolve_ticker(
+                    db, ticker, source="known_markets",
+                )
+                if len(matches) == 1:
+                    resolved_ticker = matches[0]
+                prior = await get_position_notes(
+                    db, resolved_ticker, note_type="decision", limit=1,
+                )
+                decision_body = (
+                    prior[0].get("body") if prior else None
+                )
+                ok, err = validate(
+                    ticker=resolved_ticker,
+                    observation_body=body_val,
+                    decision_body=decision_body,
+                )
+                if not ok:
+                    console.print(f"[red]{err}[/red]")
+                    raise typer.Exit(1)
+            if force and note_type == "observation":
+                console.print(
+                    "[yellow]--force bypassed the observation read-back"
+                    " validator (#614). This is an audit-visible"
+                    " bypass.[/yellow]"
+                )
             row_id = await insert_position_note(
                 db, ticker=ticker, cycle=cycle, agent=agent,
                 note_type=note_type, body=body_val,

--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -127,9 +127,13 @@ def extract_cited_evidence(decision_body: str) -> list[tuple[str, str]]:
 
 
 def contains_stale_template(observation_body: str) -> bool:
-    """Case-insensitive substring match for the c1407 stale-template
-    phrase. Whitespace inside the phrase is tolerant (the phrase has
-    spaces that real prose preserves)."""
+    """Case-insensitive plain substring match for the c1407 stale-
+    template phrase. The phrase must appear with its exact internal
+    spacing — variants with embedded newlines or collapsed whitespace
+    will NOT match. This is a tight pin against the verbatim c1407
+    regression; broader matching risks rejecting legitimate
+    "no result this cycle" entries that the playbook explicitly
+    requires."""
     if not observation_body:
         return False
     return STALE_TEMPLATE_PHRASE in observation_body.lower()

--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -1,0 +1,177 @@
+"""Observation validator — CLI-side runtime enforcement of Monitor's
+read-back assertion (#577).
+
+The read-back assertion in `.claude/agents/monitor.md` requires Monitor to
+surface CM-cited named-bank / aggregator sources in its observation. The
+rule is LLM-self-enforced; the c1407 regression demonstrated that LLM
+compliance with prose rules is unreliable. This module provides a
+deterministic runtime check: when a `--type observation` write contains
+the canonical c1407 stale-template phrase ("No named major Wall Street
+bank has published") AND the most-recent CM `decision` note for the same
+ticker cites a named bank or aggregator with a numeric percentage value,
+the write is rejected.
+
+Scope: fundamental-economic-trigger tickers only (CPI/PCE/payrolls/etc.).
+Equity-index tickers (KXSPX/KXINX/KXNASDAQ100) skip the validator —
+they have no bank-forecast vocabulary to contradict.
+
+Constants are hard-coded rather than parsed from monitor.md so the
+validator works regardless of install path / worktree state. A
+drift-guard test in `tests/unit/test_observation_validator.py` keeps
+the constants in sync with monitor.md's playbook.
+"""
+
+from __future__ import annotations
+
+import re
+
+NAMED_BANKS: tuple[str, ...] = (
+    "Goldman Sachs",
+    "JPMorgan",
+    "Morgan Stanley",
+    "Bank of America",
+    "Citi",
+    "Barclays",
+    "Wells Fargo",
+    "Deutsche Bank",
+    "UBS",
+)
+
+AGGREGATORS: tuple[str, ...] = (
+    "FXStreet",
+    "MarketWatch",
+    "Reuters",
+    "Bloomberg",
+)
+
+# Verbatim phrase from the c1407 regression. Case-insensitive match.
+# Narrowly pinned — broader patterns risk rejecting legitimate
+# "no result this cycle" entries that the playbook explicitly requires.
+STALE_TEMPLATE_PHRASE: str = "no named major wall street bank has published"
+
+# Fundamental-economic-trigger Kalshi category prefixes. Mirrors
+# monitor.md's `## Fundamental-Economic-Trigger Source Playbook` list.
+# Drift-guard test pins both lists in sync.
+ECONOMIC_CATEGORIES: tuple[str, ...] = (
+    "KXCPI",
+    "KXCPICORE",
+    "KXCPIYOY",
+    "KXCPICOREYOY",
+    "KXPCECORE",
+    "KXPAYROLLS",
+    "KXADP",
+    "KXJOBLESSCLAIMS",
+    "KXUE",
+    "KXU3",
+    "KXGDP",
+    "KXGDPNOM",
+    "KXFED",
+    "KXFEDDECISION",
+    "KXFEDCOMBO",
+    "KXRATECUTCOUNT",
+    "KXISMPMI",
+)
+
+
+_NUMERIC_VALUE_RE = re.compile(r"[-+]?\d+(?:\.\d+)?\s?%")
+
+
+def _named_source_regex() -> re.Pattern[str]:
+    # Citi is special-cased: CM prose frequently writes "Citibank" or
+    # "Citigroup" as the same institution. Treating those as Citi
+    # citations avoids a silent-pass where "Citibank analysts forecast
+    # +0.42%" wouldn't trigger the validator. Other banks don't have
+    # comparable widely-used aliases that conflict with the simple
+    # word-boundary form.
+    citi_alias = "Citi(?:bank|group)?"
+    other_banks = [b for b in NAMED_BANKS if b != "Citi"]
+    sources = other_banks + list(AGGREGATORS)
+    # Sort by length desc so longer names match before substrings
+    # (e.g., "Bank of America" before any subset).
+    sources_sorted = sorted(sources, key=len, reverse=True)
+    escaped = [re.escape(s) for s in sources_sorted]
+    pattern = r"\b(?:" + "|".join([citi_alias, *escaped]) + r")\b"
+    return re.compile(pattern)
+
+
+_NAMED_SOURCE_RE = _named_source_regex()
+
+
+def ticker_in_economic_category(ticker: str) -> bool:
+    """Return True if `ticker` matches a fundamental-economic-trigger
+    Kalshi prefix from the Monitor playbook."""
+    upper = ticker.upper()
+    for prefix in ECONOMIC_CATEGORIES:
+        if upper.startswith(prefix):
+            return True
+    return False
+
+
+def extract_cited_evidence(decision_body: str) -> list[tuple[str, str]]:
+    """Return [(source_name, numeric_value)] for each named bank /
+    aggregator in `decision_body` that has a numeric percentage value
+    on the same line. Same-line proximity rather than character-window
+    matches Monitor's surfacing format (bank + value on one line)."""
+    if not decision_body:
+        return []
+    pairs: list[tuple[str, str]] = []
+    for line in decision_body.splitlines():
+        for source_match in _NAMED_SOURCE_RE.finditer(line):
+            value_match = _NUMERIC_VALUE_RE.search(line)
+            if value_match:
+                pairs.append((source_match.group(0), value_match.group(0)))
+                # One pair per line is enough — multiple matches on the
+                # same line would be duplicates of the same evidence.
+                break
+    return pairs
+
+
+def contains_stale_template(observation_body: str) -> bool:
+    """Case-insensitive substring match for the c1407 stale-template
+    phrase. Whitespace inside the phrase is tolerant (the phrase has
+    spaces that real prose preserves)."""
+    if not observation_body:
+        return False
+    return STALE_TEMPLATE_PHRASE in observation_body.lower()
+
+
+def validate(
+    *,
+    ticker: str,
+    observation_body: str,
+    decision_body: str | None,
+) -> tuple[bool, str | None]:
+    """Validate an observation-write against the most-recent CM decision.
+
+    Returns (ok, error_message). When `ok` is False, the caller MUST
+    reject the write with exit 1 and surface `error_message`.
+
+    Returns (True, None) when:
+    - ticker is not in a fundamental-economic-trigger category
+    - decision_body is None (no prior decision to contradict)
+    - decision_body has no cited bank/aggregator with a numeric value
+    - observation_body does not contain the stale-template phrase
+    """
+    if not ticker_in_economic_category(ticker):
+        return (True, None)
+    if decision_body is None:
+        return (True, None)
+    if not contains_stale_template(observation_body):
+        return (True, None)
+    cited = extract_cited_evidence(decision_body)
+    if not cited:
+        return (True, None)
+    # Stale template AND CM cites at least one bank/aggregator with a
+    # numeric value → reject.
+    source, value = cited[0]
+    err = (
+        f"Observation contradicts cited evidence in the most-recent CM"
+        f" decision for {ticker} (#577, #614). The CM decision cites"
+        f" {source} {value}, but this observation contains the"
+        f" stale-template phrase \"{STALE_TEMPLATE_PHRASE}\"."
+        f" Re-write the observation to either reference a freshly"
+        f" searched result OR explicitly inherit the prior CM-cited"
+        f" finding with citation. Do NOT use --force to bypass — that"
+        f" is reserved for backfill scripts."
+    )
+    return (False, err)

--- a/tests/unit/test_cli_observation_validator.py
+++ b/tests/unit/test_cli_observation_validator.py
@@ -1,0 +1,258 @@
+"""CLI integration tests for the observation read-back validator (#614).
+
+Verifies that `gimmes position-note --type observation` rejects writes
+that contradict cited evidence in the most-recent CM decision note.
+
+These tests are intentionally SYNCHRONOUS — pytest-asyncio's "auto" mode
+would wrap them in an event loop, but CliRunner.invoke() calls
+position_note() which calls _run() which calls asyncio.run() — and
+asyncio.run() refuses to run inside an already-running loop. So the
+DB setup uses asyncio.run() at the start of each test (before CliRunner
+fires) and the test itself stays sync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.store.database import Database
+from gimmes.store.queries import get_position_notes, insert_position_note
+
+C1407_STALE = (
+    "No named major Wall Street bank has published April CPI MoM"
+    " strictly above 0.5%"
+)
+
+
+def _patch_config(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+
+def _seed_decision(db_path: Path, ticker: str, body: str) -> None:
+    """Synchronously seed a CM decision note via asyncio.run()."""
+
+    async def _seed() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await insert_position_note(
+                db,
+                ticker=ticker,
+                cycle=1391,
+                agent="caddie-master",
+                note_type="decision",
+                body=body,
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(_seed())
+
+
+def _seed_empty_db(db_path: Path) -> None:
+    """Synchronously initialize an empty DB (schema only)."""
+
+    async def _init() -> None:
+        db = Database(db_path)
+        await db.connect()
+        await db.close()
+
+    asyncio.run(_init())
+
+
+def _read_notes(
+    db_path: Path, ticker: str, note_type: str | None = None,
+) -> list[dict]:  # type: ignore[type-arg]
+    async def _read() -> list[dict]:  # type: ignore[type-arg]
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await get_position_notes(
+                db, ticker, note_type=note_type,
+            )
+        finally:
+            await db.close()
+
+    return asyncio.run(_read())
+
+
+CM_DECISION_WITH_BARCLAYS = (
+    "Decision: HOLD.\n"
+    "Reasoning: thesis intact; bank forecasts confirm.\n"
+    "Cited sources:\n"
+    "- Barclays April headline CPI MoM +0.55% (FXStreet, 2026-05-08)"
+)
+
+CM_DECISION_SILENT_ON_SOURCES = (
+    "Decision: HOLD.\n"
+    "Reasoning: thesis intact; price unchanged.\n"
+    "Cited sources:\n"
+    "None — decision based on price + thesis only"
+)
+
+
+def test_observation_rejected_when_validator_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject case: CM cites Barclays +0.55%, observation contains
+    c1407 stale-template phrase → exit 1, no row inserted (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_decision(db_path, "KXCPI-26APR-T0.5", CM_DECISION_WITH_BARCLAYS)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI-26APR-T0.5",
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", C1407_STALE,
+    ])
+    assert result.exit_code == 1, result.output
+    assert "Barclays" in result.output
+    assert "#577" in result.output
+    assert "#614" in result.output
+
+    notes = _read_notes(db_path, "KXCPI-26APR-T0.5", note_type="observation")
+    assert notes == []
+
+
+def test_observation_allowed_when_cm_silent_on_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vacuous case: CM has no source citations → stale phrase passes (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_decision(
+        db_path, "KXCPI-26APR-T0.5", CM_DECISION_SILENT_ON_SOURCES,
+    )
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI-26APR-T0.5",
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", C1407_STALE,
+    ])
+    assert result.exit_code == 0, result.output
+
+
+def test_observation_allowed_when_no_prior_decision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No CM decision exists yet → validator is vacuously satisfied (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_empty_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI-26APR-T0.5",
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", C1407_STALE,
+    ])
+    assert result.exit_code == 0, result.output
+
+
+def test_observation_allowed_when_ticker_not_economic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equity-index tickers (KXSPX/KXINX/KXNASDAQ100) skip the
+    validator entirely (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_decision(db_path, "KXSPX-26MAY-T5000", CM_DECISION_WITH_BARCLAYS)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXSPX-26MAY-T5000",
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", C1407_STALE,
+    ])
+    assert result.exit_code == 0, result.output
+
+
+def test_force_flag_bypasses_validator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--force allows backfill scripts to bypass the validator, with
+    a yellow audit warning printed (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_decision(db_path, "KXCPI-26APR-T0.5", CM_DECISION_WITH_BARCLAYS)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI-26APR-T0.5",
+        "--cycle", "1407",
+        "--agent", "backfill",
+        "--type", "observation",
+        "--body", C1407_STALE,
+        "--force",
+    ])
+    assert result.exit_code == 0, result.output
+    assert "--force" in result.output
+    assert "audit-visible" in result.output
+
+
+def test_flag_type_skips_validator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validator is scoped to --type observation. A `flag` note with
+    the same body content is unaffected — AND the row is actually
+    inserted (catches a spurious-pass where the CLI no-ops on `flag`
+    type without inserting anything) (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_decision(db_path, "KXCPI-26APR-T0.5", CM_DECISION_WITH_BARCLAYS)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI-26APR-T0.5",
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "flag",
+        "--body", C1407_STALE,
+    ])
+    assert result.exit_code == 0, result.output
+
+    # Verify the flag row was actually written — exit=0 alone could
+    # mask a no-op CLI path.
+    flag_notes = _read_notes(db_path, "KXCPI-26APR-T0.5", note_type="flag")
+    assert len(flag_notes) == 1, flag_notes
+    assert C1407_STALE in flag_notes[0]["body"]
+
+
+def test_observation_allowed_when_surfacing_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Good observation that surfaces the CM-cited evidence passes,
+    even with CM citing Barclays +0.55% (#614)."""
+    db_path = tmp_path / "test.db"
+    _seed_decision(db_path, "KXCPI-26APR-T0.5", CM_DECISION_WITH_BARCLAYS)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI-26APR-T0.5",
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body",
+        "Barclays +0.55% confirmed this cycle (FXStreet, 2026-05-08).",
+    ])
+    assert result.exit_code == 0, result.output

--- a/tests/unit/test_cli_observation_validator.py
+++ b/tests/unit/test_cli_observation_validator.py
@@ -23,7 +23,11 @@ from typer.testing import CliRunner
 from gimmes import cli as cli_module
 from gimmes.cli import app
 from gimmes.store.database import Database
-from gimmes.store.queries import get_position_notes, insert_position_note
+from gimmes.store.queries import (
+    get_position_notes,
+    insert_candidate,
+    insert_position_note,
+)
 
 C1407_STALE = (
     "No named major Wall Street bank has published April CPI MoM"
@@ -235,6 +239,55 @@ def test_flag_type_skips_validator(
     flag_notes = _read_notes(db_path, "KXCPI-26APR-T0.5", note_type="flag")
     assert len(flag_notes) == 1, flag_notes
     assert C1407_STALE in flag_notes[0]["body"]
+
+
+def test_ambiguous_prefix_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambiguous prefix tickers (e.g., "KXCPI" matching multiple
+    contracts) are a hard error rather than silently writing under
+    the un-resolved prefix. Mirrors position-notes / position-context
+    behavior and prevents creating unreachable journal entries — the
+    same class of bug the validator exists to prevent (#614)."""
+    db_path = tmp_path / "test.db"
+    # Seed two candidates under different canonical tickers that share
+    # the prefix "KXCPI". resolve_ticker(source="known_markets") will
+    # return both → ambiguous. (Seeding via candidates rather than
+    # position_notes because known_markets reads from
+    # positions/candidates/trades, not position_notes.)
+    _seed_decision(db_path, "KXCPI-26APR-T0.5", CM_DECISION_WITH_BARCLAYS)
+    _seed_decision(db_path, "KXCPI-26MAY-T0.5", CM_DECISION_WITH_BARCLAYS)
+
+    async def _seed_candidates() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await insert_candidate(
+                db, "KXCPI-26APR-T0.5", "April CPI", 0.5, 0.6, 0.1, 70, "",
+            )
+            await insert_candidate(
+                db, "KXCPI-26MAY-T0.5", "May CPI", 0.5, 0.6, 0.1, 70, "",
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(_seed_candidates())
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", "KXCPI",  # ambiguous prefix
+        "--cycle", "1407",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", "Some observation body.",
+    ])
+    assert result.exit_code == 1, result.output
+    assert "Ambiguous" in result.output or "ambiguous" in result.output
+
+    # Verify no note was inserted under the prefix.
+    notes = _read_notes(db_path, "KXCPI")
+    assert notes == []
 
 
 def test_observation_allowed_when_surfacing_evidence(

--- a/tests/unit/test_observation_validator.py
+++ b/tests/unit/test_observation_validator.py
@@ -1,0 +1,318 @@
+"""Unit tests for the observation read-back validator (#614).
+
+These are pure-function tests — no DB, no CLI. The CLI integration tests
+live in test_cli_observation_validator.py.
+"""
+
+from __future__ import annotations
+
+import re
+
+from gimmes.store.observation_validator import (
+    AGGREGATORS,
+    ECONOMIC_CATEGORIES,
+    NAMED_BANKS,
+    STALE_TEMPLATE_PHRASE,
+    contains_stale_template,
+    extract_cited_evidence,
+    ticker_in_economic_category,
+    validate,
+)
+
+C1407_STALE = (
+    "No named major Wall Street bank has published April CPI MoM"
+    " strictly above 0.5%"
+)
+
+CM_DECISION_WITH_BARCLAYS = (
+    "Decision: HOLD.\n"
+    "Reasoning: thesis intact; price unchanged.\n"
+    "Cited sources:\n"
+    "- Barclays April headline CPI MoM +0.55% (FXStreet, 2026-05-08)\n"
+    "- Wells Fargo April headline CPI MoM +0.63% (FXStreet, 2026-05-08)"
+)
+
+CM_DECISION_NO_BANKS = (
+    "Decision: HOLD.\n"
+    "Reasoning: thesis intact; price moved within noise band.\n"
+    "Cited sources:\n"
+    "None — decision based on price + thesis only"
+)
+
+
+class TestTickerInEconomicCategory:
+    def test_kxcpi_matches(self) -> None:
+        assert ticker_in_economic_category("KXCPI-26APR-T0.5")
+
+    def test_kxpayrolls_matches(self) -> None:
+        assert ticker_in_economic_category("KXPAYROLLS-26APR-T100000")
+
+    def test_kxjoblessclaims_matches(self) -> None:
+        assert ticker_in_economic_category(
+            "KXJOBLESSCLAIMS-26MAY14-210000",
+        )
+
+    def test_kxspx_does_not_match(self) -> None:
+        # Equity-index tickers are out of scope.
+        assert not ticker_in_economic_category("KXSPX-26MAY-T5000")
+
+    def test_kxinx_does_not_match(self) -> None:
+        assert not ticker_in_economic_category(
+            "KXINX-26APR27H1600-B7162",
+        )
+
+    def test_kxnasdaq100_does_not_match(self) -> None:
+        assert not ticker_in_economic_category(
+            "KXNASDAQ100-26APR24H1600-B27350",
+        )
+
+    def test_case_insensitive(self) -> None:
+        assert ticker_in_economic_category("kxcpi-26apr-t0.5")
+
+
+class TestContainsStaleTemplate:
+    def test_canonical_phrase_present(self) -> None:
+        assert contains_stale_template(C1407_STALE)
+
+    def test_case_insensitive_match(self) -> None:
+        upper = C1407_STALE.upper()
+        assert contains_stale_template(upper)
+
+    def test_phrase_absent(self) -> None:
+        assert not contains_stale_template(
+            "Barclays +0.55% confirmed; thesis intact.",
+        )
+
+    def test_empty_body(self) -> None:
+        assert not contains_stale_template("")
+
+
+class TestExtractCitedEvidence:
+    def test_extracts_barclays_with_value(self) -> None:
+        pairs = extract_cited_evidence(CM_DECISION_WITH_BARCLAYS)
+        # Should find both Barclays and Wells Fargo on their respective
+        # lines, each paired with the inline numeric value.
+        sources = [s for s, _ in pairs]
+        values = [v for _, v in pairs]
+        assert "Barclays" in sources
+        assert "Wells Fargo" in sources
+        assert "+0.55%" in values
+        assert "+0.63%" in values
+
+    def test_no_pairs_when_silent(self) -> None:
+        assert extract_cited_evidence(CM_DECISION_NO_BANKS) == []
+
+    def test_no_pairs_when_bank_without_value(self) -> None:
+        body = (
+            "Decision: HOLD.\n"
+            "Reasoning: Barclays research suggests interest in this print"
+            " but no quantitative claim made."
+        )
+        # No `%` on the Barclays line.
+        assert extract_cited_evidence(body) == []
+
+    def test_same_line_proximity_enforced(self) -> None:
+        # "Barclays said April CPI is interesting" → no `%`.
+        # Next paragraph: "+0.55% was the print".
+        # Even though `+0.55%` appears in the body, it's not on the
+        # Barclays line, so no pair.
+        body = (
+            "Barclays said April CPI is interesting.\n"
+            "\n"
+            "+0.55% was the print.\n"
+        )
+        assert extract_cited_evidence(body) == []
+
+    def test_citi_aliases_match_citibank_and_citigroup(self) -> None:
+        # Pre-#614 the regex was strict `\bCiti\b`, which silently let
+        # "Citibank +0.42%" through as a non-citation. The silent-
+        # failure-hunter on PR #614 surfaced this as a real silent-pass
+        # path (CM prose freely writes Citibank/Citigroup for the same
+        # institution). The validator now treats both as Citi citations.
+        body = "Citibank research +0.42% on April CPI MoM."
+        pairs = extract_cited_evidence(body)
+        assert len(pairs) == 1
+        assert pairs[0][0].startswith("Citi")
+        assert pairs[0][1] == "+0.42%"
+
+    def test_citi_matches_when_standalone(self) -> None:
+        body = "Citi +0.42% on April CPI MoM."
+        pairs = extract_cited_evidence(body)
+        assert pairs == [("Citi", "+0.42%")]
+
+    def test_citibank_matches_as_citi_alias(self) -> None:
+        # CM prose often writes "Citibank analysts forecast +0.42%" or
+        # "Citigroup +0.42%" — these are the same institution as "Citi"
+        # in the playbook list. The validator must catch all three so a
+        # CM citation under any form triggers the read-back rule.
+        body = "Citibank analysts forecast +0.42% on April CPI MoM."
+        pairs = extract_cited_evidence(body)
+        assert len(pairs) == 1
+        # The canonical-form returned is "Citibank" (the literal match);
+        # downstream consumers only need to know SOME cited evidence
+        # exists.
+        source, value = pairs[0]
+        assert source.startswith("Citi")
+        assert value == "+0.42%"
+
+    def test_citigroup_matches_as_citi_alias(self) -> None:
+        body = "Citigroup +0.50% on April CPI MoM."
+        pairs = extract_cited_evidence(body)
+        assert len(pairs) == 1
+        source, value = pairs[0]
+        assert source.startswith("Citi")
+        assert value == "+0.50%"
+
+    def test_aggregator_match_fxstreet(self) -> None:
+        body = "FXStreet aggregate +0.55% on April headline CPI MoM."
+        pairs = extract_cited_evidence(body)
+        assert pairs == [("FXStreet", "+0.55%")]
+
+    def test_jpmorgan_full_name(self) -> None:
+        body = "JPMorgan estimates +0.47% on April CPI MoM."
+        pairs = extract_cited_evidence(body)
+        assert pairs == [("JPMorgan", "+0.47%")]
+
+
+class TestValidate:
+    def test_reject_cited_bank_with_value_and_stale_template(self) -> None:
+        ok, err = validate(
+            ticker="KXCPI-26APR-T0.5",
+            observation_body=C1407_STALE,
+            decision_body=CM_DECISION_WITH_BARCLAYS,
+        )
+        assert ok is False
+        assert err is not None
+        assert "Barclays" in err or "Wells Fargo" in err
+        # Error message must reference both issue numbers for
+        # actionability.
+        assert "#577" in err
+        assert "#614" in err
+
+    def test_allow_cm_silent_on_banks(self) -> None:
+        # Vacuous case: CM cites no banks → nothing to contradict.
+        ok, err = validate(
+            ticker="KXCPI-26APR-T0.5",
+            observation_body=C1407_STALE,
+            decision_body=CM_DECISION_NO_BANKS,
+        )
+        assert ok is True
+        assert err is None
+
+    def test_allow_ticker_not_in_economic_category(self) -> None:
+        # KXSPX is an equity index — out of validator scope.
+        ok, err = validate(
+            ticker="KXSPX-26MAY-T5000",
+            observation_body=C1407_STALE,
+            decision_body=CM_DECISION_WITH_BARCLAYS,
+        )
+        assert ok is True
+        assert err is None
+
+    def test_allow_no_prior_decision(self) -> None:
+        # Position with no prior CM decision note yet.
+        ok, err = validate(
+            ticker="KXCPI-26APR-T0.5",
+            observation_body=C1407_STALE,
+            decision_body=None,
+        )
+        assert ok is True
+        assert err is None
+
+    def test_allow_bank_named_without_numeric_value(self) -> None:
+        body = (
+            "Decision: HOLD.\n"
+            "Reasoning: Barclays research mentioned but no forecast"
+            " quantified."
+        )
+        ok, err = validate(
+            ticker="KXCPI-26APR-T0.5",
+            observation_body=C1407_STALE,
+            decision_body=body,
+        )
+        # No quantitative claim → nothing to contradict.
+        assert ok is True
+        assert err is None
+
+    def test_allow_observation_without_stale_phrase(self) -> None:
+        # Observation surfaces Barclays correctly — passes regardless of
+        # what CM cited.
+        obs = "Barclays +0.55% confirmed this cycle (FXStreet, 2026-05-08)."
+        ok, err = validate(
+            ticker="KXCPI-26APR-T0.5",
+            observation_body=obs,
+            decision_body=CM_DECISION_WITH_BARCLAYS,
+        )
+        assert ok is True
+        assert err is None
+
+    def test_case_insensitive_stale_phrase_still_rejects(self) -> None:
+        ok, _ = validate(
+            ticker="KXCPI-26APR-T0.5",
+            observation_body=C1407_STALE.upper(),
+            decision_body=CM_DECISION_WITH_BARCLAYS,
+        )
+        assert ok is False
+
+
+class TestConstantsSyncWithMonitorMd:
+    """Drift-guard: hard-coded constants in observation_validator.py
+    must stay in sync with .claude/agents/monitor.md's playbook lists.
+    Validator works without parsing monitor.md at runtime (avoids
+    install-path fragility), but this test catches drift."""
+
+    def _monitor_md(self) -> str:
+        from pathlib import Path
+
+        path = (
+            Path(__file__).resolve().parents[2]
+            / ".claude"
+            / "agents"
+            / "monitor.md"
+        )
+        return path.read_text()
+
+    def test_banks_match_monitor_playbook(self) -> None:
+        text = self._monitor_md()
+        for bank in NAMED_BANKS:
+            assert bank in text, (
+                f"NAMED_BANKS contains {bank!r} but monitor.md does not"
+                f" mention it. Constants drift — sync the playbook."
+            )
+
+    def test_aggregators_match_monitor_playbook(self) -> None:
+        text = self._monitor_md()
+        for source in AGGREGATORS:
+            assert source in text, (
+                f"AGGREGATORS contains {source!r} but monitor.md does"
+                f" not mention it. Constants drift."
+            )
+
+    def test_economic_categories_match_monitor_playbook(self) -> None:
+        text = self._monitor_md()
+        for prefix in ECONOMIC_CATEGORIES:
+            # Word-boundary check so KXCPI doesn't accidentally match
+            # KXCPICORE (which is also in the list — both must appear).
+            assert re.search(rf"\b{re.escape(prefix)}\b", text), (
+                f"ECONOMIC_CATEGORIES contains {prefix!r} but"
+                f" monitor.md's playbook does not list it. Constants"
+                f" drift."
+            )
+
+    def test_stale_template_phrase_is_lowercase(self) -> None:
+        # Documented contract: the phrase is stored lowercase so the
+        # matcher can compare with `body.lower()` (case-insensitive).
+        assert STALE_TEMPLATE_PHRASE == STALE_TEMPLATE_PHRASE.lower()
+
+    def test_stale_template_phrase_appears_in_monitor_md(self) -> None:
+        """If monitor.md ever changes the canonical stale-template
+        phrase, the validator silently misses every future c1407-class
+        regression. Pin the phrase against monitor.md so a rename in
+        the prompt forces a corresponding validator update."""
+        text = self._monitor_md().lower()
+        assert STALE_TEMPLATE_PHRASE in text, (
+            f"STALE_TEMPLATE_PHRASE {STALE_TEMPLATE_PHRASE!r} is not"
+            f" present in monitor.md. The validator must pin the same"
+            f" canonical phrase that monitor.md's FORBIDDEN clause"
+            f" forbids. Update one or the other to re-align (#614)."
+        )


### PR DESCRIPTION
## Summary

Closes #614, follow-up to #577 (PR #613) and #617 (PR #620). The prior PRs added prompt-level rules for Monitor's read-back assertion; this PR adds the **runtime forcing function** that would have caught the c1407 regression deterministically.

## What changed

**NEW `src/gimmes/store/observation_validator.py`** — pure-function validator with hard-coded constants (9 named banks, 4 aggregators, 17 economic-trigger Kalshi categories, the canonical c1407 stale-template phrase). Same-line proximity for source-with-value matching. Word-boundary regex; Citi has explicit alias handling for Citibank/Citigroup.

**`src/gimmes/cli.py`** — `position-note` runs the validator before insert when `--type observation` (and not `--force`). New hidden `--force` flag for backfill scripts (prints audit warning). Ticker is canonicalized via `resolve_ticker(source="known_markets")` before the decision lookup so canonical-form drift can't silently defeat the validator.

**`.claude/agents/monitor.md`** — addendum after the FORBIDDEN clause documenting the CLI enforcement + explicit "do NOT use --force" guidance for autonomous Monitor cycles.

**Tests (NEW):** 32 unit tests (`test_observation_validator.py`) + 7 CLI integration (`test_cli_observation_validator.py`). Drift-guards pin every constant against `monitor.md`.

## Will this have caught c1407?

Yes — the test `test_observation_rejected_when_validator_fails` is a literal-AC reproduction. Seed a CM decision citing `Barclays +0.55%`, try to write the c1407 stale-template observation, validator exits 1, no row inserted. Operator/agent sees the rejection message naming Barclays + the offending phrase, with both #577/#614 issue refs.

## Known limitations (deferred to follow-ups)

- `--force` is not persisted in the DB row, only printed (no `force` column on `position_notes`). Acceptable for backfill use case; review if force becomes more common.
- WAL race window: if CM and Monitor write concurrently to the same ticker, Monitor's read could land before CM's commit. Sub-second window, ordering enforced by the autonomous-loop dispatcher in practice.
- Multi-bank-per-line citations only surface ONE bank in the error message (others silently dropped from the message but rejection still fires).

## Test plan

- [x] `uv run pytest tests/unit/test_observation_validator.py tests/unit/test_cli_observation_validator.py tests/unit/test_agent_prompts.py` — 88 passed
- [x] `uv run ruff check` on all touched files — clean
- [x] Review pipeline (3 agents parallel) — all confidence-80+ findings addressed (ticker canonicalization, Citi alias handling, STALE_TEMPLATE_PHRASE drift-guard, flag-type test tightened)
