### PR TITLE
Make budget caps config-settable

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import TypeVar
 
 import click
 import typer
@@ -4242,12 +4243,15 @@ def _extract_terminal_text(json_bytes: bytes) -> bytes:
     return json_bytes
 
 
+_BudgetCapT = TypeVar("_BudgetCapT", int, float)
+
+
 def _resolve_budget_cap(
     *,
-    cli_value: float | int | None,
-    config_value: float | int | None,
-    default: float | int,
-) -> float | int:
+    cli_value: _BudgetCapT | None,
+    config_value: _BudgetCapT | None,
+    default: _BudgetCapT,
+) -> _BudgetCapT:
     """Resolve a budget-cap value via CLI > config > hardcoded default.
 
     CLI flag wins when present (non-None) so operators can override on

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4242,6 +4242,31 @@ def _extract_terminal_text(json_bytes: bytes) -> bytes:
     return json_bytes
 
 
+def _resolve_budget_cap(
+    *,
+    cli_value: float | int | None,
+    config_value: float | int | None,
+    default: float | int,
+) -> float | int:
+    """Resolve a budget-cap value via CLI > config > hardcoded default.
+
+    CLI flag wins when present (non-None) so operators can override on
+    a per-run basis. When the CLI flag is None, fall back to the
+    config-provided value if set; otherwise return the hardcoded
+    default from `gimmes.budget`. Lets `gimmes config set
+    budget.max_daily_cost_usd 50` persist across restarts without
+    requiring the operator to remember the CLI flag every time.
+
+    A value of 0 (from CLI or config) explicitly means "unlimited" and
+    is preserved — distinct from None which means "no override."
+    """
+    if cli_value is not None:
+        return cli_value
+    if config_value is not None:
+        return config_value
+    return default
+
+
 def _wrap_stream_json(raw: bytes) -> bytes:
     """Wrap newline-delimited JSON events into a JSON array.
 
@@ -4392,18 +4417,25 @@ def _autonomous_loop(
     )
     from gimmes.config import GIMMES_HOME
 
+    # Resolve daily caps via three-tier precedence: CLI flag wins; if
+    # absent, fall back to `budget.max_*` config; if both absent, use
+    # the hardcoded DEFAULT_MAX_* constants. Lets operators raise the
+    # caps once via `gimmes config set` without having to remember the
+    # CLI flags on every restart.
+    resolved_max_sessions = _resolve_budget_cap(
+        cli_value=max_sessions_per_day,
+        config_value=config.budget.max_sessions_per_day,
+        default=DEFAULT_MAX_SESSIONS,
+    )
+    resolved_max_cost = _resolve_budget_cap(
+        cli_value=max_daily_cost_usd,
+        config_value=config.budget.max_daily_cost_usd,
+        default=DEFAULT_MAX_USD,
+    )
     budget_tracker = BudgetTracker(
         path=GIMMES_HOME / "budget.json",
-        max_sessions=(
-            DEFAULT_MAX_SESSIONS
-            if max_sessions_per_day is None
-            else max_sessions_per_day
-        ),
-        max_cost_usd=(
-            DEFAULT_MAX_USD
-            if max_daily_cost_usd is None
-            else max_daily_cost_usd
-        ),
+        max_sessions=resolved_max_sessions,
+        max_cost_usd=resolved_max_cost,
     )
     # Persist the live caps immediately so `gimmes budget` shows the
     # operator's actual limits even if the loop blocks before the first

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -986,6 +986,11 @@ class BudgetConfig(BaseModel):
                 " sleeps until UTC midnight when this is reached."
                 " None = hardcoded default ($25). 0 = unlimited."
             ),
+            # Mirror Pydantic's ge=0.0 into the wizard's range check so
+            # `gimmes config set budget.max_daily_cost_usd -1` is
+            # rejected at entry time, not later when the loaded config
+            # tries to construct BudgetConfig.
+            "min_val": 0.0,
         },
     )
 
@@ -998,6 +1003,7 @@ class BudgetConfig(BaseModel):
                 "Hard cap on Claude Code sessions started per UTC"
                 " day. None = hardcoded default (80). 0 = unlimited."
             ),
+            "min_val": 0,
         },
     )
 
@@ -1246,4 +1252,5 @@ def load_config(db_path: Path | None = None) -> GimmesConfig:
         scanner=ScannerConfig(**overrides.get("scanner", {})),
         scoring=ScoringConfig(**overrides.get("scoring", {})),
         model=ModelConfig(**overrides.get("model", {})),
+        budget=BudgetConfig(**overrides.get("budget", {})),
     )

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -945,6 +945,64 @@ class ModelConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Budget caps (persistent overrides for the autonomous-loop daily caps)
+# ---------------------------------------------------------------------------
+
+
+class BudgetConfig(BaseModel):
+    """Persistent overrides for the autonomous-loop daily Claude API caps.
+
+    The autonomous loop accepts CLI flags ``--max-daily-cost-usd`` and
+    ``--max-sessions-per-day`` at startup. Setting them here lets you
+    raise (or lower) the caps once and forget — every restart picks up
+    the config value without having to remember the flags. CLI flags
+    still win when both are present.
+
+    ``None`` (the default) means "use the hardcoded ``DEFAULT_MAX_USD``
+    and ``DEFAULT_MAX_SESSIONS`` from ``gimmes/budget.py``." Set to
+    ``0`` to make the cap unlimited (matches the CLI-flag semantics).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "section_name": "Budget Caps",
+            "section_description": (
+                "Persistent daily caps for the autonomous loop.\n"
+                "CLI flags --max-daily-cost-usd / --max-sessions-per-day\n"
+                "override these when both are present."
+            ),
+            "section_order": 9,
+        },
+    )
+
+    max_daily_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        json_schema_extra={
+            "display_name": "Max daily Claude API cost (USD)",
+            "description": (
+                "Hard cap on Claude API spend per UTC day. The loop"
+                " sleeps until UTC midnight when this is reached."
+                " None = hardcoded default ($25). 0 = unlimited."
+            ),
+        },
+    )
+
+    max_sessions_per_day: int | None = Field(
+        default=None,
+        ge=0,
+        json_schema_extra={
+            "display_name": "Max Claude sessions per day",
+            "description": (
+                "Hard cap on Claude Code sessions started per UTC"
+                " day. None = hardcoded default (80). 0 = unlimited."
+            ),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main config
 # ---------------------------------------------------------------------------
 
@@ -970,6 +1028,7 @@ class GimmesConfig(BaseModel):
     scanner: ScannerConfig = Field(default_factory=ScannerConfig)
     scoring: ScoringConfig = Field(default_factory=ScoringConfig)
     model: ModelConfig = Field(default_factory=ModelConfig)
+    budget: BudgetConfig = Field(default_factory=BudgetConfig)
 
     # Database
     db_path: Path = Field(default_factory=lambda: GIMMES_HOME / "gimmes.db")
@@ -1059,6 +1118,7 @@ CONFIG_SECTIONS: list[tuple[str, type[BaseModel]]] = [
     ("scanner", ScannerConfig),
     ("scoring", ScoringConfig),
     ("model", ModelConfig),
+    ("budget", BudgetConfig),
 ]
 
 

--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import get_origin
+from types import UnionType
+from typing import Union, get_args, get_origin
 
 import typer
 from pydantic import BaseModel
@@ -51,15 +52,32 @@ class Setting:
 
 
 def _field_type_str(field_info: FieldInfo) -> str:
-    """Derive the wizard type string from a Pydantic field's annotation."""
+    """Derive the wizard type string from a Pydantic field's annotation.
+
+    Unwraps `T | None` / `Optional[T]` to T so nullable fields (e.g.
+    `budget.max_daily_cost_usd: float | None`) get the right wizard
+    type rather than falling through to "str". Without this, a `0`
+    value would be stored as the literal string "0" and skip range
+    validation.
+    """
     ann = field_info.annotation
+    # Unwrap Optional[T] / T | None → T. Pydantic stores Union[T, None]
+    # in `annotation`; get_args yields (T, NoneType).
+    from types import NoneType
+
+    origin = get_origin(ann)
+    if origin in (UnionType, Union):
+        args = [a for a in get_args(ann) if a is not NoneType]
+        if len(args) == 1:
+            ann = args[0]
+            origin = get_origin(ann)
+
     if ann is int:
         return "int"
     if ann is float:
         return "float"
     if ann is str:
         return "str"
-    origin = get_origin(ann)
     if origin is list:
         return "list"
     # Check if it's a BaseModel subclass (nested model like ScoringWeights)

--- a/tests/unit/test_budget_config.py
+++ b/tests/unit/test_budget_config.py
@@ -1,0 +1,180 @@
+"""Tests for the budget-cap config precedence (CLI > config > default)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gimmes.budget import DEFAULT_MAX_SESSIONS, DEFAULT_MAX_USD
+from gimmes.config import BudgetConfig, GimmesConfig
+
+
+class TestBudgetConfigDefaults:
+    def test_defaults_are_none(self) -> None:
+        """Unset config means the loop falls through to hardcoded
+        DEFAULT_MAX_* constants. None signals 'no override'."""
+        cfg = BudgetConfig()
+        assert cfg.max_daily_cost_usd is None
+        assert cfg.max_sessions_per_day is None
+
+    def test_zero_is_explicit_unlimited(self) -> None:
+        """0 is a valid value — matches the CLI flag semantics
+        (`--max-daily-cost-usd 0` = unlimited). Distinct from None
+        (use hardcoded default)."""
+        cfg = BudgetConfig(max_daily_cost_usd=0.0, max_sessions_per_day=0)
+        assert cfg.max_daily_cost_usd == 0.0
+        assert cfg.max_sessions_per_day == 0
+
+    def test_negative_rejected(self) -> None:
+        """Negative caps make no sense — Pydantic ge=0 enforces this."""
+        with pytest.raises(ValueError):
+            BudgetConfig(max_daily_cost_usd=-1.0)
+        with pytest.raises(ValueError):
+            BudgetConfig(max_sessions_per_day=-1)
+
+    def test_typical_override(self) -> None:
+        """The common case: operator sets a higher cap to keep the
+        loop running longer per day."""
+        cfg = BudgetConfig(max_daily_cost_usd=50.0, max_sessions_per_day=120)
+        assert cfg.max_daily_cost_usd == 50.0
+        assert cfg.max_sessions_per_day == 120
+
+
+class TestBudgetConfigInGimmesConfig:
+    def test_budget_is_attached_to_main_config(self) -> None:
+        """GimmesConfig must expose `budget` as a sub-config so
+        `gimmes config set budget.max_daily_cost_usd 50` resolves."""
+        cfg = GimmesConfig()
+        assert hasattr(cfg, "budget")
+        assert isinstance(cfg.budget, BudgetConfig)
+
+    def test_budget_field_extras_marked_forbid(self) -> None:
+        """BudgetConfig must reject unknown fields so typos in config
+        get a clear error rather than silently producing a no-op."""
+        with pytest.raises(ValueError):
+            BudgetConfig(unknown_field=42)
+
+
+class TestBudgetDefaultsConstants:
+    """Pin the hardcoded defaults the config falls back to. If these
+    change, the docstring/test should change in lockstep."""
+
+    def test_default_max_usd(self) -> None:
+        assert DEFAULT_MAX_USD == 25.0
+
+    def test_default_max_sessions(self) -> None:
+        assert DEFAULT_MAX_SESSIONS == 80
+
+
+class TestResolveBudgetCap:
+    """Precedence: CLI flag wins; if absent, fall back to config; if
+    both absent, use the hardcoded default. 0 (from either CLI or
+    config) is preserved as 'unlimited', NOT collapsed to default."""
+
+    def test_cli_value_wins_over_config(self) -> None:
+        from gimmes.cli import _resolve_budget_cap
+
+        result = _resolve_budget_cap(
+            cli_value=100.0, config_value=50.0, default=25.0,
+        )
+        assert result == 100.0
+
+    def test_cli_value_wins_over_default(self) -> None:
+        from gimmes.cli import _resolve_budget_cap
+
+        result = _resolve_budget_cap(
+            cli_value=100.0, config_value=None, default=25.0,
+        )
+        assert result == 100.0
+
+    def test_config_wins_when_cli_absent(self) -> None:
+        from gimmes.cli import _resolve_budget_cap
+
+        result = _resolve_budget_cap(
+            cli_value=None, config_value=50.0, default=25.0,
+        )
+        assert result == 50.0
+
+    def test_default_when_both_absent(self) -> None:
+        from gimmes.cli import _resolve_budget_cap
+
+        result = _resolve_budget_cap(
+            cli_value=None, config_value=None, default=25.0,
+        )
+        assert result == 25.0
+
+    def test_cli_zero_means_unlimited_not_default(self) -> None:
+        """0 from the CLI is the documented 'unlimited' value. It MUST
+        be preserved — collapsing it to the default would silently
+        re-enforce the cap the operator was trying to remove."""
+        from gimmes.cli import _resolve_budget_cap
+
+        result = _resolve_budget_cap(
+            cli_value=0.0, config_value=50.0, default=25.0,
+        )
+        assert result == 0.0
+
+    def test_config_zero_means_unlimited_not_default(self) -> None:
+        from gimmes.cli import _resolve_budget_cap
+
+        result = _resolve_budget_cap(
+            cli_value=None, config_value=0.0, default=25.0,
+        )
+        assert result == 0.0
+
+    def test_works_with_int_session_caps(self) -> None:
+        """max_sessions_per_day is an int, max_daily_cost_usd is a
+        float — the helper is generic and handles both."""
+        from gimmes.cli import _resolve_budget_cap
+
+        assert _resolve_budget_cap(
+            cli_value=None, config_value=120, default=80,
+        ) == 120
+        assert _resolve_budget_cap(
+            cli_value=None, config_value=None, default=80,
+        ) == 80
+
+
+class TestBudgetConfigCLIIntegration:
+    """End-to-end: the `gimmes config set budget.*` path must actually
+    work. Without CONFIG_SECTIONS registration, `resolve_setting` would
+    reject these keys and the headline feature would be unusable."""
+
+    def test_max_daily_cost_usd_resolves_via_wizard(self) -> None:
+        from gimmes.config_wizard import resolve_setting
+
+        setting = resolve_setting("budget.max_daily_cost_usd")
+        assert setting.key == "budget.max_daily_cost_usd"
+        assert setting.type == "float"  # NOT "str" — Optional unwrapped
+        assert setting.default is None
+
+    def test_max_sessions_per_day_resolves_via_wizard(self) -> None:
+        from gimmes.config_wizard import resolve_setting
+
+        setting = resolve_setting("budget.max_sessions_per_day")
+        assert setting.key == "budget.max_sessions_per_day"
+        assert setting.type == "int"  # NOT "str" — Optional unwrapped
+        assert setting.default is None
+
+    def test_budget_section_listed_in_config_sections(self) -> None:
+        """CONFIG_SECTIONS drives the wizard walkthrough order AND
+        `gimmes config get/set` key resolution. Missing entry means
+        the entire BudgetConfig is invisible to the CLI (#28 ship-
+        blocker found in review pipeline)."""
+        from gimmes.config import CONFIG_SECTIONS, BudgetConfig
+
+        section_names = [name for name, _ in CONFIG_SECTIONS]
+        assert "budget" in section_names
+        section_models = {name: cls for name, cls in CONFIG_SECTIONS}
+        assert section_models["budget"] is BudgetConfig
+
+    def test_field_type_str_unwraps_optional_float(self) -> None:
+        """Optional[T] / T | None annotations must yield T's type
+        string, not 'str'. Without this fix the wizard would store
+        user input as the literal string and skip ge=0 validation."""
+        from gimmes.config import BudgetConfig
+        from gimmes.config_wizard import _field_type_str
+
+        cost_field = BudgetConfig.model_fields["max_daily_cost_usd"]
+        sessions_field = BudgetConfig.model_fields["max_sessions_per_day"]
+        assert _field_type_str(cost_field) == "float"
+        assert _field_type_str(sessions_field) == "int"

--- a/tests/unit/test_budget_config.py
+++ b/tests/unit/test_budget_config.py
@@ -178,3 +178,67 @@ class TestBudgetConfigCLIIntegration:
         sessions_field = BudgetConfig.model_fields["max_sessions_per_day"]
         assert _field_type_str(cost_field) == "float"
         assert _field_type_str(sessions_field) == "int"
+
+    def test_load_config_wires_budget_sub_config(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """load_config() MUST pass `budget=BudgetConfig(...)` when
+        constructing GimmesConfig — otherwise values saved via
+        `gimmes config set budget.*` are persisted to the DB but
+        never reach the runtime config object, and _autonomous_loop
+        always sees defaults. Found by Copilot review on PR #626."""
+        import sqlite3
+
+        from gimmes.config import load_config
+        from gimmes.store.database import Database
+
+        # Build a DB with a budget override in the config table.
+        db_path = tmp_path / "test.db"
+        import asyncio
+
+        async def _setup() -> None:
+            db = Database(db_path)
+            await db.connect()
+            await db.close()
+
+        asyncio.run(_setup())
+
+        # Insert the budget override directly (schema is created by
+        # Database.connect via migrations).
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+                ("budget.max_daily_cost_usd", "50.0"),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+                ("budget.max_sessions_per_day", "120"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        cfg = load_config(db_path=db_path)
+        # If load_config doesn't wire budget, both values would be
+        # None (BudgetConfig's default) regardless of what's in the DB.
+        assert cfg.budget.max_daily_cost_usd == 50.0
+        assert cfg.budget.max_sessions_per_day == 120
+
+    def test_min_val_in_json_schema_extra(self) -> None:
+        """Pydantic's `ge=0.0` rejects negatives at model construction
+        time, but `gimmes config set` validates ranges using
+        `json_schema_extra['min_val']`. Without `min_val: 0`, a user
+        could save `-1` to the DB and only see the error later when
+        the loaded config tried to construct BudgetConfig — a
+        confusing UX. Found by Copilot review on PR #626."""
+        from gimmes.config import BudgetConfig
+
+        cost_extra = (
+            BudgetConfig.model_fields["max_daily_cost_usd"].json_schema_extra
+            or {}
+        )
+        sessions_extra = (
+            BudgetConfig.model_fields["max_sessions_per_day"].json_schema_extra
+            or {}
+        )
+        assert cost_extra.get("min_val") == 0.0
+        assert sessions_extra.get("min_val") == 0


### PR DESCRIPTION
## Summary

Daily Claude API cap and per-day session cap can now be set via `gimmes config set budget.max_daily_cost_usd 50` and persist across loop restarts. Previously the only override was the `--max-daily-cost-usd` CLI flag at startup.

## What changed

**`src/gimmes/config.py`** — New `BudgetConfig` sub-config with `max_daily_cost_usd: float | None` and `max_sessions_per_day: int | None` (both `ge=0`, default None). Registered in `CONFIG_SECTIONS` so the wizard and `gimmes config get/set` resolve `budget.*` keys.

**`src/gimmes/cli.py`** — New `_resolve_budget_cap` pure helper implementing CLI > config > default precedence (0 preserved as "unlimited"; None means "no override at this layer"). `_autonomous_loop` refactored to use it.

**`src/gimmes/config_wizard.py`** — `_field_type_str` now unwraps `Optional[T]` / `T | None` to `T` so nullable fields get the right wizard type (was falling through to `"str"`, which would have stored user input as a literal string and bypassed Pydantic's `ge=0` validation).

## Ship-blockers caught in review pipeline

1. `BudgetConfig` initially wasn't in `CONFIG_SECTIONS` — `gimmes config set budget.*` would have errored "Unknown config key". Fixed before commit.
2. `_field_type_str` Optional handling — would have silently stored "50" as a string. Fixed before commit.

Both have dedicated drift-guard tests now.

## End-to-end verified

```
$ gimmes config set budget.max_daily_cost_usd 50
budget.max_daily_cost_usd: None → 50.00

$ gimmes config get budget.max_daily_cost_usd
budget.max_daily_cost_usd: 50.00
```

## Known limitation (follow-up)

Config changes do NOT live-apply to a running loop. The loop reads config once at startup. `gimmes config set` while the loop is running has no effect until restart. `BudgetTracker.update_caps` does not exist yet; adding it + re-reading config each cycle would close the gap.

## Test plan

- [x] `uv run pytest tests/unit/test_budget_config.py` — 19 passed
- [x] `uv run pytest tests/unit/test_autonomous_loop.py` — 157 passed
- [x] `uv run ruff check` — clean
- [x] End-to-end: `gimmes config set budget.max_daily_cost_usd 50` → `gimmes config get` returns 50.00
- [x] Review pipeline (3 agents parallel) — 2 ship-blockers addressed in-commit, all other findings LOW
