### PR TITLE
Fix #641: threshold-semantics grounding + forecast supersession rules

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -139,7 +139,7 @@ After Monitor returns, review its report. For each position Monitor flagged:
    gimmes position-notes TICKER
    ```
 
-2. Review Monitor's flag note. Understand specifically: what changed, and whether it was already in the original thesis.
+2. Review Monitor's flag note. Understand specifically: what changed, and whether it was already in the original thesis. For threshold markets, run `gimmes market-info TICKER` and verify the YES/NO description in Monitor's notes against the `Rules (primary)` row — if inverted, state the corrected semantics in your decision note rather than propagate the inversion; if the row shows `—` (empty), treat the YES/NO description as unverified and decide conservatively (#641).
 
 3. **Confer with Monitor using SendMessage if you need deeper analysis.** Use this when:
    - You want Monitor to clarify whether a data point was already present in the original thesis.
@@ -149,7 +149,7 @@ After Monitor returns, review its report. For each position Monitor flagged:
    You may go back and forth as many times as needed. Wait for each Monitor response before asking the next question. When you have enough information to make a judgment call, proceed to step 4.
 
 4. Make your own deliberate decision — **HOLD**, **CLOSE**, or **SIZE UP**:
-   - **HOLD**: The flagged information was already in the thesis, or the price move appears liquidity-driven, or the thesis is still materially intact but edge hasn't improved enough to warrant adding. When choosing HOLD, you MUST specify a re-evaluation condition so Monitor knows when to re-flag (prevents the flag-HOLD-re-flag-HOLD loop).
+   - **HOLD**: The flagged information was already in the thesis, or the price move appears liquidity-driven, or the thesis is still materially intact but edge hasn't improved enough to warrant adding. When choosing HOLD, you MUST specify a re-evaluation condition so Monitor knows when to re-flag (prevents the flag-HOLD-re-flag-HOLD loop). A HOLD MUST NOT rest on sources marked `SUPERSEDED` in Monitor's most-recent playbook audit footer (#641) — if the surviving current evidence is insufficient, confer with Monitor via SendMessage for a fresh playbook search before deciding.
    - **CLOSE**: Genuinely new information (not in the original thesis) materially changes the probability estimate, a stop-loss flag fires AND the thesis is degraded (see stop-loss rule below), or a profit-taking flag indicates the position has captured most of its available edge.
    - **SIZE UP**: Price moved adversely while the original thesis remains fully intact, resulting in a larger edge than at entry. Proceed to Step 2d.
 
@@ -344,6 +344,8 @@ For each PROCEED candidate:
    gimmes position-context TICKER
    ```
    If any of these commands fail, REJECT the candidate — you cannot review without the data.
+
+   For threshold markets, verify the YES/NO win conditions against the `Rules (primary)` row of `market-info` before APPROVE/REJECT — do NOT accept Caddie's directional description of the contract without this check; if the row shows `—` (empty), settlement is unverifiable → REJECT (#641).
 
    **Edge pre-filter.** If the candidate's net edge after fees is already below `cm_min_edge_after_fees`, REJECT immediately without conferring — the candidate cannot clear the CM floor no matter how the conferral goes. Log the REJECT note with the numeric citation and move on. Skip to sub-step 6 (log rejected candidates as skips).
 

--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -65,6 +65,7 @@ For candidates in backtested gimme categories (KXCPICORE, KXCPIYOY, KXCPICOREYOY
 
 2. **Settlement clarity check**: Is the contract settlement language unambiguous?
    - Read the contract rules from `market-info` output
+   - For threshold markets, also state the YES/NO win conditions derived from the `Rules (primary)` row ("YES wins when <metric> <comparator> <threshold>; NO wins when <complement>") before scoring — do NOT derive them from the title's directional wording alone; if `Rules (primary)` shows `—` (empty), treat settlement language as unclear → PASS with rationale (#641)
    - Red flags: "discretion", "carveout", "may determine", "at sole discretion"
    - If red flags → PASS with rationale
 
@@ -107,6 +108,7 @@ For candidates NOT in gimme categories, investigate all of these:
 
 **Threshold-arithmetic primacy rule (MUST follow):** When the Caddie has computed a threshold-specific probability via mechanical arithmetic (e.g., "MoM must be ≥ X% for YoY to exceed T%"), web forecasts MUST be used to validate the MoM/input estimate — NEVER to override the threshold probability directly.
 
+- **Threshold-semantics grounding (REQUIRED — #641):** before deriving ANY probability, read the settlement sentence verbatim from the `Rules (primary)` row of `gimmes market-info` and state: "YES wins when <metric> <comparator> <threshold>; NO wins when <complement>." NEVER derive YES/NO semantics from the title's directional wording alone. If `Rules (primary)` shows `—` (empty), settlement semantics are unverifiable — treat as a settlement red flag, not as license to use the title. Negative thresholds are the known trap (double negative): "Will CPI rise more than -0.1%?" settles YES = CPI MoM > -0.1% (flat or positive), NO = CPI MoM <= -0.1% (deflation) — every note in the KXCPI-26JUN-T-0.1 chain described this backwards (#641).
 - A consensus point forecast of "3.6% YoY" does NOT mean P(YoY > 3.6%) ≈ 50%. Point estimates reflect the distribution's center; threshold probability depends on the distribution's width. For CPI MoM, historical σ ≈ 0.15pp — a point estimate 0.2pp above a threshold implies P(exceed) is high, not a coin flip.
 - Quarterly/annualized rates (e.g., Cleveland Fed CPI nowcast "5.5% annualized") MUST be converted to the contract's units (YoY or MoM) before comparison. Do not compare annualized quarterly rates to YoY thresholds.
 - When arithmetic and web forecasts disagree, show BOTH in the research memo and explain the discrepancy. Do not silently discard the arithmetic result.

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -98,7 +98,8 @@ If a bank returned no result in your search, log that explicitly in the observat
 
 3. For each name identified, your observation this cycle MUST either:
    (a) reference a freshly searched result for that named source this cycle (with value, source, and date), OR
-   (b) explicitly inherit the prior observation's finding for that source with citation.
+   (b) explicitly inherit the prior observation's finding for that source with citation, OR
+   (c) mark the prior finding `SUPERSEDED (pre-<event>, <date>) — refresh required` when a regime-change event postdates it (see Supersession rule below — #641). A superseded CM-cited source satisfies the read-back by naming the supersession; it MUST NOT be silently inherited.
 
 **FORBIDDEN**: writing an observation whose assertions contradict cited evidence in the most-recent CM decision note. Example of a forbidden observation — writing "No named major Wall Street bank has published April CPI MoM strictly above 0.5%" when the most-recent CM decision body cites "Barclays +0.55% (FXStreet, 2026-05-08)". If your search this cycle disagrees with the CM-decision-cited evidence, you MUST surface the disagreement explicitly in the observation body — do NOT silently revert to a template assertion that contradicts cited evidence.
 
@@ -106,9 +107,11 @@ If a bank returned no result in your search, log that explicitly in the observat
 
 **Runtime enforcement (#614).** This contract is enforced at the CLI: `gimmes position-note --type observation` rejects observation writes that contain the canonical stale-template phrase ("No named major Wall Street bank has published") when the most-recent CM `decision` note for the same ticker cites a named bank or aggregator with a numeric percentage value. **On validator rejection: re-write the observation with the surfaced citations and retry. Do NOT use `--force` to bypass** — that flag is reserved for backfill scripts; autonomous Monitor cycles MUST fix the body, not bypass the check. Bypassing the validator constitutes the same regression #577/#614 are designed to prevent.
 
+**Threshold-semantics grounding (REQUIRED — #641).** Before analyzing any threshold market ("Will X be above / below / rise more than T?"), read the settlement sentence verbatim from the `Rules (primary)` row of `gimmes market-info TICKER` and state in your own analysis: "YES wins when <metric> <comparator> <threshold>; NO wins when <complement>." NEVER derive YES/NO semantics from the title's directional wording alone. Negative thresholds are the known trap (double negative): "Will CPI rise more than -0.1%?" settles YES = CPI MoM > -0.1% (flat or positive), NO = CPI MoM <= -0.1% (deflation) — every note in the KXCPI-26JUN-T-0.1 chain described this backwards (#641). If the semantics you derive contradict a prior note's YES/NO description, surface the correction explicitly in the observation body. If `Rules (primary)` shows `—` (empty), semantics are UNVERIFIABLE: say so in the observation and flag the position for Caddie Master review — do NOT fall back to title-derived semantics.
+
 After reading `position-context` and completing your analysis, write a **delta observation** — what changed since the prior observation, not a full re-assessment. If no prior observation exists (first cycle for this position), write a full observation.
 
-**Playbook audit footer (REQUIRED for fundamental-economic-trigger tickers — closes #615).** For positions whose ticker matches any category in the `## Fundamental-Economic-Trigger Source Playbook` (KXCPI, KXPAYROLLS, KXJOBLESSCLAIMS, etc.), every observation MUST end with a structured footer enumerating every named bank and aggregator from the playbook list, with one of three outcomes per source: a freshly-searched result, an explicitly-inherited prior result with citation, or `no result this cycle`. Without this footer, an operator auditing `gimmes position-notes` cannot distinguish "Monitor ran the playbook, found no change" from "Monitor skipped the playbook entirely" — the silent-failure path the 48-hour staleness rule was added to defend against. The footer makes the playbook execution machine-auditable in the position-notes history. For tickers NOT in the playbook category list (equity indices, etc.) the footer is OMITTED entirely.
+**Playbook audit footer (REQUIRED for fundamental-economic-trigger tickers — closes #615).** For positions whose ticker matches any category in the `## Fundamental-Economic-Trigger Source Playbook` (KXCPI, KXPAYROLLS, KXJOBLESSCLAIMS, etc.), every observation MUST end with a structured footer enumerating every named bank and aggregator from the playbook list, with one of four outcomes per source: a freshly-searched result, an explicitly-inherited prior result with citation, `no result this cycle`, or a superseded prior result requiring refresh (see Supersession rule below). Without this footer, an operator auditing `gimmes position-notes` cannot distinguish "Monitor ran the playbook, found no change" from "Monitor skipped the playbook entirely" — the silent-failure path the 48-hour staleness rule was added to defend against. The footer makes the playbook execution machine-auditable in the position-notes history. For tickers NOT in the playbook category list (equity indices, etc.) the footer is OMITTED entirely.
 
 Use the `--body-file` variant via a single-quoted heredoc so dollar-prefixed prices like `$0.41` survive verbatim (#589). The quoted delimiter `<<'GIMMES_EOF'` is load-bearing — it suppresses ALL parameter expansion inside the body:
 
@@ -117,25 +120,26 @@ BODY_FILE=$(mktemp -t gimmes-body.XXXXXX)
 cat > "$BODY_FILE" <<'GIMMES_EOF'
 Delta since cycle [N from prior observation note]:
 Price: $X.XX (was $X.XX, moved +/-Npp since last observation).
+Semantics: [threshold markets only (#641) — YES wins when <metric> <comparator> <threshold>; NO wins when <complement>, derived from the Rules (primary) row of market-info; OMIT for non-threshold markets]
 News delta: [new developments since last observation, or 'No new developments'].
 Thesis delta: [any change in thesis assessment, or 'Unchanged'].
 Trigger conditions: [NEW triggers only — not triggers already flagged and decided on].
 Overall: [Material change / No material change].
 
 Playbook sources checked this cycle (#615 — OMIT this entire block for non-playbook tickers; see Footer-omission rule below):
-- Goldman Sachs: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- JPMorgan: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Morgan Stanley: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Bank of America: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Citi: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Barclays: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Wells Fargo: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Deutsche Bank: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- UBS: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- FXStreet: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- MarketWatch: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Reuters: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
-- Bloomberg: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>']
+- Goldman Sachs: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- JPMorgan: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Morgan Stanley: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Bank of America: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Citi: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Barclays: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Wells Fargo: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Deutsche Bank: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- UBS: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- FXStreet: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- MarketWatch: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Reuters: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
+- Bloomberg: [value (publisher, YYYY-MM-DD) OR 'no result this cycle' OR 'inherited: <prior cite>' OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']
 GIMMES_EOF
 gimmes position-note TICKER \
   --cycle $GIMMES_CYCLE \
@@ -146,6 +150,10 @@ rm -f "$BODY_FILE"
 ```
 
 **Footer-omission rule:** for tickers NOT matching the playbook category list (e.g., KXINX, KXNASDAQ100, KXSPX equity indices), OMIT the `Playbook sources checked this cycle:` block entirely. The bank/aggregator playbook does not apply to equity-index forecasts and synthesizing it would mislead audit.
+
+**Freshness rule (#641 — fresh means newly published, not re-found):** a source row may use the bare `value (publisher, YYYY-MM-DD)` form ONLY when its publication date is strictly newer than the date in that source's most recent prior cite for this position, or when no prior cite exists for that source (first-time findings are fresh by definition). Re-discovering the same dated note this cycle confirms *existence*, not *currency* — write it as `inherited: <prior cite>`. FORBIDDEN: describing an inherited or re-found result as "freshly confirmed" or "confirmed this cycle". The KXCPI-26JUN-T-0.1 incident (#641) rode Jun 11–18 bank notes through Jul 1 cycles as "freshly confirmed" while actual consensus had moved 40+bp — because re-finding the old notes was miscounted as confirmation.
+
+**Supersession rule (#641):** if this cycle's news delta identifies a regime-change event affecting this ticker's metric (large commodity/energy move, geopolitical resolution, major data release) dated AFTER a source's publication date, that source row MUST read `SUPERSEDED (pre-<event>, <date>) — refresh required` — not `inherited`. Example: `Wells Fargo: SUPERSEDED (pre-Hormuz-reopening, 2026-06-11) — refresh required`. A SUPERSEDED forecast is not evidence of current consensus; surface the supersession in the observation body so Caddie Master does not renew a HOLD on it. Supersession is sticky: a source once marked SUPERSEDED stays SUPERSEDED in every subsequent cycle — it MUST NOT revert to `inherited` — until a publication strictly newer than the event date is found (which makes it fresh again).
 
 If the command fails, note the failure in your output and continue. Do not retry. If `mktemp` or the heredoc write itself fails, treat as a logging failure and skip — never fall back to inline `--body`.
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -13,6 +13,7 @@ from typing import TypeVar
 import click
 import typer
 from rich.console import Console
+from rich.markup import escape as rich_escape
 
 from gimmes.config import GIMMES_HOME, GimmesConfig, load_config
 
@@ -1919,9 +1920,16 @@ def market_info(
             risk_color = {"low": "green", "medium": "yellow", "high": "red"}.get(
                 settlement.risk_level, "white"
             )
+            def verbatim(value: str | None) -> str:
+                # #641: markup-escape so bracketed clauses in Kalshi text
+                # aren't eaten as Rich style tags — verbatim means verbatim;
+                # em-dash when the field is empty.
+                return rich_escape(value) if value else "—"
+
             table = format_kv_table(market.title, [
                 ("Ticker", market.ticker),
                 ("Event", market.event_ticker),
+                ("Subtitle", verbatim(market.subtitle)),
                 ("Status", market.status.value),
                 ("YES Bid", f"${market.yes_bid:.2f}"),
                 ("YES Ask", f"${market.yes_ask:.2f}"),
@@ -1935,6 +1943,9 @@ def market_info(
                 ("Best YES Ask", str(orderbook.best_yes_ask)),
                 ("Depth (YES bids)", f"{len(orderbook.yes_bids)} levels"),
                 ("Settlement Risk", f"[{risk_color}]{settlement.summary}[/{risk_color}]"),
+                # #641: verbatim settlement language so agents can ground YES/NO
+                # threshold semantics — deliberately untruncated (Rich wraps).
+                ("Rules (primary)", verbatim(market.rules_primary)),
             ])
             console.print(table)
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1926,7 +1926,8 @@ def market_info(
                 # em-dash when the field is empty.
                 return rich_escape(value) if value else "—"
 
-            table = format_kv_table(market.title, [
+            # rich_escape: table titles are markup-parsed too (#641 review).
+            table = format_kv_table(rich_escape(market.title), [
                 ("Ticker", market.ticker),
                 ("Event", market.event_ticker),
                 ("Subtitle", verbatim(market.subtitle)),
@@ -1942,7 +1943,11 @@ def market_info(
                 ("Best YES Bid", str(orderbook.best_yes_bid)),
                 ("Best YES Ask", str(orderbook.best_yes_ask)),
                 ("Depth (YES bids)", f"{len(orderbook.yes_bids)} levels"),
-                ("Settlement Risk", f"[{risk_color}]{settlement.summary}[/{risk_color}]"),
+                # Escape the summary inside the color tags: with red flags
+                # present it reads "found [discretion, ...]" and Rich would
+                # eat the bracketed list as a style tag (#641 review).
+                ("Settlement Risk",
+                 f"[{risk_color}]{rich_escape(settlement.summary)}[/{risk_color}]"),
                 # #641: verbatim settlement language so agents can ground YES/NO
                 # threshold semantics — deliberately untruncated (Rich wraps).
                 ("Rules (primary)", verbatim(market.rules_primary)),

--- a/src/gimmes/kalshi/markets.py
+++ b/src/gimmes/kalshi/markets.py
@@ -31,7 +31,7 @@ def parse_market(data: dict) -> Market:  # type: ignore[type-arg]
         event_ticker=data.get("event_ticker", ""),
         series_ticker=data.get("series_ticker", ""),
         title=data.get("title", ""),
-        subtitle=data.get("subtitle", ""),
+        subtitle=data.get("subtitle") or "",  # explicit null → "" (#641, same class as #574)
         status=MarketStatus(data.get("status", "active")),
         yes_bid=_dollars_field(data, "yes_bid"),
         yes_ask=_dollars_field(data, "yes_ask"),
@@ -44,7 +44,7 @@ def parse_market(data: dict) -> Market:  # type: ignore[type-arg]
         close_time=data.get("close_time"),
         expiration_time=data.get("expiration_time"),
         result=data.get("result", ""),
-        rules_primary=data.get("rules_primary", ""),
+        rules_primary=data.get("rules_primary") or "",  # explicit null → "" (#641)
     )
 
 

--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -174,8 +174,10 @@ def validate(
         f" {source} {value}, but this observation contains the"
         f" stale-template phrase \"{STALE_TEMPLATE_PHRASE}\"."
         f" Re-write the observation to either reference a freshly"
-        f" searched result OR explicitly inherit the prior CM-cited"
-        f" finding with citation. Do NOT use --force to bypass — that"
+        f" searched result, explicitly inherit the prior CM-cited"
+        f" finding with citation, or — if a regime-change event"
+        f" postdates that finding — mark it SUPERSEDED with the event"
+        f" and date (#641). Do NOT use --force to bypass — that"
         f" is reserved for backfill scripts."
     )
     return (False, err)

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -669,10 +669,11 @@ def test_monitor_audit_footer_enumerates_full_playbook_list(
 def test_monitor_audit_footer_allows_no_result_and_inheritance(
     monitor_text: str,
 ) -> None:
-    """Each source row MUST carry the explicit three-outcome grammar
+    """Each source row MUST carry the explicit four-outcome grammar
     inline. Without per-row grammar, agents may fill the `[...]`
     placeholders inconsistently and the audit value erodes — Copilot's
-    review of #615 caught this exact vacuous-coverage path (#615)."""
+    review of #615 caught this exact vacuous-coverage path (#615).
+    The fourth outcome (SUPERSEDED) was added by #641."""
     import re
 
     obs_match = re.search(
@@ -696,15 +697,16 @@ def test_monitor_audit_footer_allows_no_result_and_inheritance(
     # of source bullets ensures partial-row drift is caught.
     grammar = (
         "[value (publisher, YYYY-MM-DD) OR 'no result this cycle'"
-        " OR 'inherited: <prior cite>']"
+        " OR 'inherited: <prior cite>'"
+        " OR 'SUPERSEDED (pre-<event>, <date>) — refresh required']"
     )
     grammar_count = footer.count(grammar)
     assert grammar_count >= 13, (
-        f"Footer template must repeat the full three-outcome grammar"
+        f"Footer template must repeat the full four-outcome grammar"
         f" on every source row (13 sources: 9 banks + 4 aggregators)."
         f" Found grammar on {grammar_count} rows. Bare `[...]`"
         f" placeholders let agents fill inconsistently and erode"
-        f" audit value (#615)."
+        f" audit value (#615, #641)."
     )
 
 
@@ -753,6 +755,276 @@ def test_monitor_audit_footer_omitted_for_non_economic_tickers(
         " agent copy-pasting the template sees the omission rule"
         " right there, not just in surrounding prose (#615)."
     )
+
+
+# ---------------------------------------------------------------------------
+# Threshold semantics + forecast supersession (#641)
+# ---------------------------------------------------------------------------
+
+
+def _writing_observations_block(monitor_text: str) -> str:
+    """Extract monitor.md's `## Writing Observations` section (same
+    anchoring convention as `_playbook_block` below)."""
+    import re
+
+    match = re.search(
+        r"^## Writing Observations.*?(?=\n## )",
+        monitor_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None, "Writing Observations section must exist"
+    return match.group(0)
+
+
+def _observation_rule(monitor_text: str, name: str) -> str:
+    """Extract the bold `**<name>...**` rule paragraph from the Writing
+    Observations section, asserting the rule exists."""
+    import re
+
+    match = re.search(
+        rf"\*\*{re.escape(name)}.*?(?=\n\n)",
+        _writing_observations_block(monitor_text),
+        flags=re.DOTALL,
+    )
+    assert match is not None, (
+        f"Writing Observations must contain the `{name}` paragraph"
+        f" (#641)."
+    )
+    return match.group(0)
+
+
+def test_monitor_threshold_semantics_rule_pinned(monitor_text: str) -> None:
+    """Monitor MUST ground YES/NO semantics in the settlement sentence
+    (`Rules (primary)` row of market-info), never the title's
+    directional wording — the KXCPI-26JUN-T-0.1 chain described a
+    negative-threshold market backwards in every note (#641)."""
+    import re
+
+    rule = _observation_rule(monitor_text, "Threshold-semantics grounding")
+    for needle in (
+        "YES wins when",
+        "NO wins when",
+        "Rules (primary)",
+        "KXCPI-26JUN-T-0.1",
+        "#641",
+    ):
+        assert needle in rule, (
+            f"Threshold-semantics grounding rule must contain"
+            f" {needle!r} — the rule loses its teeth without the"
+            f" verbatim-quote requirement and the canonical trap"
+            f" exemplar (#641)."
+        )
+    assert re.search(r"negative threshold", rule, flags=re.IGNORECASE), (
+        "The rule must call out negative thresholds (double negative)"
+        " as the known trap (#641)."
+    )
+
+
+def test_monitor_observation_template_carries_semantics_line(
+    monitor_text: str,
+) -> None:
+    """The observation heredoc must carry a `Semantics:` line for
+    threshold markets with an inline OMIT annotation for non-threshold
+    markets — same inline-annotation convention as the #615 footer
+    header (#641)."""
+    import re
+
+    block = _writing_observations_block(monitor_text)
+    sem_match = re.search(r"^Semantics: \[[^\n]*", block, flags=re.MULTILINE)
+    assert sem_match is not None, (
+        "Observation template must include a `Semantics:` line so"
+        " threshold win conditions are stated in every observation"
+        " (#641)."
+    )
+    sem_line = sem_match.group(0)
+    for needle in ("YES wins", "NO wins", "OMIT", "#641"):
+        assert needle in sem_line, (
+            f"`Semantics:` template line must carry {needle!r} inline"
+            f" — the annotation must live on the line itself so a"
+            f" copy-pasting agent sees it (#641)."
+        )
+
+
+def test_monitor_footer_freshness_rule_pinned(monitor_text: str) -> None:
+    """`fresh` means newly published, not re-found: re-discovering the
+    same dated note must be written as inherited, and describing it as
+    'freshly confirmed' is FORBIDDEN. This is the exact miscount that
+    rode Jun 11-18 bank notes through Jul 1 cycles on
+    KXCPI-26JUN-T-0.1 (#641)."""
+    rule = _observation_rule(monitor_text, "Freshness rule")
+    for needle in (
+        "strictly newer",
+        "FORBIDDEN",
+        "freshly confirmed",
+        "inherited: <prior cite>",
+        "#641",
+    ):
+        assert needle in rule, (
+            f"Freshness rule must contain {needle!r} — without the"
+            f" strict-date requirement and the FORBIDDEN phrase, a"
+            f" re-found stale note can still masquerade as fresh"
+            f" (#641)."
+        )
+
+
+def test_monitor_footer_supersession_rule_pinned(monitor_text: str) -> None:
+    """A forecast predating a regime-change event must be marked
+    SUPERSEDED — not inherited — and cannot support HOLD continuation
+    on its own (#641)."""
+    rule = _observation_rule(monitor_text, "Supersession rule")
+    for needle in (
+        "regime-change",
+        "SUPERSEDED (pre-<event>, <date>) — refresh required",
+        "Hormuz",
+        "HOLD",
+        "#641",
+        "MUST NOT revert to",
+    ):
+        assert needle in rule, (
+            f"Supersession rule must contain {needle!r} — the exact"
+            f" SUPERSEDED grammar (em-dash included), the exemplar,"
+            f" the HOLD prohibition, and stickiness across cycles are"
+            f" all load-bearing (#641)."
+        )
+
+
+def test_monitor_footer_spec_declares_four_outcomes(
+    monitor_text: str,
+) -> None:
+    """The footer spec paragraph must agree with the row grammar: four
+    outcomes, including superseded. Prose reverting to 'three
+    outcomes' would contradict the 13 pinned rows (#641)."""
+    assert "one of four outcomes" in monitor_text, (
+        "Footer spec paragraph must declare `one of four outcomes`"
+        " (#641 added SUPERSEDED as the fourth)."
+    )
+    assert "one of three outcomes" not in monitor_text, (
+        "Stale `one of three outcomes` prose contradicts the 4-outcome"
+        " row grammar (#641)."
+    )
+    assert "superseded" in monitor_text.lower(), (
+        "Footer spec must mention the superseded outcome (#641)."
+    )
+
+
+def test_caddie_threshold_semantics_in_arithmetic_primacy(
+    caddie_text: str,
+) -> None:
+    """Caddie must state YES/NO win conditions from `Rules (primary)`
+    before deriving any probability (deep research), and in
+    Sanity-Check Mode's settlement clarity check (fast-track) —
+    covering both research paths (#641)."""
+    import re
+
+    # Scope to the grounding bullet itself so relocation out of the
+    # arithmetic-primacy block fails loudly.
+    grounding_match = re.search(
+        r"\*\*Threshold-semantics grounding.*?(?=\n- |\n\n)",
+        caddie_text,
+        flags=re.DOTALL,
+    )
+    assert grounding_match is not None, (
+        "Caddie's threshold-arithmetic primacy block must contain the"
+        " `Threshold-semantics grounding` bullet (#641)."
+    )
+    grounding = grounding_match.group(0)
+    for needle in (
+        "YES wins when",
+        "NO wins when",
+        "Rules (primary)",
+        "KXCPI-26JUN-T-0.1",
+    ):
+        assert needle in grounding, (
+            f"Caddie semantics grounding bullet must contain"
+            f" {needle!r} (#641)."
+        )
+    # Fast-track path: the settlement clarity check must also state
+    # win conditions, since gimme-category candidates skip deep
+    # research entirely.
+    clarity_match = re.search(
+        r"\*\*Settlement clarity check\*\*.*?(?=\n\n|\n3\.)",
+        caddie_text,
+        flags=re.DOTALL,
+    )
+    assert clarity_match is not None
+    clarity = clarity_match.group(0)
+    assert "Rules (primary)" in clarity and "#641" in clarity, (
+        "Sanity-Check Mode's settlement clarity check must require"
+        " stating YES/NO win conditions from `Rules (primary)` —"
+        " fast-track candidates never reach the deep-research rule"
+        " (#641)."
+    )
+
+
+def test_caddie_master_verifies_semantics_and_superseded(
+    caddie_master_text: str,
+) -> None:
+    """Caddie Master is the last line of defense: it must verify
+    Monitor's/Caddie's YES/NO descriptions against `Rules (primary)`
+    at both decision points (Step 2c flag review, Step 4c candidate
+    review), and must not renew a HOLD on SUPERSEDED sources (#641).
+    Each duty is anchored to its own section so neither clause can be
+    deleted and compensated for by a mention elsewhere."""
+    import re
+
+    # Step 2c: the flag-review sub-step itself must carry the check.
+    flag_review_match = re.search(
+        r"Review Monitor's flag note[^\n]*", caddie_master_text
+    )
+    assert flag_review_match is not None
+    flag_review = flag_review_match.group(0)
+    assert "Rules (primary)" in flag_review and "#641" in flag_review, (
+        "Step 2c's `Review Monitor's flag note` line must require"
+        " verifying Monitor's YES/NO description against"
+        " `Rules (primary)` (#641)."
+    )
+    # Step 4c: the candidate-review verification must live between the
+    # independent-research read and the Caddie conferral.
+    research_idx = caddie_master_text.find("Read the research independently")
+    confer_idx = caddie_master_text.find("Confer with Caddie using SendMessage")
+    assert research_idx != -1 and confer_idx != -1
+    candidate_review = caddie_master_text[research_idx:confer_idx]
+    assert "Rules (primary)" in candidate_review, (
+        "Step 4c must verify YES/NO win conditions against"
+        " `Rules (primary)` before APPROVE/REJECT (#641)."
+    )
+    assert "directional description" in candidate_review, (
+        "Step 4c must forbid accepting Caddie's directional"
+        " description of the contract unverified (#641)."
+    )
+    # HOLD bullet: SUPERSEDED prohibition.
+    assert "SUPERSEDED" in caddie_master_text, (
+        "Caddie Master's HOLD rule must reference SUPERSEDED sources"
+        " (#641)."
+    )
+    hold_idx = caddie_master_text.find("MUST NOT rest on sources marked")
+    assert hold_idx != -1, (
+        "HOLD bullet must contain the SUPERSEDED prohibition: a HOLD"
+        " `MUST NOT rest on sources marked` SUPERSEDED (#641)."
+    )
+    assert caddie_master_text.count("#641") >= 3, (
+        "Each #641 verification duty must cite the issue inline"
+        " (2c review, HOLD bullet, 4c review)."
+    )
+
+
+def test_threshold_semantics_exemplar_shared_across_agents(
+    monitor_text: str, caddie_text: str,
+) -> None:
+    """The canonical negative-threshold trap exemplar
+    (KXCPI-26JUN-T-0.1) must be pinned in BOTH monitor.md and
+    caddie.md so the two agents' semantics rules stay anchored to the
+    same incident — same cross-file convention as the economic-
+    category list sync test (#641)."""
+    for text, name in ((monitor_text, "monitor.md"), (caddie_text, "caddie.md")):
+        assert "KXCPI-26JUN-T-0.1" in text, (
+            f"{name} must pin the KXCPI-26JUN-T-0.1 exemplar (#641)."
+        )
+        assert 'Will CPI rise more than -0.1%?' in text, (
+            f"{name} must spell out the double-negative trap title"
+            f" verbatim so the worked example survives prompt edits"
+            f" (#641)."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -490,6 +490,49 @@ class TestMarketInfo:
         # Rich eats "[as reported by the BLS]" as a style tag (#641).
         assert "as reported" in result.output
 
+    def test_market_info_settlement_risk_flags_survive_markup(
+        self, seeded_db: Path,
+    ) -> None:
+        """With red flags present, SettlementRisk.summary reads
+        `found [discretion, ...]` — the bracketed flag list must be
+        markup-escaped inside the color tags or Rich eats it exactly
+        when the warning matters most (#641 Copilot review)."""
+        market = _stub_market("KXCPI-26APR-T0.5")
+        # Bracketed lowercase segment in the title: Rich parses table
+        # titles for markup too, so unescaped titles lose it (#641).
+        market.title = "CPI [preliminary] April 2026"
+        market.rules_primary = (
+            "The market may be settled at the sole discretion of the"
+            " exchange."
+        )
+        get_market = AsyncMock(return_value=market)
+        get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXCPI-26APR-T0.5"])
+        assert result.exit_code == 0, result.output
+        # Assert on bracket-adjacent fragments: the bare word
+        # "discretion" also appears in the verbatim Rules (primary)
+        # row, so it cannot distinguish the two rows — only the
+        # Settlement Risk flag list contains "[sole" / "discretion]",
+        # and both vanish if the escape is reverted (mutation-verified
+        # in review). The fragments have no internal spaces, so Rich
+        # word-wrap cannot split them.
+        assert "[sole" in result.output, (
+            "The bracketed red-flag list must render verbatim — without"
+            " escaping, Rich eats '[sole discretion]' as a style tag"
+            " and the Settlement Risk row silently truncates at"
+            " 'found' (#641)."
+        )
+        assert "discretion]" in result.output
+        assert "[preliminary]" in result.output, (
+            "The market title must render verbatim as the table title —"
+            " Rich markup-parses string titles, eating lowercase-start"
+            " bracketed segments unless escaped (#641)."
+        )
+
     def test_market_info_em_dash_fallback_for_missing_fields(
         self, seeded_db: Path,
     ) -> None:

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -375,6 +375,7 @@ def _stub_market(ticker: str) -> MagicMock:
     m.volume_24h = 50
     m.open_interest = 30
     m.close_time = "2026-05-14"
+    m.subtitle = ""
     m.rules_primary = ""
     return m
 
@@ -450,6 +451,72 @@ class TestMarketInfo:
             result = runner.invoke(app, ["market-info", "KXCPI-26APR-T0.5"])
         assert result.exit_code == 0, result.output
         assert get_market.await_args.args[1] == "KXCPI-26APR-T0.5"
+
+    def test_market_info_displays_settlement_rules(
+        self, seeded_db: Path,
+    ) -> None:
+        """market-info must show the verbatim settlement sentence and
+        subtitle so agents can ground YES/NO threshold semantics —
+        without these rows the #641 semantics-grounding prompt rules
+        are unimplementable (agents have no other way to read
+        rules_primary)."""
+        market = _stub_market("KXCPI-26APR-T0.5")
+        market.subtitle = "0.5% or above"
+        # Bracketed clause included deliberately: Rich parses [word
+        # groups] as style tags and silently deletes them unless the
+        # value is markup-escaped — the settlement sentence must
+        # survive verbatim (#641).
+        market.rules_primary = (
+            "If the Consumer Price Index [as reported by the BLS]"
+            " increases by more than 0.5%"
+            " in April 2026, the market resolves to Yes."
+        )
+        get_market = AsyncMock(return_value=market)
+        get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXCPI-26APR-T0.5"])
+        assert result.exit_code == 0, result.output
+        assert "Rules (primary)" in result.output
+        assert "Subtitle" in result.output
+        assert "0.5% or above" in result.output
+        # The settlement sentence must appear (Rich may wrap it across
+        # lines, so assert on fragments short enough to survive
+        # wrapping).
+        assert "resolves to" in result.output
+        # The bracketed clause must survive — without markup escaping,
+        # Rich eats "[as reported by the BLS]" as a style tag (#641).
+        assert "as reported" in result.output
+
+    def test_market_info_em_dash_fallback_for_missing_fields(
+        self, seeded_db: Path,
+    ) -> None:
+        """Missing subtitle/rules must render the em-dash fallback,
+        never `None` — an agent reading `Rules (primary): None` is the
+        precise semantics-grounding failure #641 exists to stop."""
+        market = _stub_market("KXCPI-26APR-T0.5")
+        market.subtitle = None
+        market.rules_primary = ""
+        get_market = AsyncMock(return_value=market)
+        get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", "KXCPI-26APR-T0.5"])
+        assert result.exit_code == 0, result.output
+        lines = result.output.splitlines()
+        assert any("Subtitle" in ln and "—" in ln for ln in lines), (
+            "Subtitle row must fall back to em-dash when the field is"
+            " None (#641)."
+        )
+        assert any("Rules (primary)" in ln and "—" in ln for ln in lines), (
+            "Rules (primary) row must fall back to em-dash when the"
+            " field is empty (#641)."
+        )
+        assert "None" not in result.output
 
 
 def _read_error_log(db_path: Path) -> list[dict]:


### PR DESCRIPTION
## Summary

Fixes the two agent-note defects surfaced by the KXCPI-26JUN-T-0.1 re-underwrite (2026-07-02):

**Finding 1 — YES/NO semantics inverted in position notes.** For negative-threshold markets ("Will CPI rise more than -0.1%?"), every note in the chain described YES/NO backwards. Fix:
- `monitor.md` / `caddie.md` / `caddie-master.md`: **Threshold-semantics grounding** rules — derive semantics from the settlement sentence, state "YES wins when X / NO wins when Y" before analysis, never from the title's directional wording; Caddie Master verifies at both decision points (2c flag review, 4c candidate review). Monitor's observation template gains a `Semantics:` line.
- `cli.py`: `market-info` now shows **Subtitle** and **Rules (primary)** rows — agents previously had *no CLI path* to the settlement sentence, so the grounding rules would have been unimplementable. Values are markup-escaped (Rich silently ate bracketed clauses like `[as reported by the BLS]` as style tags).
- `kalshi/markets.py`: explicit JSON `null` for subtitle/rules_primary coerced to `""` (previously an uncaught, unlogged ValidationError — same class as #574).
- Empty rules row = unverifiable: Monitor flags, Caddie PASSes, Caddie Master REJECTs — never a title-derived fallback.

**Finding 2 — stale forecasts marked "freshly confirmed" when merely re-found.** Jun 11–18 bank notes rode through Jul 1 cycles as "freshly confirmed" after the late-June Hormuz-reopening energy crash had superseded them. Fix:
- #615 audit-footer grammar extended to **four outcomes**: adds `SUPERSEDED (pre-<event>, <date>) — refresh required`.
- **Freshness rule**: bare fresh form requires a strictly newer publication date (first cites exempt); re-found notes must be written as `inherited`.
- **Supersession rule**: sticky across cycles (no silent revert to `inherited`); a HOLD must not rest on SUPERSEDED sources.
- Read-back assertion gains outcome (c); #614 validator message now mentions the supersession path.

## Review pipeline

code-reviewer, silent-failure-hunter, and pr-test-analyzer ran pre-commit; all findings ≥80 confidence fixed (Rich markup escaping, null coercion, empty-rules no-op path, read-back contradiction, 3 coverage gaps); code-simplifier pass applied. Full unit suite: **1502 passed**; ruff clean.

## Test plan

- `uv run pytest tests/unit/test_agent_prompts.py tests/unit/test_cli_ticker_prefix.py` — 10 new drift-guard tests (semantics rules ×3 agents, Semantics: template line, 4-outcome grammar 13-row count, freshness/supersession pins incl. stickiness, 2c/4c section-scoped anchors, four-outcomes spec pin) + CLI tests for the new rows, em-dash/None fallback, and bracket-escape regression.
- Full suite green (1502 passed in 16m08s).

## Operational follow-up (outside this PR)

One-time corrective `context` note on KXCPI-26JUN-T-0.1 before Jul 14 settlement (corrected semantics + supersession of Jun 11–18 cites), per #641.

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB