### PR TITLE
Fix #654: time-aware log-return Sharpe replaces daily-assuming sqrt(252)

### DIFF
--- a/.claude/agents/scorecard.md
+++ b/.claude/agents/scorecard.md
@@ -28,7 +28,7 @@ These metrics MUST appear — omit NONE:
 - **Total Trades**: Count of all open+close actions
 - **Win Rate**: wins / (wins + losses), where win = close P&L > 0
 - **Net P&L**: Gross P&L minus fees, in dollars
-- **Sharpe Ratio**: Annualized as (mean daily excess return / std daily return) * sqrt(252). Report "N/A — insufficient data" if fewer than 2 equity snapshots exist.
+- **Sharpe Ratio**: Annualized Sharpe computed on LOG returns of the equity curve, with the annualization factor derived from the curve's OBSERVED frequency (periods per year over its actual time span) — not an assumed 252 trading days (#654). Its sign matches the compounded total return whenever all equity points are positive (pairs touching non-positive equity are dropped). Report "N/A — insufficient data" if fewer than 2 equity snapshots exist. Note: values are systematically lower than pre-#654 readings, which were inflated by frequency mismatch — historical scorecards are not comparable.
 - **Max Drawdown**: In dollars and as percent of peak equity
 - **Edge Accuracy**: avg realized edge / avg predicted edge. Report as ratio (e.g., 0.85 = realized 85% of predicted edge)
 - **Risk Utilization**: Current daily loss / configured daily loss limit AND position count / configured max positions (from `risk-check` output)

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime, time
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
 from gimmes.backtest.engine import BacktestResult
-from gimmes.reporting.metrics import calculate_max_drawdown, calculate_sharpe
+from gimmes.reporting.metrics import (
+    calculate_max_drawdown,
+    calculate_sharpe_from_curve,
+)
 
 
 @dataclass
@@ -39,14 +43,15 @@ def _compute_summary(result: BacktestResult) -> _Summary:
 
     equity_values = [starting] + [e for _, e in result.equity_curve]
     max_dd, max_dd_pct = calculate_max_drawdown(equity_values)
-    returns = []
-    for i in range(1, len(equity_values)):
-        if equity_values[i - 1] > 0:
-            returns.append(
-                (equity_values[i] - equity_values[i - 1])
-                / equity_values[i - 1]
-            )
-    sharpe = calculate_sharpe(returns)
+    # #654: time-aware Sharpe on the timestamped curve — the starting
+    # balance is prepended at the configured start date so the span
+    # (and therefore the annualization frequency) is real.
+    start_ts = datetime.combine(
+        result.config.start_date, time.min, tzinfo=UTC,
+    ).isoformat()
+    sharpe = calculate_sharpe_from_curve(
+        [(start_ts, starting), *result.equity_curve],
+    )
 
     return _Summary(
         wins=wins, losses=losses, total=total, win_rate=win_rate,

--- a/src/gimmes/reporting/metrics.py
+++ b/src/gimmes/reporting/metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 
 @dataclass
@@ -46,26 +47,79 @@ def calculate_max_drawdown(equity_curve: list[float]) -> tuple[float, float]:
     return max_dd, max_dd_pct
 
 
-def calculate_sharpe(returns: list[float], risk_free_rate: float = 0.0) -> float:
-    """Calculate annualized Sharpe ratio from daily returns.
+def calculate_sharpe_from_curve(
+    curve: list[tuple[str, float]],
+    risk_free_rate: float = 0.0,
+) -> float:
+    """Annualized Sharpe ratio from a timestamped equity curve (#654).
+
+    Computed on LOG returns of consecutive equity points, annualized by
+    the OBSERVED frequency (periods per year derived from the curve's
+    actual time span) — never an assumed 252 trading days. Two
+    properties this buys over the old daily-assuming simple-returns
+    version:
+
+    - The sign matches the compounded total return (mean log return
+      telescopes to ln(final/initial)/N), so a strategy that lost
+      money can never report a positive Sharpe via variance drag —
+      the exact #654 symptom (+1.11 on a -14% backtest). Caveat: the
+      telescoping (and hence the sign identity) only holds when every
+      consecutive pair of equity points is positive; pairs touching a
+      non-positive value are dropped, not bridged, so a curve that
+      dips to zero or below can break the identity.
+    - Sampling frequency doesn't inflate the value: per-settlement
+      curves (dozens of events over months) annualize by their real
+      cadence, not sqrt(252).
+
+    Irregular event spacing is approximated as evenly spaced at the
+    span's average frequency; a daily-resampled upgrade path exists if
+    that ever matters.
 
     Args:
-        returns: List of daily returns (e.g., [0.01, -0.005, 0.02]).
-        risk_free_rate: Daily risk-free rate.
+        curve: (ISO timestamp, equity) points, chronological.
+        risk_free_rate: ANNUAL risk-free rate (converted per-period
+            internally as a simple division; exact treatment would use
+            ln(1+rf) — immaterial at realistic rates, zero by default).
+
+    Returns 0.0 when undefined: fewer than 2 usable log returns,
+    zero variance, non-positive equity pairs, unparseable timestamps,
+    or a non-positive time span.
     """
-    if len(returns) < 2:
+    if len(curve) < 2:
         return 0.0
 
-    excess = [r - risk_free_rate for r in returns]
+    log_returns: list[float] = []
+    for (_, prev), (_, cur) in zip(curve, curve[1:], strict=False):
+        if prev > 0 and cur > 0:
+            log_returns.append(math.log(cur / prev))
+    if len(log_returns) < 2:
+        return 0.0
+
+    try:
+        t0 = datetime.fromisoformat(curve[0][0])
+        t1 = datetime.fromisoformat(curve[-1][0])
+        # Normalize naive timestamps to UTC — a naive/aware mix would
+        # TypeError on subtraction (#654 review; Market.close_time can
+        # arrive naive in principle).
+        if t0.tzinfo is None:
+            t0 = t0.replace(tzinfo=UTC)
+        if t1.tzinfo is None:
+            t1 = t1.replace(tzinfo=UTC)
+        years = (t1 - t0).total_seconds() / (365.25 * 24 * 3600)
+    except (ValueError, TypeError):
+        return 0.0
+    if years <= 0:
+        return 0.0
+    periods_per_year = len(log_returns) / years
+
+    rf_per_period = risk_free_rate / periods_per_year
+    excess = [r - rf_per_period for r in log_returns]
     mean = sum(excess) / len(excess)
     variance = sum((r - mean) ** 2 for r in excess) / (len(excess) - 1)
-    std = math.sqrt(variance) if variance > 0 else 0.0
-
-    if std == 0:
+    if variance <= 0:
         return 0.0
 
-    # Annualize (assuming ~252 trading days)
-    return (mean / std) * math.sqrt(252)
+    return (mean / math.sqrt(variance)) * math.sqrt(periods_per_year)
 
 
 def _equity_curve_from_trades(
@@ -102,12 +156,11 @@ def _apply_equity_curve(
         metrics.total_return = equity_values[-1] - initial_bankroll
         metrics.total_return_pct = metrics.total_return / initial_bankroll
     if len(equity_values) >= 2:
-        daily_returns = [
-            (equity_values[i] - equity_values[i - 1]) / equity_values[i - 1]
-            for i in range(1, len(equity_values))
-            if equity_values[i - 1] > 0
-        ]
-        metrics.sharpe_ratio = calculate_sharpe(daily_returns)
+        # #654: time-aware Sharpe — snapshot cadence, not assumed daily.
+        metrics.sharpe_ratio = calculate_sharpe_from_curve([
+            (str(pt.get("timestamp", "")), float(pt["equity"]))
+            for pt in curve
+        ])
     metrics.equity_curve = curve
 
 

--- a/tests/unit/test_backtest_report.py
+++ b/tests/unit/test_backtest_report.py
@@ -170,3 +170,25 @@ class TestTruncationInJson:
         result = _make_result()
         data = backtest_result_to_json(result)
         assert data["funnel"]["truncated_chunks"] == []
+
+
+class TestSharpeSignMatchesRoi:
+    """#654: under log-return Sharpe, sign(sharpe) == sign(total
+    compounded return) is an identity — a losing backtest can never
+    again report a positive Sharpe (the +1.11-on-minus-14% headline)."""
+
+    def test_losing_backtest_negative_sharpe(self) -> None:
+        result = _make_result()  # final 9,996.70 < 10,000 start
+        data = backtest_result_to_json(result)
+        assert data["summary"]["net_pnl"] < 0
+        assert data["summary"]["sharpe"] < 0
+
+    def test_winning_backtest_positive_sharpe(self) -> None:
+        result = _make_result()
+        result.final_balance = 10_006.50
+        result.equity_curve = [
+            ("2025-03-15T00:00:00+00:00", 9_996.80),
+            ("2025-03-20T00:00:00+00:00", 10_006.50),
+        ]
+        data = backtest_result_to_json(result)
+        assert data["summary"]["sharpe"] > 0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import math
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
 from gimmes.reporting.metrics import (
     calculate_max_drawdown,
     calculate_metrics,
-    calculate_sharpe,
+    calculate_sharpe_from_curve,
 )
 
 
@@ -38,29 +43,103 @@ class TestMaxDrawdown:
         assert abs(dd_pct - 0.6) < 0.001
 
 
-class TestSharpe:
-    def test_positive_returns(self) -> None:
-        returns = [0.01, 0.02, 0.01, 0.015, 0.005]
-        sharpe = calculate_sharpe(returns)
+def _daily_curve(values: list[float]) -> list[tuple[str, float]]:
+    """Timestamped daily curve for Sharpe tests."""
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    return [
+        ((start + timedelta(days=i)).isoformat(), v)
+        for i, v in enumerate(values)
+    ]
+
+
+class TestSharpeFromCurve:
+    def test_steady_growth_positive(self) -> None:
+        # Compounding growth with slight alternation so std > 0.
+        values, v = [], 1000.0
+        for i in range(20):
+            v *= 1.02 if i % 2 == 0 else 1.005
+            values.append(v)
+        sharpe = calculate_sharpe_from_curve(_daily_curve([1000.0, *values]))
         assert sharpe > 0
 
-    def test_zero_returns(self) -> None:
-        returns = [0.0, 0.0, 0.0]
-        sharpe = calculate_sharpe(returns)
-        assert sharpe == 0.0
-
-    def test_single_return(self) -> None:
-        sharpe = calculate_sharpe([0.05])
-        assert sharpe == 0.0
-
-    def test_empty_returns(self) -> None:
-        sharpe = calculate_sharpe([])
-        assert sharpe == 0.0
-
-    def test_negative_returns(self) -> None:
-        returns = [-0.01, -0.02, -0.01, -0.015]
-        sharpe = calculate_sharpe(returns)
+    def test_variance_drag_shape_is_negative(self) -> None:
+        """The #654 headline regression pin: alternating +30%/-25%
+        compounds to a LOSS (1.3 * 0.75 = 0.975 per pair) while the
+        arithmetic mean of simple returns is +2.5% — the old
+        simple-returns Sharpe reported this POSITIVE."""
+        values, v = [1000.0], 1000.0
+        for i in range(30):
+            v *= 1.30 if i % 2 == 0 else 0.75
+            values.append(v)
+        assert values[-1] < values[0]  # compounded loss
+        sharpe = calculate_sharpe_from_curve(_daily_curve(values))
         assert sharpe < 0
+
+    def test_annualization_uses_observed_frequency(self) -> None:
+        """The core #654 defect pin: identical per-step returns spaced
+        DAILY vs WEEKLY must annualize differently — by sqrt(7) — since
+        the weekly series has 7x fewer periods per year. The old code
+        applied sqrt(252) to both, treating a sparse settlement curve
+        as if it were daily and inflating its Sharpe."""
+        values, v = [1000.0], 1000.0
+        for i in range(20):
+            v *= 1.02 if i % 2 == 0 else 1.005
+            values.append(v)
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        daily = _daily_curve(values)
+        weekly = [
+            ((start + timedelta(days=7 * i)).isoformat(), val)
+            for i, val in enumerate(values)
+        ]
+        s_daily = calculate_sharpe_from_curve(daily)
+        s_weekly = calculate_sharpe_from_curve(weekly)
+        assert s_daily > 0 and s_weekly > 0
+        assert s_daily / s_weekly == pytest.approx(math.sqrt(7), rel=1e-9)
+
+    def test_hand_computed_value(self) -> None:
+        """Exactly two log returns, hand-computable end to end.
+        Asymmetric so the mean is nonzero — a symmetric curve pins
+        nothing (mean 0 zeroes out annualization and variance terms;
+        #654 review found the first version let a ddof mutation
+        survive)."""
+        curve = _daily_curve([1000.0, 1100.0, 1050.0])  # 3 points, 2 days
+        r1, r2 = math.log(1.1), math.log(1050.0 / 1100.0)
+        mean = (r1 + r2) / 2
+        var = ((r1 - mean) ** 2 + (r2 - mean) ** 2) / 1
+        periods_per_year = 2 / (2 / 365.25)
+        expected = mean / math.sqrt(var) * math.sqrt(periods_per_year)
+        assert calculate_sharpe_from_curve(curve) == pytest.approx(expected)
+
+    def test_empty_and_single_point(self) -> None:
+        assert calculate_sharpe_from_curve([]) == 0.0
+        assert calculate_sharpe_from_curve(
+            [("2026-01-01T00:00:00+00:00", 1000.0)],
+        ) == 0.0
+
+    def test_constant_equity_zero_variance(self) -> None:
+        assert calculate_sharpe_from_curve(
+            _daily_curve([1000.0] * 5),
+        ) == 0.0
+
+    def test_zero_equity_points_skipped(self) -> None:
+        """Pairs touching a 0.0 equity point are dropped; the two
+        surviving returns (1000->1010, 1010->1000) compute normally."""
+        curve = _daily_curve([1000.0, 0.0, 1000.0, 1010.0, 1000.0])
+        r1, r2 = math.log(1.01), math.log(1000.0 / 1010.0)
+        mean = (r1 + r2) / 2
+        var = ((r1 - mean) ** 2 + (r2 - mean) ** 2) / 1
+        periods_per_year = 2 / (4 / 365.25)
+        expected = mean / math.sqrt(var) * math.sqrt(periods_per_year)
+        assert calculate_sharpe_from_curve(curve) == pytest.approx(expected)
+
+    def test_unparseable_timestamps_return_zero(self) -> None:
+        curve = [("", 1000.0), ("", 1100.0), ("not-a-ts", 1050.0)]
+        assert calculate_sharpe_from_curve(curve) == 0.0
+
+    def test_zero_time_span_returns_zero(self) -> None:
+        ts = "2026-01-01T00:00:00+00:00"
+        curve = [(ts, 1000.0), (ts, 1100.0), (ts, 1050.0)]
+        assert calculate_sharpe_from_curve(curve) == 0.0
 
 
 class TestCalculateMetrics:


### PR DESCRIPTION
## Summary

The backtest reported **Sharpe 1.11 on a strategy that lost 14% with a 72% drawdown** — and the Scorecard agent rates health HEALTHY at ≥ 1.0 off this number. Two compounding defects in `calculate_sharpe`: it annualized any series by √252 as if daily (the backtest feeds ~61 per-settlement steps over 6 months → ~2× inflation), and arithmetic-mean simple returns hide variance drag (mean step return positive while compounded growth negative).

`calculate_sharpe_from_curve` fixes both: **log returns** (sign telescopes to the compounded total — a loser can't print a positive Sharpe) annualized by **observed frequency** derived from the curve's real time span. Both callers migrated (backtest + live scorecard); the daily-assuming function is removed entirely. Naive timestamps normalize to UTC (previously an uncaught TypeError past the parse guard).

## Consumer note
`summary.sharpe` / `sharpe_ratio` keys unchanged, but **values drop substantially** — historical scorecards are not comparable, and Scorecard health ratings may transition on the next run. That is the correction working.

## Review
Combined review + mutation testing: sqrt(252)-restore, log→simple, and ddof mutations all killed (the ddof kill required de-degenerating the hand-computed pin — a symmetric curve pins nothing); sign-identity docstring corrected to its precise scope (holds when all equity points positive); rf-conversion approximation documented (exact at the rf=0 default). Simplifier applied.

## Test plan
- `uv run pytest tests/unit/test_metrics.py tests/unit/test_backtest_report.py` — annualization-by-observed-frequency pin (daily vs weekly = √7), variance-drag negative pin, hand-computed value, sign-matches-ROI, dropped-pair arithmetic, edge cases.
- Full suite green; ruff clean.

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB