### PR TITLE
Fix #644: escape external text at all remaining Rich table/title/print sites

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -703,16 +703,17 @@ def validate(
                 series_exposure=series_exp,
             )
 
-            console.print(f"\n[bold]Validation: {ticker}[/bold]")
-            if result.approved:
-                console.print(f"[green bold]{result.summary}[/green bold]")
-            else:
-                console.print(f"[red bold]{result.summary}[/red bold]")
+            # #644: summaries/failures embed settlement text with
+            # literal bracketed flag lists — escape external fragments
+            # so Rich renders them verbatim inside the styled lines.
+            console.print(f"\n[bold]Validation: {rich_escape(ticker)}[/bold]")
+            style = "green bold" if result.approved else "red bold"
+            console.print(f"[{style}]{rich_escape(result.summary)}[/{style}]")
 
             for check in result.checks:
-                console.print(f"  [green]✓[/green] {check}")
+                console.print(f"  [green]✓[/green] {rich_escape(check)}")
             for fail in result.failures:
-                console.print(f"  [red]✗[/red] {fail}")
+                console.print(f"  [red]✗[/red] {rich_escape(fail)}")
 
             if not result.approved:
                 raise typer.Exit(1)
@@ -925,12 +926,14 @@ def order(
                 )
 
                 if not validation.approved:
+                    # #644: summary/failures embed settlement text with
+                    # literal bracketed flag lists — escape.
                     console.print(
-                        f"\n[red bold]{validation.summary}"
+                        f"\n[red bold]{rich_escape(validation.summary)}"
                         f"[/red bold]"
                     )
                     for fail in validation.failures:
-                        console.print(f"  [red]✗[/red] {fail}")
+                        console.print(f"  [red]✗[/red] {rich_escape(fail)}")
                     if force:
                         console.print(
                             "[yellow bold]--force: Overriding"
@@ -1408,7 +1411,10 @@ def candidates(
             console.print("[dim]No candidate records found[/dim]")
             return
 
-        title = f"Candidates for {ticker}" if ticker else f"Candidates (last {limit})"
+        title = (
+            f"Candidates for {rich_escape(ticker)}"  # #644
+            if ticker else f"Candidates (last {limit})"
+        )
         table = Table(title=title)
         table.add_column("Ticker", overflow="fold")
         table.add_column("Score", justify="right")
@@ -1704,7 +1710,10 @@ def risk_check() -> None:
                 if check.passed:
                     console.print(f"  [green]✓[/green] {label}: OK")
                 else:
-                    console.print(f"  [red]✗[/red] {label}: {check.reason}")
+                    console.print(
+                        f"  [red]✗[/red] {label}:"
+                        f" {rich_escape(check.reason)}"  # #644
+                    )
 
     _run(_check())
 
@@ -1956,8 +1965,10 @@ def market_info(
                 # em-dash when the field is empty.
                 return rich_escape(value) if value else "—"
 
-            # rich_escape: table titles are markup-parsed too (#641 review).
-            table = format_kv_table(rich_escape(market.title), [
+            # Title escaping is central in format_kv_table (#644) —
+            # do NOT pre-escape here (double-escape renders a literal
+            # backslash).
+            table = format_kv_table(market.title, [
                 ("Ticker", market.ticker),
                 ("Event", market.event_ticker),
                 ("Subtitle", verbatim(market.subtitle)),
@@ -2953,8 +2964,11 @@ def errors(
                         format_local_timestamp(str(row["timestamp"])),
                         f"[{sev_color}]{sev}[/{sev_color}]",
                         row["category"],
-                        row.get("error_code", ""),
-                        row["message"][:50],
+                        rich_escape(row.get("error_code", "")),
+                        # #644: logged error text is the most bracket-
+                        # prone data in the system — a stray closing tag
+                        # would even crash the render. Truncate first.
+                        rich_escape(row["message"][:50]),
                         resolved,
                     )
                 console.print(table)
@@ -3290,14 +3304,20 @@ def discover(
 
         async with KalshiClient(config) as client:
             series_list = await list_series(client, category=category)
-            console.print(f"Found {len(series_list)} series in [bold]{category}[/bold]")
+            console.print(
+                f"Found {len(series_list)} series"
+                f" in [bold]{rich_escape(category)}[/bold]"  # #644
+            )
 
-            table = Table(title=f"{category} Series")
+            table = Table(title=f"{rich_escape(category)} Series")  # #644
             table.add_column("Ticker", style="cyan", overflow="fold")
             table.add_column("Title")
 
             for s in sorted(series_list, key=lambda x: x.get("ticker", "")):
-                table.add_row(s.get("ticker", ""), s.get("title", ""))
+                table.add_row(
+                    s.get("ticker", ""),
+                    rich_escape(s.get("title", "")),  # #644: API series title
+                )
 
             console.print(table)
 

--- a/src/gimmes/reporting/formatter.py
+++ b/src/gimmes/reporting/formatter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -123,7 +124,7 @@ def format_scan_results(markets: list[dict], title: str = "Scan Results") -> Non
 
     has_side = any(m.get("side") for m in markets)
 
-    table = Table(title=title)
+    table = Table(title=rich_escape(title))  # #644: title param is open to callers
     table.add_column("Ticker", style="cyan", overflow="fold")
     if has_side:
         table.add_column("Side", style="bold")
@@ -143,7 +144,7 @@ def format_scan_results(markets: list[dict], title: str = "Scan Results") -> Non
             row.append(m.get("side", "").upper())
         row.extend([
             evt_label,
-            m.get("title", "")[:20],
+            rich_escape(m.get("title", "")[:20]),  # #644
             f"${m.get('price', 0):.2f}",
             str(m.get("volume_24h", 0)),
             str(m.get("open_interest", 0)),
@@ -155,8 +156,16 @@ def format_scan_results(markets: list[dict], title: str = "Scan Results") -> Non
 
 
 def format_kv_table(title: str, rows: list[tuple[str, str]]) -> Table:
-    """Build a two-column Rich table for key-value display."""
-    table = Table(title=title, show_header=False)
+    """Build a two-column Rich table for key-value display.
+
+    The title is markup-escaped here — callers must NOT pre-escape it
+    (double-escaping renders a literal backslash). Row VALUES are still
+    markup-parsed: wrap external text in rich_escape() at the call
+    site, or pass deliberate markup like color tags (#641/#644). If a
+    styled title is ever genuinely needed, add an escape hatch then —
+    today every caller passes plain text.
+    """
+    table = Table(title=rich_escape(title), show_header=False)
     table.add_column("Key", style="cyan")
     table.add_column("Value", style="white", justify="right")
     for key, value in rows:

--- a/tests/unit/test_cli_markup_escape.py
+++ b/tests/unit/test_cli_markup_escape.py
@@ -1,0 +1,161 @@
+"""CLI regression tests for Rich markup escaping of external text (#644).
+
+Kalshi titles, CLI args, and settlement text can contain bracketed
+segments (`[preliminary]`, `[sole discretion, ...]`) that Rich eats as
+style tags unless escaped. Each test pins a bracket fragment surviving
+in the rendered output — fragments are chosen with no internal spaces
+so Rich word-wrap can't split them (the #641/#642 pattern), and
+bracket segments start lowercase because uppercase-start segments
+aren't parsed as tags and wouldn't reproduce the bug.
+
+The `size` command's title is covered by the central format_kv_table
+escape (test_formatter.py) — no per-command harness here per the #644
+plan (its 7-patch mock stack isn't worth a CLI-arg-only title).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from gimmes.cli import app
+
+runner = CliRunner()
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    c = MagicMock()
+    c.db_path = tmp_path / "test.db"
+    return c
+
+
+def _stub_market() -> MagicMock:
+    m = MagicMock()
+    m.ticker = "KXCPI-26APR-T0.5"
+    m.event_ticker = "KXCPI-26APR"
+    m.series_ticker = "KXCPI"
+    m.title = "CPI [preliminary] April 2026"
+    m.subtitle = ""
+    m.status = MagicMock()
+    m.status.value = "active"
+    m.yes_bid = 0.50
+    m.yes_ask = 0.55
+    m.no_bid = 0.45
+    m.no_ask = 0.50
+    m.last_price = 0.52
+    m.midpoint = 0.52
+    m.spread = 0.05
+    m.volume = 100
+    m.volume_24h = 50
+    m.open_interest = 30
+    m.close_time = None
+    m.rules_primary = ""
+    return m
+
+
+def test_score_title_brackets(tmp_path: Path) -> None:
+    with patch("gimmes.cli.load_config", return_value=_config(tmp_path)), \
+         patch("gimmes.kalshi.client.KalshiClient"), \
+         patch(
+             "gimmes.kalshi.markets.get_market",
+             AsyncMock(return_value=_stub_market()),
+         ), \
+         patch(
+             "gimmes.kalshi.markets.get_orderbook",
+             AsyncMock(return_value=MagicMock(yes_bids=[], yes_asks=[])),
+         ), \
+         patch(
+             "gimmes.strategy.scorer.quick_score",
+             MagicMock(return_value=85.0),
+         ):
+        result = runner.invoke(app, ["score", "KXCPI-26APR-T0.5"])
+    assert result.exit_code == 0, result.output
+    assert "[preliminary]" in result.output
+    assert "\\[preliminary]" not in result.output
+
+
+def test_candidates_title_brackets(tmp_path: Path) -> None:
+    row = {
+        "ticker": "KXCPI-26APR-T0.5", "gimme_score": 70.0,
+        "market_price": 0.5, "model_probability": 0.6, "edge": 0.1,
+        "cap_blocked": 0, "recommendation": "proceed",
+        "scanned_at": "2026-07-01 12:00:00",
+    }
+    with patch("gimmes.store.database.Database", MagicMock()), \
+         patch(
+             "gimmes.store.queries.get_candidate_for_ticker",
+             AsyncMock(return_value=[row]),
+         ), patch("gimmes.cli.load_config", return_value=_config(tmp_path)):
+        result = runner.invoke(
+            app, ["candidates", "--ticker", "kxcpi [draft]"],
+        )
+    assert "[draft]" in result.output, result.output
+
+
+def test_discover_category_brackets(tmp_path: Path) -> None:
+    series = [{"ticker": "KXCPI", "title": "CPI [preliminary] index"}]
+    with patch("gimmes.cli.load_config", return_value=_config(tmp_path)), \
+         patch("gimmes.kalshi.client.KalshiClient"), \
+         patch(
+             "gimmes.kalshi.markets.list_series",
+             AsyncMock(return_value=series),
+         ):
+        result = runner.invoke(app, ["discover", "econ [test]"])
+    assert result.exit_code == 0, result.output
+    # The category appears on BOTH the found-line and the table title —
+    # count >= 2 so reverting either escape is caught.
+    assert result.output.count("[test]") >= 2, result.output
+    assert "[preliminary]" in result.output
+
+
+def test_validate_failure_messages_brackets(tmp_path: Path) -> None:
+    """Settlement red-flag lists render as literal bracketed text in
+    validation failures — they must survive the styled output lines."""
+    from gimmes.risk.validator import ValidationResult
+
+    cfg = _config(tmp_path)
+    cfg.bankroll = 1000.0
+    cfg.strategy.side = "yes"
+    vr = ValidationResult(
+        approved=False,
+        checks=["Edge OK [margin ok]"],
+        failures=[
+            "Settlement risk HIGH: Settlement risk (high):"
+            " found [sole discretion, may determine]"
+        ],
+    )
+    with patch("gimmes.cli.load_config", return_value=cfg), \
+         patch("gimmes.kalshi.client.KalshiClient"), \
+         patch("gimmes.strategy.fee_cache.refresh_fee_cache", AsyncMock()), \
+         patch(
+             "gimmes.kalshi.markets.get_market",
+             AsyncMock(return_value=_stub_market()),
+         ), \
+         patch(
+             "gimmes.kalshi.portfolio.get_all_positions",
+             AsyncMock(return_value=[]),
+         ), \
+         patch("gimmes.store.queries.get_daily_pnl", AsyncMock(return_value=0.0)), \
+         patch(
+             "gimmes.store.queries.get_deployed_cost_basis",
+             AsyncMock(return_value=0.0),
+         ), \
+         patch(
+             "gimmes.risk.validator.validate_trade",
+             MagicMock(return_value=vr),
+         ):
+        result = runner.invoke(app, [
+            "validate", "KXCPI-26APR-T0.5",
+            "--prob", "0.9", "--dollars", "10",
+        ])
+    assert result.exit_code == 1, result.output
+    # The fragment appears on BOTH the summary line and the per-failure
+    # line — count >= 2 so reverting either escape is caught (the
+    # summary embeds the same failure text, making a single presence
+    # check blind to the per-line escape).
+    assert result.output.count("[sole") >= 2, result.output
+    assert "determine]" in result.output
+    # F6 (#644): the checks line and header ticker are escaped too.
+    assert "[margin" in result.output

--- a/tests/unit/test_cli_positions.py
+++ b/tests/unit/test_cli_positions.py
@@ -245,3 +245,40 @@ class TestRichDefaultBehaviorDocumentation:
         )
         assert LONG_TICKER in ticker_col
         assert ELLIPSIS not in ticker_col
+
+
+class TestScanResultsMarkupEscape:
+    @staticmethod
+    def _market(title: str) -> dict:
+        return {
+            "ticker": SHORTER_TICKER,
+            "event_ticker": "KXCPI-26APR",
+            "title": title,
+            "price": 0.65,
+            "volume_24h": 100,
+            "open_interest": 50,
+            "score": 80,
+        }
+
+    def test_bracketed_title_cell_survives_markup(
+        self, narrow_console: StringIO,
+    ) -> None:
+        """Market titles from the Kalshi API can carry bracketed
+        segments — the Title cell must render them verbatim (#644).
+        The fragment fits inside the column's 20-char cap."""
+        from gimmes.reporting.formatter import format_scan_results
+
+        format_scan_results([self._market("CPI [prelim] Apr")])
+        out = narrow_console.getvalue()
+        assert "[prelim]" in out
+
+    def test_bracketed_title_param_survives_markup(
+        self, narrow_console: StringIO,
+    ) -> None:
+        """The title parameter is public — bracketed callers must
+        render verbatim (#644)."""
+        from gimmes.reporting.formatter import format_scan_results
+
+        format_scan_results([self._market("CPI")], title="Scan [draft]")
+        out = narrow_console.getvalue()
+        assert "[draft]" in out

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -532,6 +532,10 @@ class TestMarketInfo:
             " Rich markup-parses string titles, eating lowercase-start"
             " bracketed segments unless escaped (#641)."
         )
+        # #644: title escaping moved INTO format_kv_table — a caller
+        # that pre-escapes now double-escapes, rendering a literal
+        # backslash that the positive assertion above cannot see.
+        assert "\\[preliminary]" not in result.output
 
     def test_market_info_em_dash_fallback_for_missing_fields(
         self, seeded_db: Path,

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -5,10 +5,22 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Iterator
+from io import StringIO
 
 import pytest
+from rich.console import Console
+from rich.table import Table
 
 from gimmes.reporting.formatter import format_kv_table, format_local_timestamp
+
+
+def _render_table(table: Table) -> str:
+    """Render a table to text at a fixed 100-col width — wide enough
+    that Rich wraps titles at the TABLE width, not the console width
+    (a narrow console would split the asserted fragments)."""
+    buf = StringIO()
+    Console(file=buf, width=100).print(table)
+    return buf.getvalue()
 
 
 class TestFormatKvTable:
@@ -25,6 +37,31 @@ class TestFormatKvTable:
     def test_no_header(self) -> None:
         table = format_kv_table("T", [("k", "v")])
         assert table.show_header is False
+
+    def test_title_with_brackets_survives_render(self) -> None:
+        """Bracketed external text in the title must render verbatim
+        (#644): the positive fragment catches markup-eating, the
+        negative catches double-escaping (a pre-escaping caller would
+        render a literal backslash — invisible to the positive check).
+        """
+        # Wide row: Rich wraps the title to the TABLE width, not
+        # the console width — a narrow table would split the fragment.
+        table = format_kv_table(
+            "CPI [preliminary] April 2026",
+            [("key", "value " * 8)],
+        )
+        out = _render_table(table)
+        assert "[preliminary]" in out
+        assert "\\[preliminary]" not in out
+
+    def test_values_still_support_markup(self) -> None:
+        """Row VALUES stay markup-parsed by contract (#644) — callers
+        pass deliberate color tags (e.g. the Settlement Risk cell). A
+        future blanket value-escape must fail here loudly."""
+        table = format_kv_table("T", [("k", "[bold]42[/bold]")])
+        out = _render_table(table)
+        assert "42" in out
+        assert "[bold]" not in out
 
 
 @pytest.fixture()

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -91,7 +91,7 @@ def _stub_config():
 def _run_order_cli(
     broker, *, sync_side_effect=None, championship_create_order=None,
     insert_error_side_effect=None, extra_args=None, market=None,
-    snapshot_mock=None,
+    snapshot_mock=None, validation=None,
 ):
     """Invoke the order CLI command with a mocked broker.
 
@@ -132,7 +132,10 @@ def _run_order_cli(
         patch("gimmes.strategy.fee_cache.get_multipliers", MagicMock(return_value=mock_fees)),
         patch(
             "gimmes.risk.validator.validate_trade",
-            MagicMock(return_value=MagicMock(approved=True, failures=[])),
+            MagicMock(
+                return_value=validation if validation is not None
+                else MagicMock(approved=True, failures=[]),
+            ),
         ),
         patch("gimmes.store.queries.get_daily_pnl", AsyncMock(return_value=0.0)),
         patch("gimmes.store.queries.get_deployed_cost_basis", AsyncMock(return_value=0.0)),
@@ -854,3 +857,30 @@ class TestRulesSnapshotWiring:
         result, snap_spy = self._run_with_snapshot_spy(snap_return=False)
         assert result.exit_code == 0, result.output
         snap_spy.assert_awaited_once()
+
+
+class TestOrderValidationMarkupEscape:
+    def test_rejection_display_escapes_bracketed_failures(self) -> None:
+        """Order-command rejection summary and per-failure lines embed
+        settlement red-flag lists — the escapes at both sites must
+        survive (console is mocked, so we pin the pre-render markup
+        directly: the escaped form contains a backslash-bracket)
+        (#644)."""
+        from gimmes.risk.validator import ValidationResult
+
+        broker = _make_mock_broker()
+        vr = ValidationResult(
+            approved=False,
+            checks=[],
+            failures=[
+                "Settlement risk HIGH: found [sole discretion]",
+            ],
+        )
+        result, mock_console, _ = _run_order_cli(broker, validation=vr)
+        printed = " ".join(
+            str(c.args[0]) for c in mock_console.print.call_args_list
+            if c.args
+        )
+        # Escaped markup contains the literal backslash-bracket form on
+        # BOTH the summary line and the per-failure line.
+        assert printed.count("\\[sole") >= 2, printed


### PR DESCRIPTION
## Summary

Closes out the Rich markup-eating bug class (#641/#642/#649): bracketed segments in external text (`[preliminary]`, `[sole discretion, ...]`) were parsed as style tags and silently dropped — or, in the errors table, could crash the render on a stray closing tag.

**Central fix:** `format_kv_table` escapes its title (callers must NOT pre-escape; the #642 market-info pre-escape is removed and a negative `\[...` assertion pins against double-escaping). Row values stay markup-parsed by contract — the Settlement Risk color cell depends on it, and a dedicated test locks the contract. `format_scan_results` escapes its title param and the truncated Title cell (truncate-then-escape order).

**Per-site escapes:** candidates/discover titles, discover series cells + found-line, validate header/summary/checks/failures, order-command validation display (pre-existing same-class site *found during mutation testing*), risk-check failure reason, errors-table cells.

## Review pipeline

Code review + combined silent-failure/coverage review + simplifier; all findings ≥80 applied (crash-capable errors-table miss, broken docstring escape-hatch claim, per-site pinning gaps). Three key fixes mutation-verified; count≥2 assertions used wherever one fragment appears at two escape sites (single-presence checks are provably blind to per-site reverts).

## Test plan

- New `tests/unit/test_cli_markup_escape.py` (score/candidates/discover/validate CLI harnesses) + render tests in test_formatter.py + scan-results cases + order-rejection pin via pre-render markup + negative double-escape assertions.
- Full suite: **1597 passed**; ruff clean.

## Follow-up

#650 — remaining low-priority sites (exception text, config wizard, Pro recommendation cells).

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB