### PR TITLE
Fix #609: synthetic close for reconcile-driven drift

### DIFF
--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -163,19 +163,134 @@ async def upsert_position(db: Database, pos: Position) -> None:
     await db.conn.commit()
 
 
-async def _sync_positions_rows(db: Database, positions: list[Position]) -> None:
-    """Core position sync SQL. Caller manages the transaction."""
+async def _sync_positions_rows(
+    db: Database, positions: list[Position],
+) -> list[Position]:
+    """Core position sync SQL. Caller manages the transaction.
+
+    Returns the list of `Position` objects that were REMOVED from the
+    DB (positions present in the DB but absent from the new sync set).
+    Callers use this to log synthetic close trades for reconcile drift
+    (#609) — without that, the removed ticker drops out of
+    `known_markets` and Caddie Master's #586 lockout query passes
+    silently with no lockout in effect.
+    """
     current_tickers = {p.ticker for p in positions}
-    # Remove positions that no longer exist
-    cursor = await db.conn.execute("SELECT ticker FROM positions")
-    for row in await cursor.fetchall():
+    cursor = await db.conn.execute("SELECT * FROM positions")
+    rows = await cursor.fetchall()
+    removed: list[Position] = []
+    for row in rows:
         if row["ticker"] not in current_tickers:
+            close_time_val = (
+                row["close_time"] if "close_time" in row.keys() else None
+            )
+            close_time_dt = None
+            if close_time_val:
+                try:
+                    close_time_dt = datetime.fromisoformat(close_time_val)
+                except (ValueError, TypeError):
+                    pass
+            removed.append(
+                Position(
+                    ticker=row["ticker"],
+                    title=row["title"],
+                    side=row["side"],
+                    count=row["count"],
+                    avg_price=row["avg_price"],
+                    market_price=row["market_price"],
+                    cost_basis=row["cost_basis"],
+                    market_value=row["market_value"],
+                    unrealized_pnl=row["unrealized_pnl"],
+                    realized_pnl=row["realized_pnl"],
+                    close_time=close_time_dt,
+                )
+            )
             await db.conn.execute(
                 "DELETE FROM positions WHERE ticker = ?", (row["ticker"],)
             )
-    # Upsert current positions
     for pos in positions:
         await db.conn.execute(_UPSERT_POSITION_SQL, _position_params(pos))
+    return removed
+
+
+async def _log_reconcile_closes(
+    db: Database,
+    removed: list[Position],
+    *,
+    exclude_ticker: str | None = None,
+) -> None:
+    """Write a synthetic close trade + decision note for each removed
+    position (#609 — reconcile-driven drift).
+
+    Without these synthetic rows, a position closed off-CLI (manual
+    Kalshi UI close, broker liquidation, settlement, API divergence
+    corrected by reconcile) drops out of `known_markets` and Caddie
+    Master's #586 stop-loss reopen lockout cannot resolve the ticker —
+    legitimate stop-loss closes would be silently un-locked.
+
+    The synthetic decision note uses `Trigger: Reconcile-divergence`
+    (NOT `Trigger: Stop-loss breach`), so the #586 lockout query
+    correctly does NOT fire on reconcile-driven closes — allowing
+    legitimate re-entry after broker drift.
+
+    Caller MUST invoke inside an active transaction. The synthetic
+    rows use commit-less helpers so they participate in the caller's
+    transaction.
+    """
+    import os
+
+    cycle_env = os.environ.get("GIMMES_CYCLE", "0")
+    try:
+        cycle = int(cycle_env or 0)
+    except ValueError:
+        cycle = 0
+
+    for pos in removed:
+        if exclude_ticker and pos.ticker == exclude_ticker:
+            continue
+        # Use last-known mark (market_price or avg_price) as the close
+        # price rather than 0.0 — keeps `get_daily_pnl`'s realized-P&L
+        # math honest. Documented in the rationale so audit can see
+        # this isn't a broker-confirmed fill.
+        close_price = pos.market_price if pos.market_price else pos.avg_price
+        synth = TradeDecision(
+            ticker=pos.ticker,
+            action=TradeDecision.Action.CLOSE,
+            side=pos.side,
+            count=pos.count,
+            price=close_price,
+            rationale=(
+                "reconcile drift — broker removed position without local"
+                " close; price is last-known mark, not broker-confirmed"
+                " fill (#609)"
+            ),
+            agent="reconcile",
+        )
+        await _insert_trade_row(db, synth)
+
+        # IMPORTANT: this body MUST NOT contain the literal string
+        # `Trigger: Stop-loss breach` anywhere — not even in explanatory
+        # text — because Caddie Master's #586 lockout query is a
+        # substring match. Quoting the forbidden phrase here would
+        # silently lock out legitimate re-entry after reconcile drift.
+        body = (
+            f"Decision: CLOSE\n"
+            f"Trigger: Reconcile-divergence\n"
+            f"Side: {pos.side}\n"
+            f"Count: {pos.count}\n"
+            f"Last-known mark: {close_price}\n"
+            f"Rationale: broker reported position absent during reconcile;"
+            f" local DB had it open. This is broker-divergence drift,"
+            f" not an adverse price event. The #586 reopen lockout does"
+            f" NOT apply to this close — re-entry is allowed on the next"
+            f" cycle."
+        )
+        await db.conn.execute(
+            "INSERT INTO position_notes"
+            " (ticker, cycle, agent, note_type, body)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (pos.ticker, cycle, "reconcile", "decision", body),
+        )
 
 
 async def sync_positions(db: Database, positions: list[Position]) -> None:
@@ -183,9 +298,12 @@ async def sync_positions(db: Database, positions: list[Position]) -> None:
 
     Runs as a single atomic transaction — clears stale positions and upserts
     current ones so the local DB always reflects the API/broker state.
+    Removed positions get a synthetic close trade + reconcile-divergence
+    decision note so they remain resolvable via `known_markets` (#609).
     """
     async with db.transaction():
-        await _sync_positions_rows(db, positions)
+        removed = await _sync_positions_rows(db, positions)
+        await _log_reconcile_closes(db, removed)
 
 
 async def sync_positions_with_trade(
@@ -195,9 +313,17 @@ async def sync_positions_with_trade(
 
     Ensures position state and trade log are always consistent — if either
     operation fails, both are rolled back.  Returns the trade row ID.
+
+    If OTHER tickers are also being removed (multi-ticker drift in the
+    same sync), they get synthetic close trades + reconcile-divergence
+    decision notes via `_log_reconcile_closes`. The caller's trade
+    ticker is excluded — it gets logged explicitly below.
     """
     async with db.transaction():
-        await _sync_positions_rows(db, positions)
+        removed = await _sync_positions_rows(db, positions)
+        await _log_reconcile_closes(
+            db, removed, exclude_ticker=trade.ticker,
+        )
         return await _insert_trade_row(db, trade)
 
 

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -182,3 +182,221 @@ class TestGetPositionsStalenessWarning:
             await get_positions(db)
 
         assert "stale" not in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Reconcile-driven synthetic close (#609)
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileDriftLogsSyntheticClose:
+    async def test_removed_ticker_logs_synthetic_close_trade(self, db):
+        """Pre-existing position absent from new sync → trades table
+        gets a close row with agent='reconcile' and the last-known
+        mark as the close price (#609)."""
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5", count=10, price=0.42))
+
+        await sync_positions(db, [])
+
+        trades = await get_trades(db)
+        assert len(trades) == 1, trades
+        t = trades[0]
+        assert t["ticker"] == "KXCPI-26APR-T0.5"
+        assert t["action"] == "close"
+        assert t["agent"] == "reconcile"
+        assert t["count"] == 10
+        # Price falls back to market_price or avg_price — both 0.42
+        # in the fixture. Verify it's NOT 0.0 (which would corrupt
+        # daily P&L math).
+        assert t["price"] == 0.42
+        assert "reconcile drift" in t["rationale"]
+        assert "#609" in t["rationale"]
+
+    async def test_removed_ticker_logs_reconcile_divergence_decision_note(
+        self, db,
+    ):
+        """The synthetic close also writes a decision note with
+        Trigger: Reconcile-divergence so the #586 lockout query does
+        NOT match — legitimate re-entry is allowed after reconcile
+        drift (#609)."""
+        from gimmes.store.queries import get_position_notes
+
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5"))
+        await sync_positions(db, [])
+
+        notes = await get_position_notes(
+            db, "KXCPI-26APR-T0.5", note_type="decision",
+        )
+        assert len(notes) == 1, notes
+        body = notes[0]["body"]
+        assert "Decision: CLOSE" in body
+        assert "Trigger: Reconcile-divergence" in body
+        # CRITICAL invariant — the body MUST NOT contain
+        # `Trigger: Stop-loss breach`. If it did, Caddie Master's
+        # #586 lockout query would treat reconcile-driven drift as
+        # a stop-loss event and silently block legitimate re-entry.
+        assert "Trigger: Stop-loss breach" not in body
+        assert notes[0]["agent"] == "reconcile"
+
+    async def test_known_markets_resolves_reconciled_close(self, db):
+        """After a reconcile-driven close, `resolve_ticker` finds the
+        ticker via the trades table — closing the #586 lockout's
+        `known_markets` resolver gap that #609 was filed to fix."""
+        from gimmes.store.ticker_resolver import resolve_ticker
+
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5"))
+        await sync_positions(db, [])
+
+        # positions table no longer has the ticker (count=0)
+        stored = await get_positions(db)
+        assert all(p.ticker != "KXCPI-26APR-T0.5" for p in stored)
+
+        # but known_markets (positions ∪ candidates ∪ trades) does,
+        # because the synthetic close wrote a trades row.
+        matches = await resolve_ticker(
+            db, "KXCPI-26APR-T0.5", source="known_markets",
+        )
+        assert matches == ["KXCPI-26APR-T0.5"]
+
+    async def test_sync_with_trade_excludes_closer_ticker(self, db):
+        """When sync_positions_with_trade is called by the Closer,
+        the caller's trade ticker is excluded from synthetic-close
+        logging (the caller logs it explicitly). Other removed tickers
+        — multi-ticker drift in the same sync — still get synthetic
+        closes (#609)."""
+        await upsert_position(db, _pos("CLOSER-TICKER"))
+        await upsert_position(db, _pos("DRIFT-TICKER"))
+
+        trade = TradeDecision(
+            ticker="CLOSER-TICKER",
+            action=TradeDecision.Action.CLOSE,
+            side="yes", count=10, price=0.55,
+            rationale="Closer sold full position",
+            agent="closer",
+        )
+        await sync_positions_with_trade(db, [], trade)
+
+        trades = await get_trades(db)
+        by_agent = {t["agent"]: t["ticker"] for t in trades}
+        # Closer's trade is logged (the caller's explicit log).
+        assert by_agent.get("closer") == "CLOSER-TICKER"
+        # DRIFT-TICKER gets a synthetic reconcile close.
+        assert by_agent.get("reconcile") == "DRIFT-TICKER"
+
+    async def test_reconcile_synthetic_close_is_idempotent(self, db):
+        """Running sync_positions twice with the same empty set does
+        not write duplicate synthetic closes — second call sees the
+        position already absent and produces no new trades (#609)."""
+        await upsert_position(db, _pos("KXCPI-26APR-T0.5"))
+        await sync_positions(db, [])
+        await sync_positions(db, [])
+
+        trades = await get_trades(db)
+        assert len(trades) == 1, trades
+
+    async def test_zero_market_price_falls_back_to_avg_price(self, db):
+        """If market_price is 0/null (e.g., position never marked),
+        the synthetic close uses avg_price as the close mark — keeps
+        daily P&L math honest. Falling back to 0.0 would corrupt P&L
+        reports."""
+        pos = Position(
+            ticker="ZERO-MARK", side="yes", count=10,
+            avg_price=0.42, market_price=0.0,
+            cost_basis=4.2,
+        )
+        await upsert_position(db, pos)
+        await sync_positions(db, [])
+
+        trades = await get_trades(db)
+        assert len(trades) == 1
+        assert trades[0]["price"] == 0.42
+
+    async def test_both_zero_marks_produce_zero_close_price(self, db):
+        """Edge case: position with market_price=0 AND avg_price=0
+        (newly-opened during a Kalshi outage, never marked). The
+        fallback chain returns 0.0 — synthetic close at 0 yields a
+        synthetic realized P&L of (0 - 0) * count = 0, which is
+        mathematically neutral. Not a corruption — just a record
+        of the close happening at the only price we have on file
+        (the entry, which itself was zero)."""
+        pos = Position(
+            ticker="DOUBLE-ZERO", side="yes", count=10,
+            avg_price=0.0, market_price=0.0,
+            cost_basis=0.0,
+        )
+        await upsert_position(db, pos)
+        await sync_positions(db, [])
+
+        trades = await get_trades(db)
+        assert len(trades) == 1
+        assert trades[0]["price"] == 0.0
+        assert trades[0]["agent"] == "reconcile"
+
+
+def test_caddie_master_lockout_query_does_not_match_reconcile_body() -> None:
+    """Cross-file drift guard (#609): the literal trigger strings
+    `Trigger: Stop-loss breach` (in caddie-master.md's #586 lockout
+    query) and `Trigger: Reconcile-divergence` (in queries.py's
+    synthetic decision-note body) are coupled across files. A rename
+    on either side breaks the lockout semantics with no other test
+    failure. This test pins both literals and asserts the body
+    generated by `_log_reconcile_closes` cannot match the lockout
+    query."""
+    from pathlib import Path
+
+    cm_md = (
+        Path(__file__).resolve().parents[2]
+        / ".claude" / "agents" / "caddie-master.md"
+    ).read_text()
+    queries_py = (
+        Path(__file__).resolve().parents[2]
+        / "src" / "gimmes" / "store" / "queries.py"
+    ).read_text()
+
+    # Lockout query string must still match the body Reconcile-divergence
+    # was designed NOT to satisfy.
+    assert "Trigger: Stop-loss breach" in cm_md, (
+        "caddie-master.md #586 lockout must still reference"
+        " `Trigger: Stop-loss breach` literal. Rename here without"
+        " a corresponding rename in queries.py's synthetic-close"
+        " logic would break lockout semantics (#609)."
+    )
+
+    # Reconcile body uses Reconcile-divergence.
+    assert "Trigger: Reconcile-divergence" in queries_py, (
+        "queries.py's _log_reconcile_closes must still write"
+        " `Trigger: Reconcile-divergence` in the decision body."
+        " Renaming this without updating caddie-master.md would"
+        " be silently fine (lockout still doesn't match) — but"
+        " auditors looking for the marker would be confused (#609)."
+    )
+
+    # And queries.py's RUNTIME body string must not contain the
+    # stop-loss breach literal. (The literal appears in docstrings
+    # / comments inside queries.py for documentation, but the
+    # actual `body = ( ... )` string passed to insert must not.)
+
+    # Pull out the `body = (\n ... )\n` block inside
+    # _log_reconcile_closes. The function name is unique in the file
+    # so a simple find-from-anchor works regardless of preceding
+    # docstring backticks.
+    func_idx = queries_py.find("def _log_reconcile_closes")
+    assert func_idx != -1, (
+        "_log_reconcile_closes function not found (drift-guard"
+        " scaffolding broken)."
+    )
+    body_assign_idx = queries_py.find("body = (", func_idx)
+    body_close_idx = queries_py.find(")", body_assign_idx)
+    assert body_assign_idx != -1 and body_close_idx != -1, (
+        "_log_reconcile_closes must have a `body = (...)` string"
+        " assignment (drift-guard scaffolding broken)."
+    )
+    body_template = queries_py[body_assign_idx:body_close_idx]
+    assert "Trigger: Stop-loss breach" not in body_template, (
+        "queries.py's _log_reconcile_closes body template MUST NOT"
+        " contain the literal `Trigger: Stop-loss breach` —"
+        " Caddie Master's #586 lockout query is a substring match,"
+        " so including the phrase anywhere in the body (even in"
+        " explanatory rationale text) would silently lock out"
+        " legitimate re-entry after reconcile drift (#609)."
+    )

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -379,17 +379,35 @@ def test_caddie_master_lockout_query_does_not_match_reconcile_body() -> None:
     # Pull out the `body = (\n ... )\n` block inside
     # _log_reconcile_closes. The function name is unique in the file
     # so a simple find-from-anchor works regardless of preceding
-    # docstring backticks.
+    # docstring backticks. Use paren-depth tracking (not a naive
+    # str.find for the next `)`) so a future edit that introduces
+    # a `)` inside the body string can't terminate the slice early
+    # and silently weaken the guard.
     func_idx = queries_py.find("def _log_reconcile_closes")
     assert func_idx != -1, (
         "_log_reconcile_closes function not found (drift-guard"
         " scaffolding broken)."
     )
     body_assign_idx = queries_py.find("body = (", func_idx)
-    body_close_idx = queries_py.find(")", body_assign_idx)
-    assert body_assign_idx != -1 and body_close_idx != -1, (
+    assert body_assign_idx != -1, (
         "_log_reconcile_closes must have a `body = (...)` string"
         " assignment (drift-guard scaffolding broken)."
+    )
+    # Start tracking AFTER the opening `(`.
+    open_paren_idx = body_assign_idx + len("body = (") - 1
+    depth = 0
+    body_close_idx = -1
+    for i, ch in enumerate(queries_py[open_paren_idx:], start=open_paren_idx):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                body_close_idx = i
+                break
+    assert body_close_idx != -1, (
+        "Could not find matching `)` for the `body = (` in"
+        " _log_reconcile_closes (drift-guard scaffolding broken)."
     )
     body_template = queries_py[body_assign_idx:body_close_idx]
     assert "Trigger: Stop-loss breach" not in body_template, (


### PR DESCRIPTION
## Summary

Closes #609 — reconcile-driven position closes used to delete the position row without logging a `trades` row. The ticker dropped out of `known_markets` (positions ∪ candidates ∪ trades) and Caddie Master's #586 stop-loss reopen lockout query passed silently with no lockout in effect.

## What changed

**`src/gimmes/store/queries.py`** — `_sync_positions_rows` now returns the removed `Position` objects. New helper `_log_reconcile_closes` writes:
- A synthetic CLOSE trade with `agent='reconcile'` and the last-known mark as the close price (`market_price or avg_price`, NOT 0.0).
- A `decision`-type position-note with `Trigger: Reconcile-divergence` (NOT `Stop-loss breach`).

Both inside the same transaction as the sync — atomic, no partial writes. `sync_positions_with_trade` excludes the caller's trade ticker so it's not double-logged.

The note body string is carefully constructed to never mention `Trigger: Stop-loss breach` — even in explanatory text — because Caddie Master's lockout query is a substring match. A cross-file drift-guard test pins the literals on both sides (`caddie-master.md` and `queries.py`).

**Tests** — 7 new + 1 cross-file drift-guard. Covers: trade row content, decision note (positive + negative invariants), `known_markets` resolves the closed ticker, multi-ticker exclusion, idempotency, market_price/avg_price/zero fallbacks.

## Known limitations (follow-ups filed)

- **#622**: `get_daily_pnl` aggregates reconcile-agent rows. Out-of-scope here — could either filter or expose drift P&L separately.
- **#623**: Paper-mode reconcile uses `paper_positions` directly and doesn't route through `sync_positions`. Same silent-failure pattern persists for paper users; needs a parallel fix in `paper/broker.py`.

## Test plan

- [x] `uv run pytest tests/unit/test_sync_positions.py` — 18 passed
- [x] `uv run ruff check` — clean
- [x] Review pipeline (3 agents parallel) — all confidence-80+ findings either addressed in-PR or filed as #622/#623
