### PR TITLE
Fix #655: backtest entries priced, gated, and sized on entry-day candles

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -9,7 +9,7 @@ from datetime import UTC, date, datetime, timedelta
 
 from gimmes.config import GimmesConfig
 from gimmes.kalshi.client import KalshiClient
-from gimmes.kalshi.historical import Candle
+from gimmes.kalshi.historical import Candle, get_candlesticks
 from gimmes.kalshi.markets import list_all_markets
 from gimmes.models.market import Market, MarketStatus, Orderbook, OrderbookLevel
 from gimmes.risk.limits import (
@@ -26,6 +26,10 @@ from gimmes.strategy.fees import (
 from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 from gimmes.strategy.scanner import effective_price, filter_markets
 from gimmes.strategy.scorer import quick_score
+
+ENTRY_OFFSET_DAYS = 1
+CANDLE_LOOKBACK_DAYS = 3
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +82,8 @@ class BacktestResult:
     markets_traded: int
     skipped_concentration: int = 0
     skipped_balance: int = 0
+    skipped_no_candle: int = 0
+    skipped_entry_gates: int = 0
     truncated_chunks: list[str] = field(default_factory=list)
 
 
@@ -230,20 +236,69 @@ def synthesize_orderbook(ticker: str, candle: Candle, depth: int = 100) -> Order
 # ---------------------------------------------------------------------------
 
 
-def pick_entry_candle(
-    candles: list[Candle],
-    min_price: float,
-    max_price: float,
-) -> Candle | None:
-    """Pick the last daily candle where the price falls in the target range.
+def candle_midpoint(candle: Candle) -> float:
+    """Bid/ask midpoint of a candle — the backtest analog of
+    Market.midpoint. Returns 0.0 unless both quote sides are positive
+    (a market with no two-sided quote could not have been maker-filled;
+    the candle's trade-price OHLC can be stale on thin days, so it is
+    deliberately NOT used as a fallback) (#655)."""
+    if candle.yes_bid_close > 0 and candle.yes_ask_close > 0:
+        return (candle.yes_bid_close + candle.yes_ask_close) / 2
+    return 0.0
 
-    This simulates "we would have entered the market on this day."
+
+def entry_candle_at(candles: list[Candle], entry_ts: int) -> Candle | None:
+    """Last candle ending at or before entry_ts — a fixed-offset rule,
+    NOT a search for an in-range day. Its predecessor pick_entry_candle
+    scanned history for the last in-range close, which conditions the
+    entry day on knowing the price path — a look-ahead of its own
+    (#655). Candles are sorted ascending by end_period_ts.
     """
-    for candle in reversed(candles):
-        price = candle.price_close
-        if min_price <= price <= max_price:
-            return candle
-    return None
+    chosen: Candle | None = None
+    for candle in candles:
+        if candle.end_period_ts <= entry_ts:
+            chosen = candle
+        else:
+            break
+    return chosen
+
+
+async def _entry_day_mid(
+    client: KalshiClient,
+    ticker: str,
+    entry_ts: int,
+    cache: dict[str, list[Candle]],
+) -> float:
+    """Entry-day candle midpoint for ticker, or 0.0 when no usable
+    candle exists. The fetch window ends AT entry_ts, so future data
+    structurally cannot leak into the engine (#655). The distinct
+    unusable cases (no history, fetch failure, one-sided quote) are
+    debug-logged so the residual can be audited (#666: one-sided
+    quotes late in life would bias the sample away from the strongest
+    gimmes)."""
+    if ticker not in cache:
+        try:
+            cache[ticker] = await get_candlesticks(
+                client, ticker,
+                start_ts=entry_ts - CANDLE_LOOKBACK_DAYS * 86400,
+                end_ts=entry_ts,
+                period_interval=1440,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("candle fetch failed for %s: %s", ticker, exc)
+            cache[ticker] = []
+    candle = entry_candle_at(cache[ticker], entry_ts)
+    mid = candle_midpoint(candle) if candle else 0.0
+    if mid <= 0:
+        logger.debug(
+            "no usable entry candle for %s: %s", ticker,
+            "no candles <= entry_ts" if candle is None
+            else (
+                f"one-sided quote (bid={candle.yes_bid_close}"
+                f" ask={candle.yes_ask_close})"
+            ),
+        )
+    return mid
 
 
 # ---------------------------------------------------------------------------
@@ -433,6 +488,9 @@ async def run_backtest(
     )
     original_by_ticker = {m.ticker: m for m in settled}
     pending: list[_PendingTrade] = []
+    candle_cache: dict[str, list[Candle]] = {}
+    skipped_no_candle = 0
+    skipped_entry_gates = 0
     seen_tickers: set[str] = set()
     total_passed = 0
     total_scored = 0
@@ -458,30 +516,15 @@ async def run_backtest(
         # min_true_probability + min_edge_after_fees (#592).
         min_true_prob = side_cfg.strategy.min_true_probability
         min_edge = side_cfg.strategy.min_edge_after_fees
-        scored: list[tuple[Market, Market, float, float, float]] = []
+        # #655: NO price/prob/edge gating here — those gates now run on
+        # the ENTRY-DAY candle price in pass 1, not the settlement-time
+        # snapshot. total_scored counts score-threshold passers.
+        scored: list[tuple[Market, Market, float]] = []
         for m in passed:
             s = quick_score(m, side_cfg)
             if s < side_threshold:
                 continue
-            orig = original_by_ticker[m.ticker]
-            raw_price = (
-                orig.midpoint if orig.midpoint > 0 else orig.last_price
-            )
-            if raw_price <= 0:
-                continue
-            eff_price = effective_price(raw_price, scan_side)
-            true_prob = min(eff_price + config.assumed_edge, 0.99)
-            true_prob = apply_base_rate_floor(
-                true_prob, orig.ticker, side=scan_side,
-            )
-            if true_prob < min_true_prob:
-                continue
-            edge = edge_after_fees(
-                eff_price, true_prob, is_taker=False, fees=fees,
-            )
-            if edge < min_edge:
-                continue
-            scored.append((m, orig, s, eff_price, true_prob))
+            scored.append((m, original_by_ticker[m.ticker], s))
         total_scored += len(scored)
 
         scored.sort(
@@ -491,15 +534,49 @@ async def run_backtest(
         )
 
         # --- 4. Pass 1: identify qualifying trades ---
-        for _, orig_m, _score, eff_price, true_prob in scored:
+        # #655: entry is priced, gated, and sized on the ENTRY-DAY
+        # candle — settlement data is used only for the payout.
+        for _, orig_m, _score in scored:
             if orig_m.ticker in seen_tickers:
                 continue
             if orig_m.close_time is None:
                 continue
 
+            entry_time = orig_m.close_time - timedelta(
+                days=ENTRY_OFFSET_DAYS,
+            )
+            entry_ts = int(entry_time.timestamp())
+            ticker = orig_m.ticker
+            mid = await _entry_day_mid(
+                client, ticker, entry_ts, candle_cache,
+            )
+            if mid <= 0:
+                skipped_no_candle += 1
+                continue
+            entry_eff = effective_price(mid, scan_side)
+            if not (
+                side_cfg.strategy.min_market_price
+                <= entry_eff
+                <= side_cfg.strategy.max_market_price
+            ):
+                skipped_entry_gates += 1
+                continue
+            true_prob = min(entry_eff + config.assumed_edge, 0.99)
+            true_prob = apply_base_rate_floor(
+                true_prob, ticker, side=scan_side,
+            )
+            if true_prob < min_true_prob:
+                skipped_entry_gates += 1
+                continue
+            if edge_after_fees(
+                entry_eff, true_prob, is_taker=False, fees=fees,
+            ) < min_edge:
+                skipped_entry_gates += 1
+                continue
+
             count = position_size(
                 config.starting_balance,
-                eff_price,
+                entry_eff,
                 true_prob,
                 fraction=side_cfg.sizing.kelly_fraction,
                 max_position_pct=side_cfg.sizing.max_position_pct,
@@ -510,17 +587,16 @@ async def run_backtest(
                 continue
 
             trade_fees = fee_for_order(
-                count, eff_price, is_taker=False, fees=fees,
+                count, entry_eff, is_taker=False, fees=fees,
             )
-            entry_time = orig_m.close_time - timedelta(days=1)
 
-            seen_tickers.add(orig_m.ticker)
+            seen_tickers.add(ticker)
             pending.append(_PendingTrade(
-                ticker=orig_m.ticker,
+                ticker=ticker,
                 title=orig_m.title,
                 side=scan_side,
                 count=count,
-                vwap=eff_price,
+                vwap=entry_eff,
                 fees=trade_fees,
                 entry_time=entry_time,
                 settle_time=orig_m.close_time,
@@ -615,6 +691,8 @@ async def run_backtest(
         markets_scored=total_scored,
         markets_traded=traded_count,
         skipped_concentration=skipped_concentration,
+        skipped_no_candle=skipped_no_candle,
+        skipped_entry_gates=skipped_entry_gates,
         skipped_balance=skipped_balance,
         truncated_chunks=truncated_chunks,
     )

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -106,7 +106,7 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         )
     if result.skipped_no_candle > 0:
         funnel.add_row(
-            "Skipped (no entry-day candle)",
+            "Skipped (no usable entry-day candle)",
             str(result.skipped_no_candle),
         )
     if result.skipped_entry_gates > 0:
@@ -120,9 +120,10 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         and result.skipped_no_candle > 0.5 * result.markets_scored
     ):
         console.print(
-            "[yellow]Caution: candle history unavailable for most"
-            " candidates — results cover a subset of the scored"
-            " markets (#655).[/yellow]"
+            "[yellow]Caution: entry-day candle data missing or"
+            " unusable (e.g. one-sided quotes) for most candidates —"
+            " results cover a subset of the scored markets"
+            " (#655).[/yellow]"
         )
     if result.truncated_chunks:
         console.print(

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -104,7 +104,26 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
             "Skipped (balance)",
             str(result.skipped_balance),
         )
+    if result.skipped_no_candle > 0:
+        funnel.add_row(
+            "Skipped (no entry-day candle)",
+            str(result.skipped_no_candle),
+        )
+    if result.skipped_entry_gates > 0:
+        funnel.add_row(
+            "Skipped (entry-day price gates)",
+            str(result.skipped_entry_gates),
+        )
     console.print(funnel)
+    if (
+        result.markets_scored > 0
+        and result.skipped_no_candle > 0.5 * result.markets_scored
+    ):
+        console.print(
+            "[yellow]Caution: candle history unavailable for most"
+            " candidates — results cover a subset of the scored"
+            " markets (#655).[/yellow]"
+        )
     if result.truncated_chunks:
         console.print(
             f"[yellow]Warning: pagination limit reached for "
@@ -204,6 +223,8 @@ def backtest_result_to_json(result: BacktestResult) -> dict:  # type: ignore[typ
             "markets_passed_filter": result.markets_passed_filter,
             "markets_scored": result.markets_scored,
             "markets_traded": result.markets_traded,
+            "skipped_no_candle": result.skipped_no_candle,
+            "skipped_entry_gates": result.skipped_entry_gates,
             "truncated_chunks": result.truncated_chunks,
         },
         "summary": {

--- a/src/gimmes/kalshi/historical.py
+++ b/src/gimmes/kalshi/historical.py
@@ -34,6 +34,21 @@ class Candle:
     open_interest: int
 
 
+def _ohlc(group: dict, field: str) -> float:  # type: ignore[type-arg]
+    """Read an OHLC component, preferring the live API's `*_dollars`
+    string fields (e.g. `close_dollars: "0.3200"`, verified 2026-07-03)
+    over the legacy plain keys used by older fixtures."""
+    value = group.get(f"{field}_dollars", group.get(field, 0))
+    try:
+        # House convention (markets.py:_dollars_field): a plain-key INT
+        # is legacy integer cents — 34 means $0.34, not $34.00.
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value / 100
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _parse_candle(data: dict) -> Candle:  # type: ignore[type-arg]
     """Parse a candlestick from the Kalshi API response."""
     yes_bid = data.get("yes_bid", {})
@@ -41,20 +56,22 @@ def _parse_candle(data: dict) -> Candle:  # type: ignore[type-arg]
     price = data.get("price", {})
     return Candle(
         end_period_ts=int(data.get("end_period_ts", 0)),
-        yes_bid_open=float(yes_bid.get("open", 0)),
-        yes_bid_high=float(yes_bid.get("high", 0)),
-        yes_bid_low=float(yes_bid.get("low", 0)),
-        yes_bid_close=float(yes_bid.get("close", 0)),
-        yes_ask_open=float(yes_ask.get("open", 0)),
-        yes_ask_high=float(yes_ask.get("high", 0)),
-        yes_ask_low=float(yes_ask.get("low", 0)),
-        yes_ask_close=float(yes_ask.get("close", 0)),
-        price_open=float(price.get("open", 0)),
-        price_high=float(price.get("high", 0)),
-        price_low=float(price.get("low", 0)),
-        price_close=float(price.get("close", 0)),
-        volume=int(float(data.get("volume", 0))),
-        open_interest=int(float(data.get("open_interest", 0))),
+        yes_bid_open=_ohlc(yes_bid, "open"),
+        yes_bid_high=_ohlc(yes_bid, "high"),
+        yes_bid_low=_ohlc(yes_bid, "low"),
+        yes_bid_close=_ohlc(yes_bid, "close"),
+        yes_ask_open=_ohlc(yes_ask, "open"),
+        yes_ask_high=_ohlc(yes_ask, "high"),
+        yes_ask_low=_ohlc(yes_ask, "low"),
+        yes_ask_close=_ohlc(yes_ask, "close"),
+        price_open=_ohlc(price, "open"),
+        price_high=_ohlc(price, "high"),
+        price_low=_ohlc(price, "low"),
+        price_close=_ohlc(price, "close"),
+        volume=int(float(data.get("volume_fp", data.get("volume", 0)))),
+        open_interest=int(float(
+            data.get("open_interest_fp", data.get("open_interest", 0)),
+        )),
     )
 
 
@@ -174,8 +191,10 @@ async def get_candlesticks(
         "end_ts": end_ts,
         "period_interval": period_interval,
     }
+    series_ticker = ticker.split("-")[0]
     data = await client.get(
-        f"/historical/markets/{ticker}/candlesticks", params=params,
+        f"/series/{series_ticker}/markets/{ticker}/candlesticks",
+        params=params,
     )
     candles = [_parse_candle(c) for c in data.get("candlesticks", [])]
     candles.sort(key=lambda c: c.end_period_ts)

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
 from gimmes.backtest.engine import (
+    DEFAULT_FEE_MULTIPLIERS,
+    ENTRY_OFFSET_DAYS,
     BacktestLedger,
+    candle_midpoint,
+    entry_candle_at,
     monthly_chunks,
-    pick_entry_candle,
+    run_backtest,
     synthesize_orderbook,
     weekly_chunks,
 )
 from gimmes.kalshi.historical import Candle
+from gimmes.strategy.kelly import position_size
 
 
 def _make_candle(
@@ -145,35 +150,6 @@ class TestSynthesizeOrderbook:
         # NO bid = 1 - 0.72 = 0.28, so best YES ask = 1 - 0.28 = 0.72
         assert ob.best_yes_ask == 0.72
 
-
-class TestPickEntryCandle:
-    def test_picks_last_in_range(self) -> None:
-        candles = [
-            _make_candle(ts=1, price_close=0.50),
-            _make_candle(ts=2, price_close=0.65),
-            _make_candle(ts=3, price_close=0.70),
-            _make_candle(ts=4, price_close=0.90),  # Out of range
-        ]
-        result = pick_entry_candle(candles, 0.55, 0.85)
-        assert result is not None
-        assert result.end_period_ts == 3
-
-    def test_none_when_no_candle_in_range(self) -> None:
-        candles = [
-            _make_candle(ts=1, price_close=0.10),
-            _make_candle(ts=2, price_close=0.95),
-        ]
-        result = pick_entry_candle(candles, 0.55, 0.85)
-        assert result is None
-
-    def test_empty_candles(self) -> None:
-        assert pick_entry_candle([], 0.55, 0.85) is None
-
-    def test_single_candle_in_range(self) -> None:
-        candles = [_make_candle(ts=1, price_close=0.70)]
-        result = pick_entry_candle(candles, 0.55, 0.85)
-        assert result is not None
-        assert result.price_close == 0.70
 
 
 class TestConcurrentPositions:
@@ -411,6 +387,30 @@ class TestConcentrationLimits:
 _FIXED_CLOSE_TIME = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
 
 
+def _stub_settlement_candles(monkeypatch, markets) -> None:
+    """Patch the candle fetcher to return one entry-day candle per
+    ticker whose quotes MIRROR the market's settlement quotes — the
+    #655 entry-day pricing then equals the pre-#655 settlement pricing,
+    preserving each legacy test's intent unchanged."""
+    by_ticker = {m.ticker: m for m in markets}
+
+    async def _fake_candles(client, ticker, *, start_ts, end_ts, **kwargs):
+        m = by_ticker[ticker]
+        entry_ts = int(
+            (m.close_time - timedelta(days=ENTRY_OFFSET_DAYS)).timestamp(),
+        )
+        return [_make_candle(
+            ts=entry_ts,
+            yes_bid_close=m.yes_bid,
+            yes_ask_close=m.yes_ask,
+            price_close=(m.yes_bid + m.yes_ask) / 2,
+        )]
+
+    monkeypatch.setattr(
+        "gimmes.backtest.engine.get_candlesticks", _fake_candles,
+    )
+
+
 def _settled_market(
     ticker: str, *, yes_bid: float, yes_ask: float, result: str = "no",
     close_time: datetime = _FIXED_CLOSE_TIME,
@@ -479,7 +479,6 @@ class TestStrategyFilters:
     async def test_min_true_probability_filter_reduces_trades(
         self, monkeypatch, yes_bid: float, yes_ask: float,
     ) -> None:
-        from gimmes.backtest.engine import run_backtest
         markets = [
             _settled_market(
                 f"KXCPI-26MAR-T0.{i}", yes_bid=yes_bid, yes_ask=yes_ask,
@@ -493,6 +492,7 @@ class TestStrategyFilters:
         monkeypatch.setattr(
             "gimmes.backtest.engine.list_all_markets", _fake_list,
         )
+        _stub_settlement_candles(monkeypatch, markets)
 
         permissive = await run_backtest(
             client=None,  # fetcher is stubbed
@@ -519,7 +519,6 @@ class TestStrategyFilters:
     async def test_min_edge_after_fees_filter_reduces_trades(
         self, monkeypatch, yes_bid: float, yes_ask: float,
     ) -> None:
-        from gimmes.backtest.engine import run_backtest
         markets = [
             _settled_market(
                 f"KXCPI-26MAR-T0.{i}", yes_bid=yes_bid, yes_ask=yes_ask,
@@ -533,6 +532,7 @@ class TestStrategyFilters:
         monkeypatch.setattr(
             "gimmes.backtest.engine.list_all_markets", _fake_list,
         )
+        _stub_settlement_candles(monkeypatch, markets)
 
         permissive = await run_backtest(
             client=None,
@@ -558,7 +558,6 @@ class TestStrategyFilters:
         # Regression-safety (#592 AC3): at live values
         # (min_true_probability=0.5, min_edge_after_fees=0.01), the
         # filter rejects nothing in the live-trade universe.
-        from gimmes.backtest.engine import run_backtest
         markets = [
             _settled_market(
                 f"KXCPI-26MAR-T0.{i}", yes_bid=0.50, yes_ask=0.55,
@@ -572,6 +571,7 @@ class TestStrategyFilters:
         monkeypatch.setattr(
             "gimmes.backtest.engine.list_all_markets", _fake_list,
         )
+        _stub_settlement_candles(monkeypatch, markets)
 
         live_defaults = await run_backtest(
             client=None,
@@ -588,3 +588,188 @@ class TestStrategyFilters:
             ),
         )
         assert len(live_defaults.trades) == len(permissive.trades)
+
+
+class TestEntryDayPricing:
+    """#655 regression suite: entries are priced, gated, and sized on
+    the ENTRY-DAY candle — settlement data reaches only the payout."""
+
+    def _markets(self):
+        # Settlement quotes 0.25/0.35 → NO eff at settlement = 0.70
+        # (inside the scanner band — selection still reads settlement
+        # data by design; only entry pricing/gating moved to the
+        # entry-day candle in #655).
+        return [_settled_market("KXCPI-26MAR-T0.5",
+                                yes_bid=0.25, yes_ask=0.35)]
+
+    def _entry_ts(self, m) -> int:
+        return int(
+            (m.close_time - timedelta(days=ENTRY_OFFSET_DAYS)).timestamp(),
+        )
+
+    def _stub(self, monkeypatch, markets, candles_by_ticker):
+        async def _fake_list(*args, **kwargs):
+            return markets
+
+        calls: list[dict] = []
+
+        async def _fake_candles(client, ticker, *, start_ts, end_ts, **kw):
+            calls.append({"ticker": ticker, "start_ts": start_ts,
+                          "end_ts": end_ts})
+            result = candles_by_ticker.get(ticker, [])
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.get_candlesticks", _fake_candles,
+        )
+        return calls
+
+    def _permissive_config(self):
+        """Prob/edge gates neutralized so each test isolates the
+        entry-day pricing path."""
+        return _backtest_config_with_overrides(
+            min_true_probability=0.0, min_edge_after_fees=-1.0,
+        )
+
+    async def _run(self, config=None):
+        return await run_backtest(
+            client=None, config=config or self._permissive_config(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_entry_priced_from_candle_not_settlement(
+        self, monkeypatch,
+    ) -> None:
+        markets = self._markets()
+        m = markets[0]
+        entry_ts = self._entry_ts(m)
+        # Entry-day candle 0.30/0.40 → NO eff at entry = 0.65.
+        candles = {m.ticker: [_make_candle(
+            ts=entry_ts, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        calls = self._stub(monkeypatch, markets, candles)
+
+        result = await self._run()
+        assert len(result.trades) == 1
+        t = result.trades[0]
+        assert t.entry_price == pytest.approx(0.65)
+        # Settlement-time NO eff was 0.70 — must NOT be the fill.
+        assert t.entry_price != pytest.approx(0.70)
+        # The fetch window must end AT entry time — future candles are
+        # structurally unreachable.
+        assert calls and all(c["end_ts"] == entry_ts for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_sizing_uses_entry_day_price(self, monkeypatch) -> None:
+        markets = self._markets()
+        m = markets[0]
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m), yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+
+        config = self._permissive_config()
+        result = await self._run(config)
+        assert len(result.trades) == 1
+        side_cfg = config.gimmes_config.effective_config_for_side("no")
+        expected = position_size(
+            config.starting_balance, 0.65,
+            min(0.65 + config.assumed_edge, 0.99),
+            fraction=side_cfg.sizing.kelly_fraction,
+            max_position_pct=side_cfg.sizing.max_position_pct,
+            fees=DEFAULT_FEE_MULTIPLIERS,
+            mode=side_cfg.sizing.mode,
+        )
+        assert result.trades[0].count == expected
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_on_entry_day_dropped(
+        self, monkeypatch,
+    ) -> None:
+        markets = self._markets()
+        m = markets[0]
+        # Entry-day NO eff = 0.05 — far below min_market_price.
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m), yes_bid_close=0.90, yes_ask_close=1.00,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.skipped_entry_gates == 1
+
+    @pytest.mark.asyncio
+    async def test_no_candle_dropped(self, monkeypatch) -> None:
+        markets = self._markets()
+        self._stub(monkeypatch, markets, {markets[0].ticker: []})
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.skipped_no_candle == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_error_dropped_not_crashed(
+        self, monkeypatch,
+    ) -> None:
+        markets = self._markets()
+        self._stub(
+            monkeypatch, markets,
+            {markets[0].ticker: RuntimeError("api down")},
+        )
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.skipped_no_candle == 1
+
+    @pytest.mark.asyncio
+    async def test_degenerate_quote_dropped(self, monkeypatch) -> None:
+        markets = self._markets()
+        m = markets[0]
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m), yes_bid_close=0.30, yes_ask_close=0.0,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.skipped_no_candle == 1
+
+    @pytest.mark.asyncio
+    async def test_future_candle_not_used(self, monkeypatch) -> None:
+        """A candle ending after entry_ts must be invisible even if the
+        (stubbed) fetcher leaks it."""
+        markets = self._markets()
+        m = markets[0]
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m) + 3600,
+            yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.skipped_no_candle == 1
+
+
+class TestEntryCandleHelpers:
+    def test_candle_midpoint(self) -> None:
+        assert candle_midpoint(
+            _make_candle(yes_bid_close=0.30, yes_ask_close=0.40),
+        ) == pytest.approx(0.35)
+        assert candle_midpoint(
+            _make_candle(yes_bid_close=0.0, yes_ask_close=0.40),
+        ) == 0.0
+
+    def test_entry_candle_at_boundary_and_order(self) -> None:
+        c1 = _make_candle(ts=100)
+        c2 = _make_candle(ts=200)
+        c3 = _make_candle(ts=300)
+        assert entry_candle_at([c1, c2, c3], 200) is c2  # boundary ==
+        assert entry_candle_at([c1, c2, c3], 250) is c2
+        assert entry_candle_at([c1, c2, c3], 50) is None
+        assert entry_candle_at([], 100) is None

--- a/tests/unit/test_backtest_report.py
+++ b/tests/unit/test_backtest_report.py
@@ -192,3 +192,40 @@ class TestSharpeSignMatchesRoi:
         ]
         data = backtest_result_to_json(result)
         assert data["summary"]["sharpe"] > 0
+
+
+class TestSkipCountersInReport:
+    """#655: the new funnel counters must reach the JSON output and the
+    coverage warning must fire when candle history is mostly missing."""
+
+    def test_json_carries_skip_counters(self) -> None:
+        result = _make_result()
+        result.skipped_no_candle = 3
+        result.skipped_entry_gates = 5
+        data = backtest_result_to_json(result)
+        assert data["funnel"]["skipped_no_candle"] == 3
+        assert data["funnel"]["skipped_entry_gates"] == 5
+
+    def test_coverage_warning_fires_above_half(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.markets_scored = 10
+        result.skipped_no_candle = 6
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "Caution" in buf.getvalue()
+
+    def test_no_warning_at_or_below_half(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.markets_scored = 10
+        result.skipped_no_candle = 5
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "Caution" not in buf.getvalue()

--- a/tests/unit/test_historical.py
+++ b/tests/unit/test_historical.py
@@ -8,6 +8,7 @@ import pytest
 
 from gimmes.kalshi.historical import (
     Candle,
+    _parse_candle,
     get_candlesticks,
     list_all_historical_markets,
     list_historical_markets,
@@ -214,3 +215,52 @@ class TestListAllHistoricalMarketsFiltering:
         markets = await list_all_historical_markets(mock_client)
 
         assert len(markets) == 2
+
+
+class TestParseCandleLiveShape:
+    """#655: the live API serves nested `*_dollars` string OHLC and
+    `*_fp` counts (verified against the real endpoint 2026-07-03) —
+    the parser previously read only legacy plain keys and would have
+    produced all-zero candles."""
+
+    def test_dollars_fields_parsed(self) -> None:
+        c = _parse_candle({
+            "end_period_ts": 1776168000,
+            "yes_bid": {"open_dollars": "0.3400", "high_dollars": "0.3600",
+                        "low_dollars": "0.2900", "close_dollars": "0.3200"},
+            "yes_ask": {"open_dollars": "0.3600", "high_dollars": "0.3800",
+                        "low_dollars": "0.3100", "close_dollars": "0.3300"},
+            "price": {"open_dollars": "0.3500", "close_dollars": "0.3250"},
+            "volume_fp": "1200",
+            "open_interest_fp": "800",
+        })
+        assert c.yes_bid_close == 0.32
+        assert c.yes_ask_close == 0.33
+        assert c.price_close == 0.325
+        assert c.volume == 1200
+        assert c.open_interest == 800
+
+    def test_legacy_plain_keys_still_parse(self) -> None:
+        c = _parse_candle({
+            "end_period_ts": 1,
+            "yes_bid": {"close": "0.63"},
+            "yes_ask": {"close": "0.70"},
+            "price": {},
+            "volume": 10,
+            "open_interest": 5,
+        })
+        assert c.yes_bid_close == 0.63
+        assert c.volume == 10
+
+    def test_legacy_int_cents_fallback(self) -> None:
+        """Plain-key INT values are legacy cents per the markets.py
+        convention — 34 means $0.34 (#655 review: a silent 100x
+        sizing error otherwise)."""
+        c = _parse_candle({
+            "end_period_ts": 1,
+            "yes_bid": {"close": 34},
+            "yes_ask": {"close": 36},
+            "price": {},
+        })
+        assert c.yes_bid_close == 0.34
+        assert c.yes_ask_close == 0.36


### PR DESCRIPTION
## Summary

The backtest had **perfect foresight**: it simulated entry one day before settlement while pricing, gating, and sizing with the settlement-time midpoint. Now every P&L-affecting quantity derives from the **entry-day candle** — the fetch window ends at entry time (future data structurally unreachable), the price-band/true-prob/edge gates re-run at the entry-day price, Kelly sizes at it, and settlement reaches only the payout. `pick_entry_candle` is deleted: scanning for the last in-range close was itself a peek; a fixed-offset rule replaces it.

**Bonus find:** the smoke run proved the candle fetcher had never worked — the endpoint 404s (wrong path, zero callers ever). Fixed to the series-scoped path (verified live) and the parser now reads the live API's `*_dollars`/`*_fp` shapes (it would have produced all-zero candles), with int fallbacks treated as legacy cents (silent 100× error otherwise).

## The honest numbers

May–Jul window: **−41.2% ROI, Sharpe −1.28, 50% win rate** — 28 trades, with **20 candidates dropped at entry-day gates** (trades the biased backtest was crediting as winners). Combined with #653 (scorecard) and #654 (Sharpe), the strategy's real performance is now visible end-to-end. Value change is the correction, not a regression.

## Funnel visibility
New `skipped_no_candle` / `skipped_entry_gates` counters (report + JSON), coverage caution when candle history is missing for most candidates, and skip-cause debug logging (no-candles vs one-sided quotes — policy note on #666).

## Review
Full pipeline + a second pass on the endpoint/parser delta; mutation-verified sizing pin (516-vs-446 discriminates); settlement-mirroring candle stub preserves every legacy test's #592 intent. Residual selection-lens bias tracked in **#666**.

## Test plan
- `uv run pytest tests/unit/test_backtest_engine.py tests/unit/test_backtest_report.py tests/unit/test_historical.py` — entry-priced-from-candle pin (incl. fetch-window assertion), sizing pin, out-of-range/no-candle/fetch-error/degenerate/future-candle drops, live-shape + cents-fallback parser tests, counter/warning report tests.
- Full suite green; ruff clean; live smoke run verified (candles fetched, 28 trades).

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB