### PR TITLE
Fix #615: observation footer for playbook search audit

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -100,6 +100,8 @@ If a bank returned no result in your search, log that explicitly in the observat
 
 After reading `position-context` and completing your analysis, write a **delta observation** — what changed since the prior observation, not a full re-assessment. If no prior observation exists (first cycle for this position), write a full observation.
 
+**Playbook audit footer (REQUIRED for fundamental-economic-trigger tickers — closes #615).** For positions whose ticker matches any category in the `## Fundamental-Economic-Trigger Source Playbook` (KXCPI, KXPAYROLLS, KXJOBLESSCLAIMS, etc.), every observation MUST end with a structured footer enumerating every named bank and aggregator from the playbook list, with one of three outcomes per source: a freshly-searched result, an explicitly-inherited prior result with citation, or `no result this cycle`. Without this footer, an operator auditing `gimmes position-notes` cannot distinguish "Monitor ran the playbook, found no change" from "Monitor skipped the playbook entirely" — the silent-failure path the 48-hour staleness rule was added to defend against. The footer makes the playbook execution machine-auditable in the position-notes history. For tickers NOT in the playbook category list (equity indices, etc.) the footer is OMITTED entirely.
+
 Use the `--body-file` variant via a single-quoted heredoc so dollar-prefixed prices like `$0.41` survive verbatim (#589). The quoted delimiter `<<'GIMMES_EOF'` is load-bearing — it suppresses ALL parameter expansion inside the body:
 
 ```bash
@@ -111,6 +113,21 @@ News delta: [new developments since last observation, or 'No new developments'].
 Thesis delta: [any change in thesis assessment, or 'Unchanged'].
 Trigger conditions: [NEW triggers only — not triggers already flagged and decided on].
 Overall: [Material change / No material change].
+
+Playbook sources checked this cycle (#615):
+- Goldman Sachs: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- JPMorgan: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Morgan Stanley: [...]
+- Bank of America: [...]
+- Citi: [...]
+- Barclays: [...]
+- Wells Fargo: [...]
+- Deutsche Bank: [...]
+- UBS: [...]
+- FXStreet: [...]
+- MarketWatch: [...]
+- Reuters: [...]
+- Bloomberg: [...]
 GIMMES_EOF
 gimmes position-note TICKER \
   --cycle $GIMMES_CYCLE \
@@ -119,6 +136,8 @@ gimmes position-note TICKER \
   --body-file "$BODY_FILE"
 rm -f "$BODY_FILE"
 ```
+
+**Footer-omission rule:** for tickers NOT matching the playbook category list (e.g., KXINX, KXNASDAQ100, KXSPX equity indices), OMIT the `Playbook sources checked this cycle:` block entirely. The bank/aggregator playbook does not apply to equity-index forecasts and synthesizing it would mislead audit.
 
 If the command fails, note the failure in your output and continue. Do not retry. If `mktemp` or the heredoc write itself fails, treat as a logging failure and skip — never fall back to inline `--body`.
 

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -114,20 +114,20 @@ Thesis delta: [any change in thesis assessment, or 'Unchanged'].
 Trigger conditions: [NEW triggers only — not triggers already flagged and decided on].
 Overall: [Material change / No material change].
 
-Playbook sources checked this cycle (#615):
+Playbook sources checked this cycle (#615 — OMIT this entire block for non-playbook tickers; see Footer-omission rule below):
 - Goldman Sachs: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
 - JPMorgan: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Morgan Stanley: [...]
-- Bank of America: [...]
-- Citi: [...]
-- Barclays: [...]
-- Wells Fargo: [...]
-- Deutsche Bank: [...]
-- UBS: [...]
-- FXStreet: [...]
-- MarketWatch: [...]
-- Reuters: [...]
-- Bloomberg: [...]
+- Morgan Stanley: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Bank of America: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Citi: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Barclays: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Wells Fargo: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Deutsche Bank: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- UBS: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- FXStreet: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- MarketWatch: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Reuters: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Bloomberg: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
 GIMMES_EOF
 gimmes position-note TICKER \
   --cycle $GIMMES_CYCLE \

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -593,6 +593,138 @@ def test_monitor_stop_loss_flag_carries_thesis_and_time(
 
 
 # ---------------------------------------------------------------------------
+# Monitor playbook audit footer (#615)
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_observation_template_includes_playbook_audit_footer(
+    monitor_text: str,
+) -> None:
+    """The observation template must include a `Playbook sources
+    checked this cycle:` block so an operator auditing position-notes
+    can distinguish 'Monitor ran the playbook' from 'Monitor skipped
+    the playbook entirely' — the silent-failure path the 48h
+    staleness rule was added to defend against (#615)."""
+    import re
+
+    obs_match = re.search(
+        r"^## Writing Observations.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert obs_match is not None, "Writing Observations section must exist"
+    block = obs_match.group(0)
+    assert "Playbook sources checked this cycle" in block, (
+        "Observation template MUST include a `Playbook sources checked"
+        " this cycle:` audit footer for fundamental-economic-trigger"
+        " tickers (#615). Without it, operators can't tell whether"
+        " Monitor actually ran the playbook this cycle."
+    )
+    assert "#615" in block, (
+        "Audit footer must cite #615 inline so the rationale is"
+        " preserved when the prompt is read in isolation."
+    )
+
+
+def test_monitor_audit_footer_enumerates_full_playbook_list(
+    monitor_text: str,
+) -> None:
+    """The footer template must enumerate every named bank AND every
+    aggregator from the playbook list — partial enumeration would
+    let Monitor silently drop sources from cycle to cycle (#615)."""
+    import re
+
+    obs_match = re.search(
+        r"^## Writing Observations.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert obs_match is not None
+    block = obs_match.group(0)
+
+    # Locate just the footer template (between "Playbook sources
+    # checked this cycle" header and the GIMMES_EOF terminator).
+    footer_match = re.search(
+        r"Playbook sources checked this cycle.*?GIMMES_EOF",
+        block,
+        flags=re.DOTALL,
+    )
+    assert footer_match is not None
+    footer = footer_match.group(0)
+
+    required = [
+        "Goldman Sachs", "JPMorgan", "Morgan Stanley", "Bank of America",
+        "Citi", "Barclays", "Wells Fargo", "Deutsche Bank", "UBS",
+        "FXStreet", "MarketWatch", "Reuters", "Bloomberg",
+    ]
+    missing = [name for name in required if name not in footer]
+    assert not missing, (
+        f"Audit footer template missing playbook sources: {missing}."
+        f" Every bank and aggregator in the playbook MUST be enumerated"
+        f" in the footer template so partial enumeration can't drop"
+        f" sources silently (#615)."
+    )
+
+
+def test_monitor_audit_footer_allows_no_result_and_inheritance(
+    monitor_text: str,
+) -> None:
+    """Each source row supports three outcomes: a fresh search result,
+    an inherited prior result with citation, or 'no result this cycle'.
+    Without these explicit affordances, Monitor would have no way to
+    record absent sources without fabricating data (#615)."""
+    import re
+
+    obs_match = re.search(
+        r"^## Writing Observations.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert obs_match is not None
+    block = obs_match.group(0)
+    assert "no result this cycle" in block, (
+        "Footer template must allow `no result this cycle` as an"
+        " explicit per-source value so absent forecasts can be"
+        " recorded without fabrication (#615)."
+    )
+    assert "inherited" in block, (
+        "Footer template must allow inheritance from a prior"
+        " observation's cited finding — matches the (b) branch of"
+        " the read-back assertion (#577/#615)."
+    )
+
+
+def test_monitor_audit_footer_omitted_for_non_economic_tickers(
+    monitor_text: str,
+) -> None:
+    """The footer MUST be explicitly scoped to fundamental-economic-
+    trigger tickers — equity indices (KXINX, KXNASDAQ100, KXSPX) have
+    no bank-forecast vocabulary; synthesizing a footer for them would
+    mislead audit (#615)."""
+    import re
+
+    obs_match = re.search(
+        r"^## Writing Observations.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert obs_match is not None
+    block = obs_match.group(0)
+    # The "Footer-omission rule" callout must exist and explicitly
+    # name equity-index categories OR the broader exclusion.
+    assert "Footer-omission rule" in block, (
+        "Observation template must contain a `Footer-omission rule`"
+        " callout that scopes the footer requirement to fundamental-"
+        " economic-trigger tickers (#615)."
+    )
+    assert "OMIT" in block, (
+        "Footer-omission rule must use the uppercase token `OMIT`"
+        " (matching the existing prompt's emphasis convention) so"
+        " agents reading the rule treat it as a hard instruction."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Monitor fundamental-economic-trigger source playbook (#577)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -669,10 +669,10 @@ def test_monitor_audit_footer_enumerates_full_playbook_list(
 def test_monitor_audit_footer_allows_no_result_and_inheritance(
     monitor_text: str,
 ) -> None:
-    """Each source row supports three outcomes: a fresh search result,
-    an inherited prior result with citation, or 'no result this cycle'.
-    Without these explicit affordances, Monitor would have no way to
-    record absent sources without fabricating data (#615)."""
+    """Each source row MUST carry the explicit three-outcome grammar
+    inline. Without per-row grammar, agents may fill the `[...]`
+    placeholders inconsistently and the audit value erodes — Copilot's
+    review of #615 caught this exact vacuous-coverage path (#615)."""
     import re
 
     obs_match = re.search(
@@ -682,15 +682,29 @@ def test_monitor_audit_footer_allows_no_result_and_inheritance(
     )
     assert obs_match is not None
     block = obs_match.group(0)
-    assert "no result this cycle" in block, (
-        "Footer template must allow `no result this cycle` as an"
-        " explicit per-source value so absent forecasts can be"
-        " recorded without fabrication (#615)."
+    # Find the footer template specifically.
+    footer_match = re.search(
+        r"Playbook sources checked this cycle.*?GIMMES_EOF",
+        block,
+        flags=re.DOTALL,
     )
-    assert "inherited" in block, (
-        "Footer template must allow inheritance from a prior"
-        " observation's cited finding — matches the (b) branch of"
-        " the read-back assertion (#577/#615)."
+    assert footer_match is not None
+    footer = footer_match.group(0)
+
+    # Every enumerated source line MUST carry the full grammar.
+    # Counting occurrences of the grammar string against the count
+    # of source bullets ensures partial-row drift is caught.
+    grammar = (
+        "[value (publisher, YYYY-MM-DD) OR 'no result this cycle'"
+        " OR 'inherited: <prior cite>']"
+    )
+    grammar_count = footer.count(grammar)
+    assert grammar_count >= 13, (
+        f"Footer template must repeat the full three-outcome grammar"
+        f" on every source row (13 sources: 9 banks + 4 aggregators)."
+        f" Found grammar on {grammar_count} rows. Bare `[...]`"
+        f" placeholders let agents fill inconsistently and erode"
+        f" audit value (#615)."
     )
 
 
@@ -721,6 +735,23 @@ def test_monitor_audit_footer_omitted_for_non_economic_tickers(
         "Footer-omission rule must use the uppercase token `OMIT`"
         " (matching the existing prompt's emphasis convention) so"
         " agents reading the rule treat it as a hard instruction."
+    )
+    # The omission rule must be inline on the footer header itself
+    # (not just in surrounding prose) so an agent copy-pasting the
+    # template sees the rule immediately. Copilot's review of #615
+    # flagged the unconditional-template / omission-rule mismatch.
+    footer_header_match = re.search(
+        r"Playbook sources checked this cycle[^\n]*",
+        block,
+    )
+    assert footer_header_match is not None
+    footer_header = footer_header_match.group(0)
+    assert "OMIT" in footer_header, (
+        "The `Playbook sources checked this cycle:` header line MUST"
+        " contain an inline omission annotation (e.g.,"
+        " `OMIT this entire block for non-playbook tickers`) so an"
+        " agent copy-pasting the template sees the omission rule"
+        " right there, not just in surrounding prose (#615)."
     )
 
 


### PR DESCRIPTION
## Summary

Closes #615, follow-up to #577. Monitor's observation template now ends with a `Playbook sources checked this cycle:` audit footer for fundamental-economic-trigger tickers — every named bank + aggregator enumerated, with one of three outcomes per source.

Without this footer, an operator auditing `gimmes position-notes` could not distinguish "Monitor ran the playbook, no signal" from "Monitor skipped the playbook entirely" — the silent-failure path the 48h staleness rule (#577) was designed to defend against.

## What changed

**`.claude/agents/monitor.md`** — observation template extended with the footer block:
```
Playbook sources checked this cycle (#615):
- Goldman Sachs: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
- JPMorgan: [...]
- ... (all 9 banks + 4 aggregators)
```

Plus a `Footer-omission rule` callout: tickers not in the playbook category list (equity indices) OMIT the block entirely — synthesizing it would mislead audit.

**`tests/unit/test_agent_prompts.py`** — 4 new drift-guards pinning footer presence, full source enumeration (so partial drop-out is detected), the three allowed per-source outcomes (`no result this cycle` + `inherited`), and the omission rule for non-economic tickers.

## Test plan
- [x] `uv run pytest tests/unit/test_agent_prompts.py` — 52 passed
- [x] `uv run ruff check` — clean
