### PR TITLE
Fix #653: settlement P&L reaches the scorecard — settle() close trades, backfill, drift repricing

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2109,6 +2109,206 @@ def log_candidate(
     _run(_log())
 
 
+@app.command(name="backfill-settlements", hidden=True)
+def backfill_settlements(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would change without writing",
+    ),
+) -> None:
+    """One-time #653 correction: write missing settlement close trades
+    for paper positions the broker settled without a trade row, and
+    repair mark-priced reconcile drift closes to settlement value.
+
+    Idempotent: residual-count guard skips tickers whose closes already
+    cover their opens; the drift repair is a no-op once prices match
+    settlement values. Historical timestamps keep backfilled P&L out of
+    today's daily-loss trigger.
+    """
+    config = load_config()
+
+    class _DryRunRollbackError(Exception):
+        """Raised to abort the transaction on --dry-run."""
+
+    async def _backfill() -> None:
+        from gimmes.store.database import Database
+
+        inserted: list[tuple[str, str, int, float]] = []
+        repaired: list[tuple[str, float, float]] = []
+        conflicts: list[tuple[str, str, str]] = []
+
+        async with Database(config.db_path) as db:
+            try:
+                await _apply(db, inserted, repaired, conflicts)
+            except _DryRunRollbackError:
+                console.print("[dim]Dry run — no changes written.[/dim]")
+        _print_summary(inserted, repaired, conflicts, dry_run)
+
+    async def _apply(db, inserted, repaired, conflicts) -> None:  # type: ignore[no-untyped-def]
+        from datetime import UTC, datetime
+
+        from gimmes.store.queries import (
+            count_opened_closed,
+            fill_resolved_outcome,
+            log_settlement_close,
+            settlement_outcome,
+        )
+
+        async with db.transaction():
+            # paper_positions is created by PaperBroker, not the main
+            # schema — championship-only DBs won't have it.
+            cursor = await db.conn.execute(
+                "SELECT name FROM sqlite_master"
+                " WHERE type='table' AND name='paper_positions'",
+            )
+            if await cursor.fetchone() is None:
+                console.print(
+                    "[yellow]No paper_positions table — nothing to"
+                    " backfill (#653 applies to paper-mode"
+                    " settlements).[/yellow]"
+                )
+                return
+            cursor = await db.conn.execute(
+                "SELECT ticker, side, avg_price, cost_basis,"
+                " market_price, updated_at"
+                " FROM paper_positions"
+                " WHERE count = 0 AND market_price IN (0.0, 1.0)",
+            )
+            settled = [dict(r) for r in await cursor.fetchall()]
+
+            for row in settled:
+                ticker, side = row["ticker"], row["side"]
+                won = row["market_price"] == 1.0
+                # Residual = opens+size_ups minus closes. <= 0 means
+                # closes already cover the position (idempotency, and
+                # skips fully-sold rows with real close records).
+                opened, closed = await count_opened_closed(db, ticker, side)
+                residual = opened - closed
+                if residual <= 0:
+                    continue
+
+                # Cross-checks (warn-only): trades-derived residual is
+                # authoritative for the close count.
+                if row["avg_price"]:
+                    implied = round(row["cost_basis"] / row["avg_price"])
+                    if abs(implied - residual) > 1:
+                        console.print(
+                            f"[yellow]{ticker}: residual {residual}"
+                            f" differs from cost-basis-implied"
+                            f" {implied} — using trades-derived"
+                            f" residual (#653)[/yellow]"
+                        )
+
+                ts = None
+                if row["updated_at"]:
+                    try:
+                        ts = datetime.fromisoformat(
+                            row["updated_at"],
+                        ).replace(tzinfo=UTC)
+                    except ValueError:
+                        ts = None
+                if ts is None:
+                    console.print(
+                        f"[yellow]{ticker}: no usable settle"
+                        f" timestamp — the backfilled close will"
+                        f" be stamped NOW and count toward"
+                        f" today's daily P&L / loss trigger"
+                        f" (#653).[/yellow]"
+                    )
+                outcome = settlement_outcome(side, won)
+                # Detect resolved_outcome conflicts BEFORE the helper
+                # fills NULLs: paper truth (the broker moved the
+                # balance on this outcome) wins over log-outcome.
+                cursor = await db.conn.execute(
+                    "SELECT DISTINCT resolved_outcome FROM trades"
+                    " WHERE ticker = ? AND resolved_outcome IS NOT NULL",
+                    (ticker,),
+                )
+                existing = [r[0] for r in await cursor.fetchall()]
+                if existing and any(o != outcome for o in existing):
+                    conflicts.append((ticker, str(existing), outcome))
+                    await db.conn.execute(
+                        "UPDATE trades SET resolved_outcome = ?"
+                        " WHERE ticker = ?", (outcome, ticker),
+                    )
+                await log_settlement_close(
+                    db, ticker=ticker, side=side, count=residual,
+                    won=won, timestamp=ts,
+                    rationale=(
+                        "settlement backfill (#653) — close"
+                        " reconstructed from paper_positions settle"
+                        " state"
+                    ),
+                )
+                inserted.append(
+                    (ticker, side, residual, 1.0 if won else 0.0),
+                )
+
+            # Phase 2: repair mark-priced reconcile drift rows whose
+            # market actually settled.
+            cursor = await db.conn.execute(
+                """SELECT t.id, t.ticker, t.side, t.price,
+                          p.market_price
+                   FROM trades t
+                   JOIN paper_positions p
+                     ON p.ticker = t.ticker AND p.side = t.side
+                   WHERE t.action = 'close' AND t.agent = 'reconcile'
+                     AND p.count = 0
+                     AND p.market_price IN (0.0, 1.0)
+                     AND t.price != p.market_price""",
+            )
+            drift_rows = [dict(r) for r in await cursor.fetchall()]
+            for row in drift_rows:
+                settlement_value = row["market_price"]
+                await db.conn.execute(
+                    """UPDATE trades SET price = ?, rationale =
+                         rationale ||
+                         ' — price corrected to settlement value'
+                         || ' (#653 backfill)'
+                       WHERE id = ?""",
+                    (settlement_value, row["id"]),
+                )
+                won = settlement_value == 1.0
+                outcome = settlement_outcome(row["side"], won)
+                await fill_resolved_outcome(db, row["ticker"], outcome)
+                repaired.append(
+                    (row["ticker"], row["price"], settlement_value),
+                )
+
+            if dry_run:
+                raise _DryRunRollbackError
+
+    def _print_summary(inserted, repaired, conflicts, dry: bool) -> None:  # type: ignore[no-untyped-def]
+        verb = "Would insert" if dry else "Inserted"
+        console.print(
+            f"[bold]{verb} {len(inserted)} settlement close(s);"
+            f" {'would repair' if dry else 'repaired'}"
+            f" {len(repaired)} drift row(s).[/bold]"
+        )
+        for ticker, side, count, price in inserted:
+            console.print(
+                f"  + {ticker} {side} x{count} @ settlement {price}",
+                markup=False,
+            )
+        for ticker, old, new in repaired:
+            console.print(
+                f"  ~ {ticker} price {old} -> {new}", markup=False,
+            )
+        for ticker, existing, truth in conflicts:
+            console.print(
+                f"  ! {ticker}: resolved_outcome {existing} conflicted"
+                f" with paper truth '{truth}' — paper truth applied",
+                markup=False,
+            )
+        if not dry:
+            console.print(
+                "[yellow]Scorecard now reflects settlement outcomes —"
+                " the net P&L change is a CORRECTION of previously"
+                " unrecorded settlements, not a new loss (#653).[/yellow]"
+            )
+
+    _run(_backfill())
+
+
 @app.command(name="log-outcome", hidden=True)
 def log_outcome(
     ticker: str = typer.Argument(..., help="Market ticker"),

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2215,9 +2215,10 @@ def backfill_settlements(
                         f" (#653).[/yellow]"
                     )
                 outcome = settlement_outcome(side, won)
-                # Detect resolved_outcome conflicts BEFORE the helper
-                # fills NULLs: paper truth (the broker moved the
-                # balance on this outcome) wins over log-outcome.
+                # Detect resolved_outcome conflicts for the WARNING
+                # (the authoritative helper corrects them either way):
+                # paper truth — the broker moved the balance on this
+                # outcome — wins over log-outcome.
                 cursor = await db.conn.execute(
                     "SELECT DISTINCT resolved_outcome FROM trades"
                     " WHERE ticker = ? AND resolved_outcome IS NOT NULL",

--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -598,6 +598,8 @@ class PaperBroker:
         if not rows:
             return
 
+        from gimmes.store.queries import log_settlement_close
+
         async with self._db.transaction():
             for row in rows:
                 count = int(row["count"])
@@ -617,6 +619,22 @@ class PaperBroker:
                        WHERE ticker = ? AND side = ?""",
                     (1.0 if won else 0.0, realized_pnl, ticker, side),
                 )
+
+                # #653: settlements are real outcomes — write the close
+                # trade at settlement value so the lifetime scorecard
+                # sees the W/L (previously only the balance knew).
+                await log_settlement_close(
+                    self._db, ticker=ticker, side=side,
+                    count=count, won=won,
+                )
+
+            # #653: remove the mirror row in the main positions table
+            # inside the SAME transaction — otherwise the next
+            # sync_positions sees the ticker vanish from the broker and
+            # writes a duplicate mark-priced reconcile drift close.
+            await self._conn.execute(
+                "DELETE FROM positions WHERE ticker = ?", (ticker,)
+            )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/gimmes/reporting/formatter.py
+++ b/src/gimmes/reporting/formatter.py
@@ -48,6 +48,15 @@ def format_pnl_summary(summary: PnLSummary) -> None:
     table.add_column("Value", style="white", justify="right")
 
     table.add_row("Total Trades", str(summary.total_trades))
+    # #653: total = closed (W+L+scratch) + open — show the split so the
+    # table is internally consistent instead of leaving readers to
+    # wonder where total - W - L - S trades went.
+    closed = (
+        summary.winning_trades + summary.losing_trades
+        + summary.scratch_trades
+    )
+    table.add_row("Closed", str(closed))
+    table.add_row("Open Positions", str(summary.open_trades))
     table.add_row("Winning", str(summary.winning_trades))
     table.add_row("Losing", str(summary.losing_trades))
     table.add_row("Scratch", str(summary.scratch_trades))

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -15,6 +15,7 @@ class PnLSummary:
     """Profit and loss summary."""
 
     total_trades: int = 0
+    open_trades: int = 0
     winning_trades: int = 0
     losing_trades: int = 0
     scratch_trades: int = 0
@@ -64,10 +65,36 @@ def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  
         remaining = 0
         avg_cost = 0.0
 
+        # #653: resolution outcome propagated across the group — the
+        # outcome is usually recorded on the OPEN row (Monitor's
+        # log-outcome ran before any drift close existed), never on the
+        # reconcile close itself.
+        group_outcome = next(
+            (
+                e.get("resolved_outcome")
+                for e in events
+                if e.get("resolved_outcome") in ("yes", "no")
+            ),
+            None,
+        )
+
         for e in events:
             action = e["action"]
             count = int(e.get("count", 0) or 0)
             price = float(e.get("price", 0.0) or 0.0)
+
+            # #653: a reconcile drift close is priced at the last-known
+            # mark, not the broker-confirmed outcome. When the market's
+            # resolution is known, reprice at settlement value — this is
+            # how championship-mode settlements (which arrive as drift)
+            # enter the scorecard correctly. Without a known outcome the
+            # mark stands (genuine non-settlement drift).
+            if (
+                action == "close"
+                and e.get("agent") == "reconcile"
+                and group_outcome is not None
+            ):
+                price = 1.0 if side == group_outcome else 0.0
 
             if action in ("open", "size_up"):
                 if count <= 0:
@@ -117,8 +144,11 @@ def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  
 
         # Still-open residual: count once per (ticker, side) with carry, so
         # the prior open-only test (test_open_only_counted) keeps passing.
+        # open_trades makes the summary internally consistent:
+        # total = wins + losses + scratch + open (#653).
         if remaining > 0:
             summary.total_trades += 1
+            summary.open_trades += 1
 
     summary.net_pnl = summary.gross_pnl - summary.total_fees
     return summary

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -383,15 +383,22 @@ async def count_opened_closed(
 async def fill_resolved_outcome(
     db: Database, ticker: str, outcome: str
 ) -> None:
-    """Fill `resolved_outcome` (where NULL) on a ticker's trade rows.
+    """Set `resolved_outcome` on a ticker's trade rows — filling NULLs
+    AND overwriting conflicting values.
 
-    Commit-less variant of `update_trade_outcome` — the caller manages
-    the transaction (#653).
+    Settlement is the authoritative resolution source: an already-
+    populated but WRONG outcome (Monitor's log-outcome was proven
+    wrong at least once — the KXUE-UK26FEB-5.1 case) must be corrected,
+    or read-time repricing would trust the stale outcome over the
+    settlement truth. Idempotent when already correct (#653 review).
+
+    Commit-less — the caller manages the transaction.
     """
     await db.conn.execute(
         "UPDATE trades SET resolved_outcome = ?"
-        " WHERE ticker = ? AND resolved_outcome IS NULL",
-        (outcome, ticker),
+        " WHERE ticker = ?"
+        " AND (resolved_outcome IS NULL OR resolved_outcome != ?)",
+        (outcome, ticker, outcome),
     )
 
 
@@ -415,9 +422,10 @@ async def log_settlement_close(
     COUNT toward daily P&L (unlike `agent='reconcile'` drift, #622): a
     settlement loss is real realized money lost that day.
 
-    Also fills `resolved_outcome` (where NULL) on the ticker's trade
-    rows — settlement IS the resolution event, so the scorecard does
-    not depend on Monitor's log-outcome timing.
+    Also sets `resolved_outcome` on the ticker's trade rows — filling
+    NULLs AND correcting conflicting values, since settlement IS the
+    authoritative resolution event (Monitor's log-outcome has been
+    wrong before) and the scorecard must not depend on its timing.
 
     Commit-less: caller manages the transaction. Returns the trade
     row id.

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime
 from typing import TypedDict
 
@@ -273,16 +274,23 @@ async def _log_reconcile_closes(
     rows use commit-less helpers so they participate in the caller's
     transaction.
     """
-    import os
-
-    cycle_env = os.environ.get("GIMMES_CYCLE", "0")
-    try:
-        cycle = int(cycle_env or 0)
-    except ValueError:
-        cycle = 0
+    cycle = _cycle_from_env()
 
     for pos in removed:
         if exclude_ticker and pos.ticker == exclude_ticker:
+            continue
+        # #653 guard: if the ticker/side's closes already cover its
+        # opens (residual <= 0 — e.g. the paper broker just wrote a
+        # settlement close in this same sync window), do NOT write a
+        # duplicate drift close — that was how mark-priced phantom
+        # rows were born. Quantity-based, not timestamp-based: a
+        # partial close must NOT suppress the drift close for the
+        # remaining contracts (#653 review).
+        opened, closed = await count_opened_closed(db, pos.ticker, pos.side)
+        if opened > 0 and closed >= opened:
+            # Recorded closes already cover the recorded opens — a
+            # position with NO trade history (opened == 0) still gets
+            # its drift close (pre-#609 DBs, seeded positions).
             continue
         # Use last-known mark (market_price or avg_price) as the close
         # price rather than 0.0 — keeps `get_daily_pnl`'s realized-P&L
@@ -327,6 +335,137 @@ async def _log_reconcile_closes(
             " VALUES (?, ?, ?, ?, ?)",
             (pos.ticker, cycle, "reconcile", "decision", body),
         )
+
+
+def _cycle_from_env() -> int:
+    """Current cycle number from GIMMES_CYCLE (0 if unset or invalid)."""
+    try:
+        return int(os.environ.get("GIMMES_CYCLE", "0") or 0)
+    except ValueError:
+        return 0
+
+
+def settlement_outcome(side: str, won: bool) -> str:
+    """Resolution outcome implied by a settlement result (#653).
+
+    A winning YES position means the market resolved yes; a losing
+    YES position means it resolved no; and vice versa for NO.
+    """
+    if won:
+        return side
+    return "no" if side == "yes" else "yes"
+
+
+async def count_opened_closed(
+    db: Database, ticker: str, side: str
+) -> tuple[int, int]:
+    """Contract counts (opened, closed) for a ticker/side in the trades log.
+
+    Opened sums `open` + `size_up` rows; closed sums `close` rows.
+    Used by the #653 reconcile dup-guard and the backfill residual.
+    """
+    cursor = await db.conn.execute(
+        """SELECT
+             COALESCE(SUM(CASE WHEN action IN ('open','size_up')
+               THEN count END), 0) AS opened,
+             COALESCE(SUM(CASE WHEN action = 'close'
+               THEN count END), 0) AS closed
+           FROM trades WHERE ticker = ? AND side = ?
+             AND action IN ('open','size_up','close')""",
+        (ticker, side),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return 0, 0
+    return int(row["opened"] or 0), int(row["closed"] or 0)
+
+
+async def fill_resolved_outcome(
+    db: Database, ticker: str, outcome: str
+) -> None:
+    """Fill `resolved_outcome` (where NULL) on a ticker's trade rows.
+
+    Commit-less variant of `update_trade_outcome` — the caller manages
+    the transaction (#653).
+    """
+    await db.conn.execute(
+        "UPDATE trades SET resolved_outcome = ?"
+        " WHERE ticker = ? AND resolved_outcome IS NULL",
+        (outcome, ticker),
+    )
+
+
+async def log_settlement_close(
+    db: Database,
+    *,
+    ticker: str,
+    side: str,
+    count: int,
+    won: bool,
+    timestamp: datetime | None = None,
+    rationale: str | None = None,
+) -> int:
+    """Write a settlement close trade + decision note (#653).
+
+    Settlements are broker-confirmed outcomes — priced at exactly 1.0
+    (win) or 0.0 (loss), fee-free (Kalshi charges no settlement fee;
+    `calculate_fee` returns 0 outside 0<price<1 automatically), and
+    tagged `agent='settlement'` so they are distinguishable from both
+    intentional agent closes and reconcile drift. Settlement closes
+    COUNT toward daily P&L (unlike `agent='reconcile'` drift, #622): a
+    settlement loss is real realized money lost that day.
+
+    Also fills `resolved_outcome` (where NULL) on the ticker's trade
+    rows — settlement IS the resolution event, so the scorecard does
+    not depend on Monitor's log-outcome timing.
+
+    Commit-less: caller manages the transaction. Returns the trade
+    row id.
+    """
+    cycle = _cycle_from_env()
+
+    price = 1.0 if won else 0.0
+    synth = TradeDecision(
+        ticker=ticker,
+        action=TradeDecision.Action.CLOSE,
+        side=side,
+        count=count,
+        price=price,
+        rationale=rationale or (
+            "market settled — broker-confirmed outcome; close at"
+            " settlement value (#653)"
+        ),
+        agent="settlement",
+    )
+    if timestamp is not None:
+        synth.timestamp = timestamp
+    row_id = await _insert_trade_row(db, synth)
+
+    # resolved_outcome is derivable from the settlement itself:
+    # a winning YES position means the market resolved yes, etc.
+    outcome = settlement_outcome(side, won)
+    await fill_resolved_outcome(db, ticker, outcome)
+
+    # IMPORTANT: this body MUST NOT contain the literal string
+    # `Trigger: Stop-loss breach` (the #586 lockout query is a
+    # substring match — see _log_reconcile_closes above).
+    body = (
+        f"Decision: CLOSE\n"
+        f"Trigger: Settlement\n"
+        f"Side: {side}\n"
+        f"Count: {count}\n"
+        f"Settlement value: {price}\n"
+        f"Rationale: market resolved {outcome}; position settled by the"
+        f" broker at {price}. This is a settlement outcome, not an"
+        f" adverse price event — the #586 reopen lockout does NOT apply."
+    )
+    await db.conn.execute(
+        "INSERT INTO position_notes"
+        " (ticker, cycle, agent, note_type, body)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (ticker, cycle, "settlement", "decision", body),
+    )
+    return row_id
 
 
 async def sync_positions(db: Database, positions: list[Position]) -> None:
@@ -627,6 +766,9 @@ async def get_daily_pnl(db: Database, *, today: str | None = None) -> float:
     Synthetic reconcile-divergence close trades (agent='reconcile', written
     by `_log_reconcile_closes` per #609) are EXCLUDED from daily P&L because
     they represent broker-side drift, not intentional realized trading P&L.
+    Settlement closes (agent='settlement', #653) ARE included: a settlement
+    loss is real realized money lost that day and the daily-loss trigger
+    should see it.
     Including them distorts the daily-loss-limit trigger that the autonomous
     loop reads from this value — a reconcile-driven close at the last-known
     mark would show as realized loss/gain the operator did not actually

--- a/tests/unit/test_backfill_settlements.py
+++ b/tests/unit/test_backfill_settlements.py
@@ -1,0 +1,337 @@
+"""Tests for `gimmes backfill-settlements` (#653) — the one-time
+correction that writes missing settlement close trades for
+paper-settled positions and repairs mark-priced reconcile drift rows.
+
+Synchronous tests (asyncio.run for setup) — CliRunner's invocation
+drives the CLI's own asyncio.run, which cannot nest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import get_trades, insert_trade
+
+runner = CliRunner()
+
+TICKER = "KXCPI-26APR-T0.5"
+
+
+def _patch_config(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+
+def _trade(
+    ticker: str, action: str, count: int, price: float,
+    agent: str = "closer", ts: str | None = None,
+) -> TradeDecision:
+    t = TradeDecision(
+        ticker=ticker,
+        action=TradeDecision.Action(action),
+        side="no",
+        count=count,
+        price=price,
+        model_probability=0.8,
+        gimme_score=70.0,
+        edge=0.1,
+        kelly_fraction=0.02,
+        rationale="test",
+        agent=agent,
+        order_id=f"o-{ticker}-{action}",
+    )
+    if ts is not None:
+        t.timestamp = datetime.fromisoformat(ts).replace(tzinfo=UTC)
+    return t
+
+
+def _seed(
+    db_path: Path, *,
+    open_count: int = 100,
+    close_count: int | None = None,
+    close_agent: str = "closer",
+    close_price: float = 0.9,
+    paper_market_price: float = 1.0,
+    paper_count: int = 0,
+) -> None:
+    """Seed an open trade, an optional close, and a paper_positions row."""
+
+    async def _s() -> None:
+        from gimmes.paper.broker import PaperBroker
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            # paper_positions is created by PaperBroker.initialize().
+            paper_cfg = MagicMock()
+            paper_cfg.starting_balance = 10_000.0
+            broker = PaperBroker(db, paper_cfg)
+            await broker.initialize()
+            await insert_trade(db, _trade(
+                TICKER, "open", open_count, 0.63, ts="2026-04-20T12:00:00",
+            ))
+            if close_count is not None:
+                await insert_trade(db, _trade(
+                    TICKER, "close", close_count, close_price,
+                    agent=close_agent, ts="2026-04-25T12:00:00",
+                ))
+            await db.conn.execute(
+                """INSERT INTO paper_positions
+                   (ticker, side, count, avg_price, market_price,
+                    cost_basis, realized_pnl, updated_at)
+                   VALUES (?, 'no', ?, 0.63, ?, ?, ?,
+                           '2026-04-24 12:00:00')""",
+                (
+                    TICKER, paper_count, paper_market_price,
+                    open_count * 0.63,
+                    (open_count * 1.0 if paper_market_price == 1.0
+                     else 0.0) - open_count * 0.63,
+                ),
+            )
+            await db.conn.commit()
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+
+
+def _closes(db_path: Path) -> list[dict]:
+    async def _r() -> list[dict]:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            trades = await get_trades(db, ticker=TICKER)
+            return [t for t in trades if t["action"] == "close"]
+        finally:
+            await db.close()
+
+    return asyncio.run(_r())
+
+
+def test_ghost_settlement_gets_close_at_historical_timestamp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed(db_path)  # open, no close, paper settled as win (mp=1.0)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    c = closes[0]
+    assert c["agent"] == "settlement"
+    assert c["price"] == 1.0
+    assert c["count"] == 100
+    assert c["resolved_outcome"] == "no"  # NO side won → resolved no
+    # Historical timestamp from paper_positions.updated_at — keeps the
+    # backfilled P&L out of today's daily-loss trigger.
+    assert c["timestamp"].startswith("2026-04-24")
+
+
+def test_second_run_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    runner.invoke(app, ["backfill-settlements"])
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    assert len(_closes(db_path)) == 1  # no duplicate
+
+
+def test_dry_run_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert "Would insert 1" in result.output
+    assert _closes(db_path) == []
+
+
+def test_drift_row_repaired_to_settlement_price(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reconcile drift close at mark 0.705 whose market settled at
+    0.0 (loss) must be repriced — the KXJOBLESSCLAIMS case."""
+    db_path = tmp_path / "test.db"
+    _seed(
+        db_path, close_count=100, close_agent="reconcile",
+        close_price=0.705, paper_market_price=0.0,
+    )
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1  # residual 0 → no ghost insert
+    c = closes[0]
+    assert c["agent"] == "reconcile"  # agent unchanged (#622 semantics)
+    assert c["price"] == 0.0
+    assert "corrected to settlement value" in c["rationale"]
+    assert c["resolved_outcome"] == "yes"  # NO side lost → resolved yes
+
+
+def test_open_positions_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """paper_positions rows with count > 0 (still open) are skipped."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path, paper_count=100, paper_market_price=0.9)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    assert _closes(db_path) == []
+
+
+def test_fully_closed_position_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A settled row whose closes already cover the opens (a real
+    closer close exists) must not get a backfill close."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path, close_count=100, close_agent="closer",
+          close_price=0.9, paper_market_price=1.0)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "closer"
+
+
+def test_resolved_outcome_conflict_prefers_paper_truth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The KXUE-UK26FEB-5.1 case: log-outcome recorded 'no' (which
+    would mean the NO side won) but the broker settled it at 0.0 —
+    paper truth wins, loudly."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path, paper_market_price=0.0)  # NO side lost → truth 'yes'
+
+    async def _set_wrong_outcome() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await db.conn.execute(
+                "UPDATE trades SET resolved_outcome = 'no'"
+                " WHERE ticker = ?", (TICKER,),
+            )
+            await db.conn.commit()
+        finally:
+            await db.close()
+
+    asyncio.run(_set_wrong_outcome())
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    assert "conflicted with paper truth" in result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["price"] == 0.0
+    assert closes[0]["resolved_outcome"] == "yes"
+
+
+def test_backfill_isolated_from_todays_daily_pnl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The historical timestamp keeps the correction out of today's
+    daily-loss trigger — the property that makes the backfill safe to
+    run on a live system (#653)."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path, paper_market_price=0.0)  # settled loss
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+
+    async def _daily() -> float:
+        from datetime import UTC
+        from datetime import datetime as dt
+
+        from gimmes.store.queries import get_daily_pnl
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await get_daily_pnl(
+                db, today=dt.now(UTC).strftime("%Y-%m-%d"),
+            )
+        finally:
+            await db.close()
+
+    assert asyncio.run(_daily()) == 0.0
+
+
+def test_backfill_null_timestamp_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unparseable settle timestamp → the close stamps NOW and the
+    command warns that it will count toward today's loss trigger
+    (updated_at is NOT NULL, so malformed strings are the real
+    fallback trigger)."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+
+    async def _null_ts() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await db.conn.execute(
+                "UPDATE paper_positions SET updated_at ="
+                " 'not-a-timestamp' WHERE ticker = ?", (TICKER,),
+            )
+            await db.conn.commit()
+        finally:
+            await db.close()
+
+    asyncio.run(_null_ts())
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    assert "no usable settle timestamp" in result.output.lower()
+    assert len(_closes(db_path)) == 1
+
+
+def test_backfill_without_paper_positions_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Championship-only DBs have no paper_positions — graceful no-op."""
+    db_path = tmp_path / "test.db"
+
+    async def _bare() -> None:
+        db = Database(db_path)
+        await db.connect()
+        await db.close()
+
+    asyncio.run(_bare())
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    assert "No paper_positions table" in result.output

--- a/tests/unit/test_daily_pnl.py
+++ b/tests/unit/test_daily_pnl.py
@@ -259,3 +259,33 @@ class TestGetDailyPnlExcludesReconcileCloses:
 
         pnl = await get_daily_pnl(db, today=now.strftime("%Y-%m-%d"))
         assert pnl == 0.0
+
+
+class TestGetDailyPnlIncludesSettlementCloses:
+    """#653: settlement closes (agent='settlement') ARE included in
+    daily P&L — a settlement loss is real realized money lost that day
+    and the daily-loss trigger should see it. Only reconcile DRIFT
+    (#622) is excluded."""
+
+    async def test_settlement_close_included_in_pnl(
+        self, db: Database,
+    ) -> None:
+        now = datetime.now(UTC)
+        await insert_trade(db, _trade(
+            action="open", price=0.40, count=10, timestamp=now,
+        ))
+        settlement_trade = TradeDecision(
+            ticker="KXTEST",
+            action=TradeDecision.Action.CLOSE,
+            price=0.0,  # settled as a loss
+            count=10,
+            edge=0.0,
+            agent="settlement",
+            rationale="market settled (#653)",
+            timestamp=now,
+        )
+        await insert_trade(db, settlement_trade)
+
+        pnl = await get_daily_pnl(db, today=now.strftime("%Y-%m-%d"))
+        # (0.0 - 0.40) * 10 = -$4.00 — the settlement loss IS visible.
+        assert pnl == pytest.approx(-4.0)

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -117,3 +117,39 @@ class TestFormatLocalTimestamp:
         # January -> EST (UTC-5), not EDT
         result = format_local_timestamp("2026-01-15 14:30:00")
         assert result == "2026-01-15 09:30:00"
+
+
+class TestFormatPnlSummary:
+    """#653: the Closed/Open Positions rows make the P&L table
+    internally consistent — pin the arithmetic."""
+
+    def test_closed_and_open_rows(self) -> None:
+        from io import StringIO
+        from unittest.mock import patch
+
+        from rich.console import Console
+
+        from gimmes.reporting.formatter import format_pnl_summary
+        from gimmes.reporting.pnl import PnLSummary
+
+        summary = PnLSummary(
+            total_trades=5, open_trades=1, winning_trades=2,
+            losing_trades=1, scratch_trades=1,
+        )
+        buf = StringIO()
+        with patch(
+            "gimmes.reporting.formatter.console",
+            Console(file=buf, width=100),
+        ):
+            format_pnl_summary(summary)
+        out = buf.getvalue()
+        assert "Closed" in out and "Open Positions" in out
+        # Closed = W+L+S = 4; Open = 1; Total = 5.
+        lines = {
+            line.split("│")[1].strip(): line.split("│")[2].strip()
+            for line in out.splitlines()
+            if line.count("│") >= 3
+        }
+        assert lines.get("Closed") == "4"
+        assert lines.get("Open Positions") == "1"
+        assert lines.get("Total Trades") == "5"

--- a/tests/unit/test_paper_broker.py
+++ b/tests/unit/test_paper_broker.py
@@ -1054,3 +1054,46 @@ class TestPartialSellThenSettleCloseRow:
         assert len(settlement) == 1
         assert settlement[0]["count"] == 5
         assert settlement[0]["price"] == 1.0
+
+
+class TestSettlementOverridesWrongOutcome:
+    """#664 review: settlement is authoritative — a pre-existing WRONG
+    resolved_outcome (bad log-outcome) must be corrected at settle
+    time, or read-time repricing trusts the stale outcome."""
+
+    @pytest.mark.asyncio
+    async def test_settle_corrects_conflicting_outcome(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        from gimmes.store.queries import get_trades
+
+        params = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.BUY,
+            side=OrderSide.YES, count=10, yes_price=0.70,
+            post_only=True,
+        )
+        await broker.create_order(params, orderbook)
+        # The paper broker itself writes no trades rows — seed the open
+        # row an agent's decision logging would have written, carrying
+        # a WRONG outcome from an earlier bad log-outcome (the KXUE
+        # case). Without a real row here the wrong-outcome setup is a
+        # no-op and the test is vacuous (mutation-proven in review).
+        from gimmes.models.trade import TradeDecision
+        from gimmes.store.queries import insert_trade
+
+        await insert_trade(broker._db, TradeDecision(
+            ticker="TEST-MKT", action=TradeDecision.Action.OPEN,
+            side="yes", count=10, price=0.70,
+        ))
+        await broker._conn.execute(
+            "UPDATE trades SET resolved_outcome = 'no'"
+            " WHERE ticker = 'TEST-MKT'",
+        )
+        await broker._db.conn.commit()
+
+        await broker.settle("TEST-MKT", "yes")  # market actually: yes
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        assert all(
+            t["resolved_outcome"] == "yes" for t in trades
+        ), trades

--- a/tests/unit/test_paper_broker.py
+++ b/tests/unit/test_paper_broker.py
@@ -946,3 +946,111 @@ class TestNegativeBalanceGuard:
 
         balance = await broker.get_balance()
         assert balance == 10_000.00
+
+
+class TestSettlementCloseTrade:
+    """#653: settle() writes the settlement close trade and removes the
+    positions mirror row so reconcile can't write a duplicate."""
+
+    async def _buy(self, broker, orderbook, side, count=10) -> None:
+        params = CreateOrderParams(
+            ticker="TEST-MKT",
+            action=OrderAction.BUY,
+            side=side,
+            count=count,
+            yes_price=0.70,
+            post_only=True,
+        )
+        await broker.create_order(params, orderbook)
+
+    @pytest.mark.asyncio
+    async def test_settle_writes_settlement_close_win(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        from gimmes.store.queries import get_trades
+
+        await self._buy(broker, orderbook, OrderSide.YES)
+        await broker.settle("TEST-MKT", "yes")  # YES won
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        closes = [t for t in trades if t["action"] == "close"]
+        assert len(closes) == 1
+        assert closes[0]["agent"] == "settlement"
+        assert closes[0]["price"] == 1.0
+        assert closes[0]["count"] == 10
+        assert closes[0]["resolved_outcome"] == "yes"
+
+    @pytest.mark.asyncio
+    async def test_settle_writes_settlement_close_loss(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        from gimmes.store.queries import get_trades
+
+        await self._buy(broker, orderbook, OrderSide.YES)
+        await broker.settle("TEST-MKT", "no")  # YES lost
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        closes = [t for t in trades if t["action"] == "close"]
+        assert len(closes) == 1
+        assert closes[0]["price"] == 0.0
+        assert closes[0]["resolved_outcome"] == "no"
+
+    @pytest.mark.asyncio
+    async def test_settle_deletes_positions_mirror_row(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        from gimmes.models.portfolio import Position
+        from gimmes.store.queries import get_positions, upsert_position
+
+        await self._buy(broker, orderbook, OrderSide.YES)
+        # Mirror the position into the main positions table the way a
+        # cycle's sync would.
+        await upsert_position(broker._db, Position(
+            ticker="TEST-MKT", side="yes", count=10, avg_price=0.70,
+        ))
+        await broker.settle("TEST-MKT", "yes")
+
+        remaining = {p.ticker for p in await get_positions(broker._db)}
+        assert "TEST-MKT" not in remaining
+
+    @pytest.mark.asyncio
+    async def test_settle_nonexistent_writes_no_trade(
+        self, broker: PaperBroker,
+    ) -> None:
+        from gimmes.store.queries import get_trades
+
+        await broker.settle("KXT-GHOST", "yes")
+        assert await get_trades(broker._db, ticker="KXT-GHOST") == []
+
+
+class TestPartialSellThenSettleCloseRow:
+    """#653 gap 4: settle() after a partial sell must write the
+    settlement close for the RESIDUAL count only."""
+
+    @pytest.mark.asyncio
+    async def test_settlement_close_counts_residual_only(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        from gimmes.store.queries import get_trades
+
+        buy = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.BUY,
+            side=OrderSide.YES, count=10, yes_price=0.70,
+            post_only=True,
+        )
+        await broker.create_order(buy, orderbook)
+        sell = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.SELL,
+            side=OrderSide.YES, count=5, yes_price=0.68,
+            post_only=True,
+        )
+        await broker.create_order(sell, orderbook)
+        await broker.settle("TEST-MKT", "yes")
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        settlement = [
+            t for t in trades if t.get("agent") == "settlement"
+        ]
+        assert len(settlement) == 1
+        assert settlement[0]["count"] == 5
+        assert settlement[0]["price"] == 1.0

--- a/tests/unit/test_paper_reconcile_drift.py
+++ b/tests/unit/test_paper_reconcile_drift.py
@@ -129,20 +129,24 @@ class TestPaperReconcileDriftCoveredBy609:
         # sync_positions. This is what cli.py:1750 does.
         await sync_positions(db, positions_after)
 
-        # ASSERT #609 fired in paper mode:
-        # 1. Synthetic close trade with agent='reconcile'.
+        # #653: settle() itself wrote the ONE close — at settlement
+        # value, agent='settlement' — and deleted the positions mirror
+        # row, so reconcile must NOT write a duplicate mark-priced
+        # drift close (that was how phantom rows were born).
         trades = await get_trades(db)
-        reconcile_trades = [
-            t for t in trades if t.get("agent") == "reconcile"
-        ]
-        assert len(reconcile_trades) == 1, (
-            f"Expected 1 reconcile-agent trade, got {reconcile_trades}"
+        closes = [t for t in trades if t["action"] == "close"]
+        assert len(closes) == 1, (
+            f"Expected exactly 1 close after settle+reconcile,"
+            f" got {closes}"
         )
-        t = reconcile_trades[0]
+        t = closes[0]
+        assert t["agent"] == "settlement"
         assert t["ticker"] == "KXCPI-26APR-T0.5"
-        assert t["action"] == "close"
+        # YES position + result 'no' → lost → settlement value 0.0.
+        assert t["price"] == 0.0
+        assert t["resolved_outcome"] == "no"
 
-        # 2. Decision note with Trigger: Reconcile-divergence (NOT
+        # 2. Decision note with Trigger: Settlement (NOT
         #    Trigger: Stop-loss breach).
         notes = await get_position_notes(
             db, "KXCPI-26APR-T0.5", note_type="decision",
@@ -150,9 +154,9 @@ class TestPaperReconcileDriftCoveredBy609:
         assert len(notes) == 1
         body = notes[0]["body"]
         assert "Decision: CLOSE" in body
-        assert "Trigger: Reconcile-divergence" in body
+        assert "Trigger: Settlement" in body
         assert "Trigger: Stop-loss breach" not in body
-        assert notes[0]["agent"] == "reconcile"
+        assert notes[0]["agent"] == "settlement"
 
         # 3. known_markets resolver finds the closed ticker (closes
         #    the #586 lockout-resolver gap that #623 was filed to fix).
@@ -176,13 +180,14 @@ class TestPaperReconcileDriftCoveredBy609:
         fresh = await broker.get_positions()
         await sync_positions(db, fresh)
 
-        # Exactly one synthetic close, for the settled ticker.
+        # #653: exactly one close for the settled ticker — written by
+        # settle() at settlement value — and no reconcile duplicate.
         trades = await get_trades(db)
-        reconcile_trades = [
-            t for t in trades if t.get("agent") == "reconcile"
-        ]
-        assert len(reconcile_trades) == 1
-        assert reconcile_trades[0]["ticker"] == "KXCPI-26APR-T0.5"
+        closes = [t for t in trades if t["action"] == "close"]
+        assert len(closes) == 1
+        assert closes[0]["ticker"] == "KXCPI-26APR-T0.5"
+        assert closes[0]["agent"] == "settlement"
+        assert not any(t.get("agent") == "reconcile" for t in trades)
 
         # The other two positions are unchanged.
         from gimmes.store.queries import get_positions
@@ -258,29 +263,28 @@ def test_cli_reconcile_paper_mode_writes_synthetic_close(  # type: ignore[no-unt
     result = runner.invoke(app, ["reconcile"])
     assert result.exit_code == 0, result.output
 
-    # Verify the actual CLI path produced the synthetic close.
+    # Verify the actual CLI path: settle() already wrote the ONE
+    # settlement close; the CLI reconcile must not add a duplicate
+    # drift close (#653).
     async def _check() -> None:
         db = Database(db_path)
         await db.connect()
         try:
             trades = await get_trades(db)
-            reconcile_trades = [
-                t for t in trades if t.get("agent") == "reconcile"
-            ]
-            assert len(reconcile_trades) == 1, (
-                f"Expected one reconcile-agent trade after CLI"
-                f" reconcile, got {len(reconcile_trades)}:"
-                f" {reconcile_trades}"
+            closes = [t for t in trades if t["action"] == "close"]
+            assert len(closes) == 1, (
+                f"Expected exactly one close after CLI reconcile,"
+                f" got {len(closes)}: {closes}"
             )
-            assert reconcile_trades[0]["ticker"] == "KXCPI-26APR-T0.5"
-            assert reconcile_trades[0]["action"] == "close"
+            assert closes[0]["ticker"] == "KXCPI-26APR-T0.5"
+            assert closes[0]["agent"] == "settlement"
 
             notes = await get_position_notes(
                 db, "KXCPI-26APR-T0.5", note_type="decision",
             )
             assert len(notes) == 1
             body = notes[0]["body"]
-            assert "Trigger: Reconcile-divergence" in body
+            assert "Trigger: Settlement" in body
             assert "Trigger: Stop-loss breach" not in body
         finally:
             await db.close()

--- a/tests/unit/test_pnl.py
+++ b/tests/unit/test_pnl.py
@@ -188,3 +188,91 @@ class TestCalculatePnlWeightedAverage:
         summary = calculate_pnl(trades)
         assert summary.total_trades == 1
         assert summary.gross_pnl == 0.0
+
+
+class TestReconcileRepricing:
+    """#653: reconcile drift closes reprice at settlement value when
+    the group's resolution outcome is known (typically recorded on the
+    OPEN row by Monitor's log-outcome, never on the drift close)."""
+
+    def _group(self, *, close_agent, close_price, outcome_on_open):
+        return [
+            {
+                "ticker": "KX1", "side": "no", "action": "open",
+                "count": 100, "price": 0.63, "timestamp": "2026-04-20",
+                "agent": "closer", "resolved_outcome": outcome_on_open,
+            },
+            {
+                "ticker": "KX1", "side": "no", "action": "close",
+                "count": 100, "price": close_price, "timestamp": "2026-04-25",
+                "agent": close_agent, "resolved_outcome": None,
+            },
+        ]
+
+    def test_reconcile_close_repriced_to_loss(self) -> None:
+        # NO position; market resolved yes → NO lost → settlement 0.0,
+        # even though the drift row carries mark 0.705.
+        summary = calculate_pnl(self._group(
+            close_agent="reconcile", close_price=0.705,
+            outcome_on_open="yes",
+        ))
+        assert summary.losing_trades == 1
+        assert summary.gross_pnl == pytest.approx((0.0 - 0.63) * 100)
+
+    def test_reconcile_close_repriced_to_win(self) -> None:
+        summary = calculate_pnl(self._group(
+            close_agent="reconcile", close_price=0.705,
+            outcome_on_open="no",
+        ))
+        assert summary.winning_trades == 1
+        assert summary.gross_pnl == pytest.approx((1.0 - 0.63) * 100)
+
+    def test_reconcile_close_without_outcome_stays_at_mark(self) -> None:
+        """Genuine non-settlement drift (no known outcome) keeps the
+        last-known mark."""
+        summary = calculate_pnl(self._group(
+            close_agent="reconcile", close_price=0.705,
+            outcome_on_open=None,
+        ))
+        assert summary.gross_pnl == pytest.approx((0.705 - 0.63) * 100)
+
+    def test_non_reconcile_close_never_repriced(self) -> None:
+        """An intentional closer close keeps its actual fill price even
+        when the outcome is known — repricing is drift-only."""
+        summary = calculate_pnl(self._group(
+            close_agent="closer", close_price=0.705,
+            outcome_on_open="yes",
+        ))
+        assert summary.gross_pnl == pytest.approx((0.705 - 0.63) * 100)
+
+    def test_settlement_price_close_has_no_close_fee(self) -> None:
+        """Settlement closes at 1.0/0.0 are fee-free automatically via
+        calculate_fee's price-range guard; open-leg fee remains."""
+        summary = calculate_pnl(self._group(
+            close_agent="reconcile", close_price=0.705,
+            outcome_on_open="no",  # repriced to 1.0
+        ))
+        from gimmes.strategy.fees import fee_for_order
+
+        assert summary.total_fees == pytest.approx(
+            fee_for_order(100, 0.63),
+        )
+
+
+class TestOpenTradesField:
+    def test_total_equals_closed_plus_open(self) -> None:
+        trades = [
+            {"ticker": "KX1", "side": "no", "action": "open",
+             "count": 100, "price": 0.6, "timestamp": "1"},
+            {"ticker": "KX1", "side": "no", "action": "close",
+             "count": 100, "price": 0.8, "timestamp": "2"},
+            {"ticker": "KX2", "side": "yes", "action": "open",
+             "count": 50, "price": 0.4, "timestamp": "1"},
+        ]
+        summary = calculate_pnl(trades)
+        assert summary.open_trades == 1
+        closed = (
+            summary.winning_trades + summary.losing_trades
+            + summary.scratch_trades
+        )
+        assert summary.total_trades == closed + summary.open_trades

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -418,3 +418,77 @@ def test_caddie_master_lockout_query_does_not_match_reconcile_body() -> None:
         " explanatory rationale text) would silently lock out"
         " legitimate re-entry after reconcile drift (#609)."
     )
+
+
+def _guard_trade(
+    ticker: str, action: str, count: int, price: float,
+    agent: str = "closer",
+) -> TradeDecision:
+    return TradeDecision(
+        ticker=ticker, action=TradeDecision.Action(action),
+        side="yes", count=count, price=price, agent=agent,
+    )
+
+
+class TestReconcileDuplicateGuard:
+    """#653: the drift-close duplicate guard in _log_reconcile_closes —
+    mutation testing showed it previously had zero kill coverage."""
+
+    async def test_guard_suppresses_when_closes_cover_opens(self, db):
+        """Settlement close exists but the mirror row survived (the
+        race the guard exists for): sync must NOT write a duplicate
+        reconcile drift close."""
+        await insert_trade(db, _guard_trade("KX1", "open", 10, 0.6))
+        await insert_trade(db, _guard_trade(
+            "KX1", "close", 10, 1.0, agent="settlement",
+        ))
+        await upsert_position(db, _pos("KX1", count=10))
+
+        await sync_positions(db, [])  # ticker removed
+
+        trades = await get_trades(db, ticker="KX1")
+        closes = [t for t in trades if t["action"] == "close"]
+        assert len(closes) == 1
+        assert closes[0]["agent"] == "settlement"
+
+    async def test_guard_allows_drift_close_after_reopen(self, db):
+        """close -> reopen -> drift: the reopened contracts are not
+        covered by the old close, so the drift close MUST be written
+        (a timestamp-based guard would wrongly suppress it)."""
+        await insert_trade(db, _guard_trade("KX2", "open", 100, 0.6))
+        await insert_trade(db, _guard_trade("KX2", "close", 100, 0.8))
+        await insert_trade(db, _guard_trade("KX2", "open", 100, 0.55))
+        await upsert_position(db, _pos("KX2", count=100))
+
+        await sync_positions(db, [])
+
+        trades = await get_trades(db, ticker="KX2")
+        reconcile = [t for t in trades if t.get("agent") == "reconcile"]
+        assert len(reconcile) == 1
+
+    async def test_guard_allows_drift_close_after_partial_close(self, db):
+        """open 10, close 4, drift removes the rest: the residual 6
+        must still get a drift close."""
+        await insert_trade(db, _guard_trade("KX3", "open", 10, 0.6))
+        await insert_trade(db, _guard_trade("KX3", "close", 4, 0.7))
+        await upsert_position(db, _pos("KX3", count=6))
+
+        await sync_positions(db, [])
+
+        trades = await get_trades(db, ticker="KX3")
+        reconcile = [t for t in trades if t.get("agent") == "reconcile"]
+        assert len(reconcile) == 1
+        assert reconcile[0]["count"] == 6
+
+    async def test_guard_allows_drift_close_with_no_trade_history(
+        self, db,
+    ):
+        """A position with no recorded opens (pre-#609 DB, seeded)
+        still gets its drift close."""
+        await upsert_position(db, _pos("KX4", count=5))
+
+        await sync_positions(db, [])
+
+        trades = await get_trades(db, ticker="KX4")
+        reconcile = [t for t in trades if t.get("agent") == "reconcile"]
+        assert len(reconcile) == 1


### PR DESCRIPTION
## Summary

**The bug:** `gimmes report` said +$377.50 net; the paper account implied ≈ −$431 MTM. Two causes, both verified against the live DB:
1. Paper-broker `settle()` credited the balance and zeroed positions but **wrote no close trade** — ~9 ghost settlements (~$1,050 realized) invisible to the scorecard.
2. The 7 reconcile drift closes that did exist were priced at **stale marks** — one recorded a +$5 "win" at mark $0.705 on a market that settled at $0.00 (a ~$366 loss).

## The fix

- **Forward:** `settle()` writes an `agent='settlement'` close at true settlement value (fee-free automatically via the fee curve's price-range guard), fills `resolved_outcome` (settlement *is* the resolution event — Monitor's log-outcome was proven wrong at least once), writes a `Trigger: Settlement` note (#586 lockout-safe), and deletes the positions mirror row in the same transaction. A residual-count duplicate-guard in `_log_reconcile_closes` backs it up — quantity-based and side-filtered after review showed a timestamp guard suppresses residual closes after partials, with direct kill-coverage tests after mutation testing showed zero coverage on the first draft.
- **Read-time:** reconcile drift closes reprice at settlement value when the group's resolution is known — the forward path for championship mode, where settlements arrive as drift. Settlement closes count in daily P&L (real money lost that day); **#622's drift exclusion untouched and pinned**.
- **One-time:** hidden `gimmes backfill-settlements` (`--dry-run`) inserts the missing closes at historical timestamps (isolated from today's daily-loss trigger — pinned) and repairs the 7 drift rows; idempotent; resolved_outcome conflicts prefer paper truth loudly.
- **Consistency:** `PnLSummary.open_trades` + Closed/Open rows — total = closed + open.

## Behavior change to note
Paper settlement losses now hit that day's daily P&L and can contribute to the daily-loss trigger — intended (they're real), but new for the autonomous loop.

## Review pipeline
3 reviewers (transaction atomicity, guard edge cases, mutation testing) + simplifier; all findings ≥80 applied. Follow-ups: #663 (authoritative settlements-API source, manual-close repricing caveat, resting-sell double-count).

## Test plan
- 129 targeted tests across 8 files (settle close rows incl. partial-sell residual, guard kill-coverage incl. reopen/partial/no-history, repricing matrix, backfill: ghost/idempotent/dry-run/repair/conflict/isolation/table-guard, daily-pnl inclusion+exclusion, formatter rows).
- Full suite: **1624 passed**; ruff clean.
- Post-merge operational step: run `gimmes backfill-settlements --dry-run`, eyeball the 12 candidates, then apply.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB