### PR TITLE
Fix #656: pair closes to entries — gimmes lesson produces recommendations

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1166,9 +1166,24 @@ def order(
                         trade_action is TradeDecision.Action.CLOSE
                         and probability is None
                     ):
-                        entry = (
-                            await get_entry_analytics(db, ticker, side) or {}
-                        )
+                        # Best-effort enrichment: a failed read must
+                        # not surface as "position sync failed" and
+                        # drop the trade row after a confirmed fill.
+                        # Log-only degrade (the #643 snapshot
+                        # precedent) — no insert_error row, since the
+                        # DB just failed a read.
+                        try:
+                            entry = (
+                                await get_entry_analytics(db, ticker, side)
+                                or {}
+                            )
+                        except sqlite3.Error:
+                            logger.error(
+                                "Entry-analytics fetch failed for %s;"
+                                " recording close with zeroed"
+                                " analytics (#656)",
+                                ticker, exc_info=True,
+                            )
                     trade = TradeDecision(
                         ticker=ticker,
                         action=trade_action,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1090,6 +1090,7 @@ def order(
                 if result.status in ("executed", "resting"):
                     from gimmes.models.trade import TradeDecision
                     from gimmes.store.queries import (
+                        get_entry_analytics,
                         get_open_trade_for_ticker,
                         get_thesis_for_ticker,
                         sync_positions_with_trade,
@@ -1155,18 +1156,37 @@ def order(
                     else:
                         trade_action = TradeDecision.Action.CLOSE
                         thesis = ""
+                    # #656: a close without an explicit --probability
+                    # inherits the entry decision's analytics — a close
+                    # row with zeroed prob/edge/score is blind to the
+                    # reasoning that opened it. An explicit probability
+                    # keeps close-time semantics (prob/edge as of now).
+                    entry: dict = {}
+                    if (
+                        trade_action is TradeDecision.Action.CLOSE
+                        and probability is None
+                    ):
+                        entry = (
+                            await get_entry_analytics(db, ticker, side) or {}
+                        )
                     trade = TradeDecision(
                         ticker=ticker,
                         action=trade_action,
                         side=side,
                         count=final_count,
                         price=final_price,
-                        model_probability=0.0 if probability is None else probability,
+                        model_probability=(
+                            entry.get("model_probability", 0.0)
+                            if probability is None
+                            else probability
+                        ),
+                        gimme_score=entry.get("gimme_score", 0.0),
                         edge=(
                             probability - final_price
                             if probability is not None
-                            else 0.0
+                            else entry.get("edge", 0.0)
                         ),
+                        kelly_fraction=entry.get("kelly_fraction", 0.0),
                         rationale=thesis or f"{agent} order",
                         thesis=thesis,
                         agent=agent,
@@ -1357,8 +1377,10 @@ def trades(
         table.add_column("Side")
         table.add_column("Count", justify="right")
         table.add_column("Price", justify="right")
+        table.add_column("Prob", justify="right")
         table.add_column("Edge", justify="right")
         table.add_column("Score", justify="right")
+        table.add_column("Outcome")
         table.add_column("Timestamp")
 
         for t in records:
@@ -1368,8 +1390,10 @@ def trades(
                 str(t.get("side", "")),
                 str(t.get("count", 0)),
                 f"${t.get('price', 0):.2f}",
+                f"{t.get('model_probability', 0):.1%}",
                 f"{t.get('edge', 0):.1%}",
                 f"{t.get('gimme_score', 0):.0f}",
+                str(t.get("resolved_outcome") or ""),
                 format_local_timestamp(str(t.get("timestamp", ""))),
             )
 
@@ -2028,7 +2052,7 @@ def log_trade(
     async def _log() -> None:
         from gimmes.models.trade import TradeDecision
         from gimmes.store.database import Database
-        from gimmes.store.queries import insert_trade
+        from gimmes.store.queries import get_entry_analytics, insert_trade
         from gimmes.strategy.scanner import effective_price
 
         resolved_side = side if side else config.strategy.side
@@ -2047,6 +2071,16 @@ def log_trade(
         )
 
         async with Database(config.db_path) as db:
+            # #656: a close logged without --prob inherits the entry
+            # decision's analytics; an explicit --prob or --score wins.
+            if trade.action is TradeDecision.Action.CLOSE and prob is None:
+                entry = await get_entry_analytics(db, ticker, resolved_side)
+                if entry:
+                    trade.model_probability = entry["model_probability"]
+                    trade.edge = entry["edge"]
+                    trade.kelly_fraction = entry["kelly_fraction"]
+                    if not score_val:
+                        trade.gimme_score = entry["gimme_score"]
             row_id = await insert_trade(db, trade)
             console.print(f"[green]Logged trade #{row_id}: {action} {ticker}[/green]")
 

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -297,12 +297,19 @@ async def _log_reconcile_closes(
         # math honest. Documented in the rationale so audit can see
         # this isn't a broker-confirmed fill.
         close_price = pos.market_price if pos.market_price else pos.avg_price
+        # #656: carry the entry decision's analytics onto the synthetic
+        # close so the trades table isn't blind to its own reasoning.
+        entry = await get_entry_analytics(db, pos.ticker, pos.side) or {}
         synth = TradeDecision(
             ticker=pos.ticker,
             action=TradeDecision.Action.CLOSE,
             side=pos.side,
             count=pos.count,
             price=close_price,
+            model_probability=entry.get("model_probability", 0.0),
+            gimme_score=entry.get("gimme_score", 0.0),
+            edge=entry.get("edge", 0.0),
+            kelly_fraction=entry.get("kelly_fraction", 0.0),
             rationale=(
                 "reconcile drift — broker removed position without local"
                 " close; price is last-known mark, not broker-confirmed"
@@ -433,12 +440,28 @@ async def log_settlement_close(
     cycle = _cycle_from_env()
 
     price = 1.0 if won else 0.0
+    # #656: carry the entry decision's analytics onto the settlement
+    # close so calibration audits can read entry vs outcome per row.
+    entry = await get_entry_analytics(db, ticker, side)
+    if entry is None:
+        # No entry on record (pre-#653 data, seeded positions) — the
+        # close keeps honest zeros, but log it so a calibration gap is
+        # traceable to missing history rather than a broken writer.
+        logging.getLogger(__name__).debug(
+            "settlement close for %s/%s found no entry row —"
+            " analytics default to 0 (#656)", ticker, side,
+        )
+        entry = {}
     synth = TradeDecision(
         ticker=ticker,
         action=TradeDecision.Action.CLOSE,
         side=side,
         count=count,
         price=price,
+        model_probability=entry.get("model_probability", 0.0),
+        gimme_score=entry.get("gimme_score", 0.0),
+        edge=entry.get("edge", 0.0),
+        kelly_fraction=entry.get("kelly_fraction", 0.0),
         rationale=rationale or (
             "market settled — broker-confirmed outcome; close at"
             " settlement value (#653)"
@@ -914,6 +937,30 @@ async def get_open_trade_for_ticker(db: Database, ticker: str) -> dict | None:  
         "SELECT * FROM trades WHERE ticker = ? AND action = 'open'"
         " ORDER BY timestamp DESC LIMIT 1",
         (ticker,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_entry_analytics(
+    db: Database, ticker: str, side: str,
+) -> dict | None:  # type: ignore[type-arg]
+    """Return the latest open/size_up row's analytics for a ticker/side.
+
+    Carries entry-time analytics (model probability, score, edge, kelly
+    fraction) onto close rows so `gimmes trades` and calibration audits
+    see the entry decision that produced the close (#656). Synthetic
+    closes otherwise inherit TradeDecision's 0.0 defaults, which left
+    the trades table blind to its own entry reasoning.
+
+    Commit-less: safe inside a caller's transaction.
+    """
+    cursor = await db.conn.execute(
+        "SELECT model_probability, gimme_score, edge, kelly_fraction"
+        " FROM trades WHERE ticker = ? AND side = ?"
+        " AND action IN ('open', 'size_up')"
+        " ORDER BY timestamp DESC, id DESC LIMIT 1",
+        (ticker, side),
     )
     row = await cursor.fetchone()
     return dict(row) if row else None

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -12,14 +12,97 @@ from gimmes.models.recommendation import (
 )
 
 
-def _close_trades(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
-    """Filter to close trades only."""
-    return [t for t in trades if t.get("action") == "close"]
-
-
 def _open_trades(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
     """Filter to open trades only."""
     return [t for t in trades if t.get("action") == "open"]
+
+
+def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
+    """Pair each close row to its opens and classify it won/lost.
+
+    Close rows carry no reliable outcome signal of their own (#656):
+    synthetic closes (settlement, reconcile) historically defaulted
+    edge/score to 0, and even entry edge copied onto a close says
+    nothing about how the trade resolved — opens are min_edge-gated,
+    so close-row ``edge > 0`` would classify every trade a win.
+
+    Mirrors the ``calculate_pnl`` walk (reporting/pnl.py): group
+    ``open``/``size_up``/``close`` by (ticker, side), scan in timestamp
+    order with a running weighted-average cost, and reprice reconcile
+    drift closes at settlement value when the group's resolution is
+    known (#653). ``won`` is resolution-first (side == resolved_outcome
+    anywhere in the group), falling back to the realized return's sign.
+    Orphan closes (no matched open on record) are dropped — they have
+    no entry decision to learn from.
+
+    Returns one record per matched close: ``{ticker, side, timestamp,
+    won, realized_return, entry_score, entry_price}`` where
+    ``realized_return`` is per-contract (close price − avg cost) and
+    entry fields come from the most recent open/size_up before the
+    close.
+    """
+    groups: dict[tuple[str, str], list[dict]] = {}  # type: ignore[type-arg]
+    for t in trades:
+        if t.get("action") not in ("open", "close", "size_up"):
+            continue
+        key = (t.get("ticker", ""), t.get("side", "yes"))
+        groups.setdefault(key, []).append(t)
+
+    paired: list[dict] = []  # type: ignore[type-arg]
+    for (ticker, side), events in groups.items():
+        events.sort(key=lambda e: str(e.get("timestamp", "")))
+        group_outcome = next(
+            (
+                e.get("resolved_outcome")
+                for e in events
+                if e.get("resolved_outcome") in ("yes", "no")
+            ),
+            None,
+        )
+        remaining = 0
+        avg_cost = 0.0
+        entry_score = 0.0
+        entry_price = 0.0
+        for e in events:
+            action = e.get("action")
+            count = int(e.get("count", 0) or 0)
+            price = float(e.get("price", 0.0) or 0.0)
+            if count <= 0:
+                continue
+            if action in ("open", "size_up"):
+                total = remaining + count
+                avg_cost = (
+                    (avg_cost * remaining + price * count) / total
+                    if total
+                    else 0.0
+                )
+                remaining = total
+                entry_score = float(e.get("gimme_score", 0) or 0)
+                entry_price = price
+                continue
+            # action == "close"
+            matched = min(count, remaining)
+            remaining -= matched
+            if matched <= 0:
+                continue
+            if e.get("agent") == "reconcile" and group_outcome is not None:
+                price = 1.0 if side == group_outcome else 0.0
+            realized = price - avg_cost
+            won = (
+                side == group_outcome
+                if group_outcome is not None
+                else realized > 0
+            )
+            paired.append({
+                "ticker": ticker,
+                "side": side,
+                "timestamp": e.get("timestamp", ""),
+                "won": won,
+                "realized_return": realized,
+                "entry_score": entry_score,
+                "entry_price": entry_price,
+            })
+    return paired
 
 
 # ---------------------------------------------------------------------------
@@ -38,16 +121,14 @@ def analyze_threshold_sweep(
     Returns a recommendation if a better threshold is found, else None.
     """
     opens = _open_trades(trades)
-    closes = _close_trades(trades)
-    if len(closes) < MIN_TRADES_THRESHOLD:
+    paired = _pair_closes(trades)
+    if len(paired) < MIN_TRADES_THRESHOLD:
         return None
 
-    # Build outcome map: ticker -> won (True/False)
-    outcomes: dict[str, bool] = {}
-    for t in closes:
-        ticker = t.get("ticker", "")
-        edge = t.get("edge", 0)
-        outcomes[ticker] = edge > 0
+    # Build outcome map: ticker -> won (True/False). Resolution-first
+    # via _pair_closes — close-row edge is an entry artifact, not an
+    # outcome (#656).
+    outcomes: dict[str, bool] = {r["ticker"]: r["won"] for r in paired}
 
     # Build score map from opens
     scored: list[dict] = []  # type: ignore[type-arg]
@@ -134,15 +215,18 @@ def analyze_edge_decay(
 ) -> Recommendation | None:
     """Detect if realized edge is shrinking over time.
 
-    Compares the rolling edge of the most recent half of trades to the first half.
+    Compares the per-contract realized return of the most recent half
+    of paired closes to the first half. Close-row `edge` is an entry
+    artifact (zeroed on synthetic closes, min_edge-gated otherwise) and
+    cannot express realized decay (#656).
     """
-    closes = _close_trades(trades)
-    if len(closes) < MIN_TRADES_EDGE_DECAY:
+    paired = _pair_closes(trades)
+    if len(paired) < MIN_TRADES_EDGE_DECAY:
         return None
 
     # Sort by timestamp ascending
-    sorted_trades = sorted(closes, key=lambda t: t.get("timestamp", ""))
-    edges = [t.get("edge", 0) for t in sorted_trades]
+    sorted_trades = sorted(paired, key=lambda r: str(r.get("timestamp", "")))
+    edges = [r["realized_return"] for r in sorted_trades]
 
     mid = len(edges) // 2
     first_half = edges[:mid]
@@ -161,7 +245,7 @@ def analyze_edge_decay(
         return None
 
     confidence = Confidence.LOW
-    if decay_pct >= 0.30 and len(closes) >= 50:
+    if decay_pct >= 0.30 and len(paired) >= 50:
         confidence = Confidence.HIGH
     elif decay_pct >= 0.20:
         confidence = Confidence.MEDIUM
@@ -181,7 +265,7 @@ def analyze_edge_decay(
             "first_half_avg_edge": round(avg_first, 4),
             "second_half_avg_edge": round(avg_second, 4),
             "decay_pct": round(decay_pct, 3),
-            "sample_size": len(closes),
+            "sample_size": len(paired),
         }),
     )
 
@@ -231,20 +315,25 @@ def analyze_kelly_optimization(
     trades: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
 ) -> Recommendation | None:
-    """Compute optimal Kelly fraction from realized win rate and payoffs."""
-    closes = _close_trades(trades)
-    if len(closes) < MIN_TRADES_KELLY:
+    """Compute optimal Kelly fraction from realized win rate and payoffs.
+
+    Wins/losses and payoff magnitudes come from per-contract realized
+    returns via _pair_closes — entry edge is identical on both legs of
+    a trade and would corrupt the payoff ratio (#656).
+    """
+    paired = _pair_closes(trades)
+    if len(paired) < MIN_TRADES_KELLY:
         return None
 
-    wins = [t for t in closes if t.get("edge", 0) > 0]
-    losses = [t for t in closes if t.get("edge", 0) < 0]
+    wins = [r for r in paired if r["realized_return"] > 0]
+    losses = [r for r in paired if r["realized_return"] < 0]
 
     if not wins or not losses:
         return None
 
-    win_rate = len(wins) / len(closes)
-    avg_win = sum(abs(t.get("edge", 0)) for t in wins) / len(wins)
-    avg_loss = sum(abs(t.get("edge", 0)) for t in losses) / len(losses)
+    win_rate = len(wins) / len(paired)
+    avg_win = sum(r["realized_return"] for r in wins) / len(wins)
+    avg_loss = sum(-r["realized_return"] for r in losses) / len(losses)
 
     if avg_loss == 0:
         return None
@@ -266,9 +355,9 @@ def analyze_kelly_optimization(
         return None
 
     confidence = Confidence.LOW
-    if len(closes) >= 50 and abs(recommended - current) >= 0.10:
+    if len(paired) >= 50 and abs(recommended - current) >= 0.10:
         confidence = Confidence.HIGH
-    elif len(closes) >= 30:
+    elif len(paired) >= 30:
         confidence = Confidence.MEDIUM
 
     return Recommendation(
@@ -289,7 +378,7 @@ def analyze_kelly_optimization(
             "payoff_ratio": round(b, 3),
             "full_kelly": round(full_kelly, 3),
             "recommended_fraction": recommended,
-            "sample_size": len(closes),
+            "sample_size": len(paired),
         }),
     )
 
@@ -306,15 +395,13 @@ def analyze_scanner_parameters(
     config: GimmesConfig,
 ) -> Recommendation | None:
     """Analyze price distribution of winners vs losers for price range tuning."""
-    closes = _close_trades(trades)
     opens = _open_trades(trades)
-    if len(closes) < MIN_TRADES_SCANNER:
+    paired = _pair_closes(trades)
+    if len(paired) < MIN_TRADES_SCANNER:
         return None
 
-    # Build outcome map
-    outcomes: dict[str, bool] = {}
-    for t in closes:
-        outcomes[t.get("ticker", "")] = t.get("edge", 0) > 0
+    # Build outcome map — resolution-first via _pair_closes (#656)
+    outcomes: dict[str, bool] = {r["ticker"]: r["won"] for r in paired}
 
     # Get prices from opens
     winner_prices: list[float] = []
@@ -358,7 +445,7 @@ def analyze_scanner_parameters(
         parameter_path=param,
         current_value=str(current),
         recommended_value=str(recommended),
-        confidence=Confidence.MEDIUM if len(closes) >= 50 else Confidence.LOW,
+        confidence=Confidence.MEDIUM if len(paired) >= 50 else Confidence.LOW,
         analysis_type=AnalysisType.SCANNER_REVIEW,
         rationale=(
             f"Winners avg price: {avg_winner_price:.2f} (n={len(winner_prices)}), "

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -262,8 +262,10 @@ def analyze_edge_decay(
             f"Consider raising min_edge_after_fees to filter weaker opportunities."
         ),
         supporting_data=json.dumps({
-            "first_half_avg_edge": round(avg_first, 4),
-            "second_half_avg_edge": round(avg_second, 4),
+            # Per-contract realized returns since #656 (were entry
+            # edges) — keys named for what they now carry.
+            "first_half_avg_return": round(avg_first, 4),
+            "second_half_avg_return": round(avg_second, 4),
             "decay_pct": round(decay_pct, 3),
             "sample_size": len(paired),
         }),

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -15,6 +15,7 @@ from gimmes.store.queries import (
     update_recommendation_status,
 )
 from gimmes.strategy.advisor import (
+    _pair_closes,
     analyze_edge_decay,
     analyze_kelly_optimization,
     analyze_missed_opportunities,
@@ -40,7 +41,14 @@ def _make_trades(
     win_price: float = 0.70,
     loss_price: float = 0.65,
 ) -> list[dict]:
-    """Generate synthetic trade data for testing."""
+    """Generate production-shaped trade data.
+
+    Close rows carry ZERO analytics — exactly how synthetic closes
+    (settlement, reconcile) were written historically (#656). Outcome
+    is expressed only through prices: win closes above the open price,
+    loss closes below. Analyses must derive wins by pairing, never
+    from close-row edge.
+    """
     trades: list[dict] = []
     for i in range(n_wins):
         ticker = f"WIN-{i}"
@@ -52,9 +60,9 @@ def _make_trades(
         })
         trades.append({
             "ticker": ticker, "action": "close", "side": "yes", "count": 10,
-            "price": win_price + win_edge, "model_probability": 0.90,
-            "gimme_score": win_score, "edge": win_edge, "rationale": "settled",
-            "agent": "closer",
+            "price": win_price + win_edge, "model_probability": 0.0,
+            "gimme_score": 0.0, "edge": 0.0, "rationale": "settled",
+            "agent": "settlement",
             "timestamp": f"2026-01-{(i % 28) + 1:02d}T18:00:00",
         })
     for i in range(n_losses):
@@ -67,9 +75,9 @@ def _make_trades(
         })
         trades.append({
             "ticker": ticker, "action": "close", "side": "yes", "count": 10,
-            "price": loss_price + loss_edge, "model_probability": 0.85,
-            "gimme_score": loss_score, "edge": loss_edge, "rationale": "settled",
-            "agent": "closer",
+            "price": loss_price + loss_edge, "model_probability": 0.0,
+            "gimme_score": 0.0, "edge": 0.0, "rationale": "settled",
+            "agent": "settlement",
             "timestamp": f"2026-02-{(i % 28) + 1:02d}T18:00:00",
         })
     return trades
@@ -113,6 +121,152 @@ class TestRecommendationModel:
 
 
 # ---------------------------------------------------------------------------
+# Pairing tests (#656)
+# ---------------------------------------------------------------------------
+
+
+def _pair_group(
+    *,
+    ticker: str = "KXCPI-26APR-T0.5",
+    side: str = "yes",
+    open_price: float = 0.60,
+    close_price: float = 0.75,
+    agent: str = "closer",
+    resolved_outcome: str | None = None,
+    score: float = 80.0,
+) -> list[dict]:
+    """One open + one close with optional resolution on the OPEN row
+    (where Monitor's log-outcome lands, per pnl.py)."""
+    return [
+        {
+            "ticker": ticker, "action": "open", "side": side, "count": 10,
+            "price": open_price, "gimme_score": score, "edge": 0.15,
+            "resolved_outcome": resolved_outcome, "agent": "closer",
+            "timestamp": "2026-01-01T10:00:00",
+        },
+        {
+            "ticker": ticker, "action": "close", "side": side, "count": 10,
+            "price": close_price, "gimme_score": 0.0, "edge": 0.0,
+            "resolved_outcome": None, "agent": agent,
+            "timestamp": "2026-01-02T10:00:00",
+        },
+    ]
+
+
+class TestPairCloses:
+    def test_pnl_fallback_win_and_loss(self) -> None:
+        trades = (
+            _pair_group(ticker="A", open_price=0.60, close_price=0.75)
+            + _pair_group(ticker="B", open_price=0.60, close_price=0.40)
+        )
+        paired = {r["ticker"]: r for r in _pair_closes(trades)}
+        assert paired["A"]["won"] is True
+        assert paired["A"]["realized_return"] == pytest.approx(0.15)
+        assert paired["B"]["won"] is False
+        assert paired["B"]["realized_return"] == pytest.approx(-0.20)
+
+    def test_resolution_beats_realized_sign(self) -> None:
+        """A stop-loss close at a paper loss on a market that resolved
+        our way is still a WON prediction — resolution-first."""
+        trades = _pair_group(
+            open_price=0.60, close_price=0.40, resolved_outcome="yes",
+        )
+        [r] = _pair_closes(trades)
+        assert r["won"] is True
+        assert r["realized_return"] == pytest.approx(-0.20)
+
+    def test_resolution_against_us_beats_positive_entry_edge(self) -> None:
+        """Anti-inversion (#656): the close row carrying copied POSITIVE
+        entry edge must not classify as a win when the market resolved
+        against the side."""
+        trades = _pair_group(
+            open_price=0.60, close_price=0.75, resolved_outcome="no",
+        )
+        trades[1]["edge"] = 0.15  # entry edge copied onto the close
+        [r] = _pair_closes(trades)
+        assert r["won"] is False
+
+    def test_reconcile_close_repriced_at_settlement(self) -> None:
+        """Reconcile drift priced at a stale mark is repriced 1.0/0.0
+        when the group's resolution is known (#653 semantics)."""
+        trades = _pair_group(
+            open_price=0.63, close_price=0.705, agent="reconcile",
+            resolved_outcome="no",  # yes side lost
+        )
+        [r] = _pair_closes(trades)
+        assert r["won"] is False
+        assert r["realized_return"] == pytest.approx(-0.63)
+
+    def test_orphan_close_dropped(self) -> None:
+        trades = [{
+            "ticker": "GHOST", "action": "close", "side": "yes",
+            "count": 10, "price": 0.9, "timestamp": "2026-01-01T10:00:00",
+        }]
+        assert _pair_closes(trades) == []
+
+    def test_size_up_rolls_into_avg_cost(self) -> None:
+        trades = [
+            {
+                "ticker": "S", "action": "open", "side": "yes", "count": 10,
+                "price": 0.50, "gimme_score": 70.0,
+                "timestamp": "2026-01-01T10:00:00",
+            },
+            {
+                "ticker": "S", "action": "size_up", "side": "yes",
+                "count": 10, "price": 0.70, "gimme_score": 72.0,
+                "timestamp": "2026-01-02T10:00:00",
+            },
+            {
+                "ticker": "S", "action": "close", "side": "yes", "count": 20,
+                "price": 0.55, "timestamp": "2026-01-03T10:00:00",
+            },
+        ]
+        [r] = _pair_closes(trades)
+        # avg cost (0.50*10 + 0.70*10)/20 = 0.60 → realized −0.05
+        assert r["realized_return"] == pytest.approx(-0.05)
+        assert r["won"] is False
+        assert r["entry_score"] == 72.0
+
+    def test_entry_analytics_captured(self) -> None:
+        [r] = _pair_closes(_pair_group(score=85.0, open_price=0.62))
+        assert r["entry_score"] == 85.0
+        assert r["entry_price"] == 0.62
+
+
+class TestLessonNotBlind:
+    """The dead-loop regression (#656): production-shaped data — close
+    rows with zeroed analytics — must still produce recommendations."""
+
+    def test_run_all_analyses_produces_a_recommendation(
+        self, config: GimmesConfig,
+    ) -> None:
+        # Wins score 70 (below default threshold 75), losses score 85:
+        # the sweep must discover the better threshold from PAIRED
+        # outcomes despite every close row carrying edge=0/score=0.
+        trades = _make_trades(
+            n_wins=25, n_losses=10, win_score=70, loss_score=85,
+        )
+        recs = run_all_analyses(trades, [], config)
+        assert len(recs) >= 1
+        # Pin the specific analyses (all four fire on this data) so a
+        # single-analysis regression can't hide behind the others.
+        types = {r.analysis_type for r in recs}
+        assert AnalysisType.THRESHOLD_SWEEP in types
+        assert AnalysisType.KELLY_OPTIMIZATION in types
+        assert AnalysisType.SCANNER_REVIEW in types
+
+    def test_not_all_losses_under_zeroed_close_edge(
+        self, config: GimmesConfig,
+    ) -> None:
+        """The original bug: close-row `edge > 0` classified every
+        trade a loss. Pairing must see the actual mix."""
+        paired = _pair_closes(_make_trades(n_wins=20, n_losses=10))
+        wins = sum(1 for r in paired if r["won"])
+        assert wins == 20
+        assert len(paired) - wins == 10
+
+
+# ---------------------------------------------------------------------------
 # Analysis tests
 # ---------------------------------------------------------------------------
 
@@ -124,13 +278,14 @@ class TestThresholdSweep:
 
     def test_finds_better_threshold(self, config: GimmesConfig) -> None:
         # Wins have score 70 (below default threshold of 75)
-        # so lowering threshold should capture more wins
+        # so lowering threshold should capture more wins. Hard assert:
+        # an `if rec is not None` guard let a per-analysis revert to
+        # close-row edge classification survive (#656 review).
         trades = _make_trades(n_wins=25, n_losses=5, win_score=70, loss_score=85)
         rec = analyze_threshold_sweep(trades, config)
-        # Should recommend lowering threshold
-        if rec is not None:
-            assert rec.parameter_path == "strategy.gimme_threshold"
-            assert rec.analysis_type == AnalysisType.THRESHOLD_SWEEP
+        assert rec is not None
+        assert rec.parameter_path == "strategy.gimme_threshold"
+        assert rec.analysis_type == AnalysisType.THRESHOLD_SWEEP
 
     def test_no_change_needed(self, config: GimmesConfig) -> None:
         # All trades at exactly the threshold — no improvement possible
@@ -145,32 +300,45 @@ class TestEdgeDecay:
         trades = _make_trades(n_wins=5, n_losses=2)
         assert analyze_edge_decay(trades, config) is None
 
-    def test_detects_decay(self, config: GimmesConfig) -> None:
-        # First half has good edge, second half has poor edge
+    @staticmethod
+    def _paired_trades(
+        prefix: str, n: int, month: int, realized: float,
+    ) -> list[dict]:
+        """n open/close pairs whose per-contract realized return is
+        `realized` — decay must be visible from PAIRED returns, not
+        close-row edge (which is zeroed in production, #656)."""
         trades: list[dict] = []
-        for i in range(20):
+        for i in range(n):
+            day = (i % 28) + 1
             trades.append({
-                "ticker": f"EARLY-{i}", "action": "close", "edge": 0.20,
-                "timestamp": f"2026-01-{(i % 28) + 1:02d}T10:00:00",
+                "ticker": f"{prefix}-{i}", "action": "open", "side": "yes",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "timestamp": f"2026-{month:02d}-{day:02d}T10:00:00",
             })
-        for i in range(20):
             trades.append({
-                "ticker": f"LATE-{i}", "action": "close", "edge": 0.05,
-                "timestamp": f"2026-03-{(i % 28) + 1:02d}T10:00:00",
+                "ticker": f"{prefix}-{i}", "action": "close", "side": "yes",
+                "count": 10, "price": 0.50 + realized, "edge": 0.0,
+                "timestamp": f"2026-{month:02d}-{day:02d}T18:00:00",
             })
+        return trades
+
+    def test_detects_decay(self, config: GimmesConfig) -> None:
+        # First half realizes +0.20/contract, second half +0.05
+        trades = (
+            self._paired_trades("EARLY", 20, 1, 0.20)
+            + self._paired_trades("LATE", 20, 3, 0.05)
+        )
         rec = analyze_edge_decay(trades, config)
         assert rec is not None
         assert rec.analysis_type == AnalysisType.EDGE_DECAY
         assert "decaying" in rec.rationale.lower()
 
     def test_no_decay(self, config: GimmesConfig) -> None:
-        # Consistent edge across both halves — no decay
-        trades: list[dict] = []
-        for i in range(40):
-            trades.append({
-                "ticker": f"CONSISTENT-{i}", "action": "close", "edge": 0.15,
-                "timestamp": f"2026-0{(i // 28) + 1}-{(i % 28) + 1:02d}T10:00:00",
-            })
+        # Consistent realized return across both halves — no decay
+        trades = (
+            self._paired_trades("CONSISTENT", 20, 1, 0.15)
+            + self._paired_trades("STEADY", 20, 2, 0.15)
+        )
         rec = analyze_edge_decay(trades, config)
         assert rec is None
 
@@ -181,14 +349,15 @@ class TestKellyOptimization:
         assert analyze_kelly_optimization(trades, config) is None
 
     def test_recommends_adjustment(self, config: GimmesConfig) -> None:
-        # High win rate with good payoff ratio should suggest higher Kelly
+        # High win rate with good payoff ratio should suggest higher
+        # Kelly. Hard assert — see TestThresholdSweep note (#656).
         trades = _make_trades(n_wins=25, n_losses=5, win_edge=0.20, loss_edge=-0.05)
         rec = analyze_kelly_optimization(trades, config)
-        if rec is not None:
-            assert rec.parameter_path == "sizing.kelly_fraction"
-            assert rec.analysis_type == AnalysisType.KELLY_OPTIMIZATION
-            assert float(rec.recommended_value) > 0
-            assert float(rec.recommended_value) <= 0.50
+        assert rec is not None
+        assert rec.parameter_path == "sizing.kelly_fraction"
+        assert rec.analysis_type == AnalysisType.KELLY_OPTIMIZATION
+        assert float(rec.recommended_value) > 0
+        assert float(rec.recommended_value) <= 0.50
 
     def test_no_wins(self, config: GimmesConfig) -> None:
         trades = _make_trades(n_wins=0, n_losses=25)
@@ -205,10 +374,11 @@ class TestScannerParameters:
             n_wins=20, n_losses=15,
             win_price=0.72, loss_price=0.58,
         )
+        # Hard assert — see TestThresholdSweep note (#656).
         rec = analyze_scanner_parameters(trades, config)
-        if rec is not None:
-            assert rec.analysis_type == AnalysisType.SCANNER_REVIEW
-            assert "strategy.m" in rec.parameter_path
+        assert rec is not None
+        assert rec.analysis_type == AnalysisType.SCANNER_REVIEW
+        assert "strategy.m" in rec.parameter_path
 
 
 class TestScoringCorrelation:

--- a/tests/unit/test_backfill_settlements.py
+++ b/tests/unit/test_backfill_settlements.py
@@ -141,6 +141,27 @@ def test_ghost_settlement_gets_close_at_historical_timestamp(
     assert c["timestamp"].startswith("2026-04-24")
 
 
+def test_backfill_close_carries_entry_analytics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#656: the settlement close inherits the open row's analytics
+    (seeded prob 0.8 / score 70 / edge 0.1 / kelly 0.02) instead of
+    TradeDecision's 0.0 defaults — calibration audits read entry vs
+    outcome off the close row directly."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+
+    [c] = _closes(db_path)
+    assert c["model_probability"] == 0.8
+    assert c["gimme_score"] == 70.0
+    assert c["edge"] == 0.1
+    assert c["kelly_fraction"] == 0.02
+
+
 def test_second_run_is_noop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_cli_close_analytics.py
+++ b/tests/unit/test_cli_close_analytics.py
@@ -1,0 +1,159 @@
+"""`log-trade` close rows inherit entry analytics (#656).
+
+A close logged without --prob carries the entry decision's
+model_probability/edge/kelly (and score, unless --score was given)
+instead of TradeDecision's 0.0 defaults. Real seeded DB + CliRunner,
+following the test_backfill_settlements pattern (synchronous seeding;
+the CLI drives its own asyncio.run).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import get_trades, insert_trade
+
+runner = CliRunner()
+
+TICKER = "KXCPI-26APR-T0.5"
+
+
+def _patch_config(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.strategy.side = "yes"
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+
+def _seed_open(db_path: Path) -> None:
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            t = TradeDecision(
+                ticker=TICKER,
+                action=TradeDecision.Action.OPEN,
+                side="yes",
+                count=10,
+                price=0.60,
+                model_probability=0.9,
+                gimme_score=82.0,
+                edge=0.25,
+                kelly_fraction=0.03,
+                rationale="entry",
+                agent="closer",
+            )
+            t.timestamp = datetime(2026, 4, 20, 12, tzinfo=UTC)
+            await insert_trade(db, t)
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+
+
+def _close_row(db_path: Path) -> dict:
+    async def _r() -> dict:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            trades = await get_trades(db, ticker=TICKER)
+            [c] = [t for t in trades if t["action"] == "close"]
+            return c
+        finally:
+            await db.close()
+
+    return asyncio.run(_r())
+
+
+def _invoke_close(*extra: str) -> object:
+    return runner.invoke(app, [
+        "log-trade", TICKER, "--action", "close",
+        "--side", "yes", "--count", "10", "--price", "0.80",
+        *extra,
+    ])
+
+
+def test_close_without_prob_inherits_entry_analytics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_open(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_close()
+    assert result.exit_code == 0, result.output
+
+    c = _close_row(db_path)
+    assert c["model_probability"] == 0.9
+    assert c["gimme_score"] == 82.0
+    assert c["edge"] == 0.25
+    assert c["kelly_fraction"] == 0.03
+
+
+def test_close_with_explicit_prob_keeps_close_time_semantics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gimmes.strategy.scanner import effective_price
+
+    db_path = tmp_path / "test.db"
+    _seed_open(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_close("--prob", "0.5")
+    assert result.exit_code == 0, result.output
+
+    c = _close_row(db_path)
+    assert c["model_probability"] == 0.5
+    assert c["edge"] == pytest.approx(0.5 - effective_price(0.80, "yes"))
+    assert c["gimme_score"] == 0.0
+    assert c["kelly_fraction"] == 0.0
+
+
+def test_explicit_score_survives_inheritance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_open(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_close("--score", "55")
+    assert result.exit_code == 0, result.output
+
+    c = _close_row(db_path)
+    assert c["gimme_score"] == 55.0
+    # prob/edge/kelly still inherited from the entry
+    assert c["model_probability"] == 0.9
+    assert c["edge"] == 0.25
+    assert c["kelly_fraction"] == 0.03
+
+
+def test_close_without_entry_keeps_zeros(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+
+    async def _bare() -> None:
+        db = Database(db_path)
+        await db.connect()
+        await db.close()
+
+    asyncio.run(_bare())
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_close()
+    assert result.exit_code == 0, result.output
+
+    c = _close_row(db_path)
+    assert c["model_probability"] == 0.0
+    assert c["edge"] == 0.0
+    assert c["gimme_score"] == 0.0

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -12,6 +12,7 @@ the Kalshi client for ``market-info``, and invokes the CLI through
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -88,20 +89,24 @@ def _config(db_path: Path) -> MagicMock:
     return c
 
 
-def _ticker_column_text(output: str) -> str:
-    """Concatenate the first (Ticker) column's content across every
-    body row of a Rich table, including fold-continuation rows. Lets
-    tests assert a full ticker appears even when Rich wraps it across
-    cell rows (#567)."""
+def _column_text(output: str, index: int) -> str:
+    """Concatenate one column's content across every body row of a
+    Rich table, including fold-continuation rows. Lets tests assert a
+    cell value appears even when Rich wraps it across rows (#567)."""
     parts: list[str] = []
     for line in output.splitlines():
         if not line.startswith("│"):
             continue
         segments = line.split("│")
-        if len(segments) < 3:
+        if len(segments) <= index + 1:
             continue
-        parts.append(segments[1].strip())
+        parts.append(segments[index].strip())
     return "".join(parts)
+
+
+def _ticker_column_text(output: str) -> str:
+    """First (Ticker) column's concatenated content."""
+    return _column_text(output, 1)
 
 
 class TestPositionContext:
@@ -258,6 +263,42 @@ class TestTradesCommand:
         # (KXCPI-26APR-T0.5 is NOT a prefix of KXCPI-26MAY-T0.6, so
         #  the natural behavior excludes it.)
         assert "KXCPI-26MAY-T0.6" not in ticker_col
+
+    def test_prob_and_outcome_columns(self, seeded_db: Path) -> None:
+        """#656: the trades table exposes the entry probability and
+        the market's resolution so calibration audits (entry prob vs
+        resolved outcome) work through the CLI."""
+
+        async def _resolve() -> None:
+            db = Database(seeded_db)
+            await db.connect()
+            try:
+                # side is 'yes' in the fixture — 'no' means it lost.
+                # 'no' is also unambiguous in the rendered table (the
+                # Side cells all say 'yes'; 'yes' would be vacuous).
+                await db.conn.execute(
+                    "UPDATE trades SET resolved_outcome = 'no'"
+                    " WHERE ticker = 'KXCPI-26APR-T0.5'",
+                )
+                await db.conn.commit()
+            finally:
+                await db.close()
+
+        asyncio.run(_resolve())
+        # 10 columns don't fit an 80-col terminal — headers get
+        # crushed to nothing. Widen so every header renders.
+        with patch("gimmes.config.GIMMES_HOME", seeded_db.parent), \
+                patch.dict(os.environ, {"COLUMNS": "200"}):
+            result = runner.invoke(app, ["trades", "-n", "10"])
+        assert result.exit_code == 0, result.output
+        assert "Prob" in result.output
+        assert "Outcome" in result.output
+        # Fixture trades carry model_probability=0.6 → rendered 60.0%
+        assert "60.0%" in result.output
+        outcome_col = _column_text(result.output, 9)
+        assert "no" in outcome_col
+        # Unresolved rows render a blank Outcome, not "None"
+        assert "None" not in outcome_col
 
     def test_wildcard_in_input_is_rejected(self, seeded_db: Path) -> None:
         # ``trades`` must apply the same wildcard guard as the other

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -8,10 +8,12 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from gimmes.models.error import ErrorCategory, ErrorSeverity
 from gimmes.models.order import Order, OrderAction, OrderSide
 from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
 
 _ORDER_CLI_ARGS = [
     "order", "TEST-TICKER",
@@ -91,7 +93,7 @@ def _stub_config():
 def _run_order_cli(
     broker, *, sync_side_effect=None, championship_create_order=None,
     insert_error_side_effect=None, extra_args=None, market=None,
-    snapshot_mock=None, validation=None,
+    snapshot_mock=None, validation=None, cli_args=None,
 ):
     """Invoke the order CLI command with a mocked broker.
 
@@ -181,7 +183,8 @@ def _run_order_cli(
         from gimmes.cli import app
 
         runner = CliRunner()
-        cli_args = _ORDER_CLI_ARGS + (extra_args or [])
+        if cli_args is None:
+            cli_args = _ORDER_CLI_ARGS + (extra_args or [])
         result = runner.invoke(app, cli_args)
     finally:
         for p in patches:
@@ -884,3 +887,105 @@ class TestOrderValidationMarkupEscape:
         # Escaped markup contains the literal backslash-bracket form on
         # BOTH the summary line and the per-failure line.
         assert printed.count("\\[sole") >= 2, printed
+
+
+# ---------------------------------------------------------------------------
+# #656: order-close entry-analytics inheritance
+# ---------------------------------------------------------------------------
+
+_SELL_CLI_ARGS = [
+    "order", "TEST-TICKER", "--action", "sell",
+    "--side", "yes", "--count", "10", "--price", "40", "--yes",
+]
+
+_ENTRY = {
+    "model_probability": 0.9, "gimme_score": 82.0,
+    "edge": 0.25, "kelly_fraction": 0.03,
+}
+
+
+class TestCloseInheritsEntryAnalytics:
+    """#656: the capital-deployment close path. Without an explicit
+    --prob, the recorded close row inherits the entry decision's
+    analytics; with one, close-time semantics are preserved."""
+
+    @staticmethod
+    def _broker_with_position():
+        """Sell orders require an existing position to close."""
+        pos = Position(
+            ticker="TEST-TICKER", side="yes", count=100,
+            avg_price=0.60, market_price=0.60, cost_basis=60.0,
+        )
+        return _make_mock_broker(get_positions_side_effect=lambda: [pos])
+
+    @staticmethod
+    def _capture():
+        captured = {}
+
+        async def _sync(db, positions, trade):
+            captured["trade"] = trade
+
+        return captured, _sync
+
+    def test_close_without_prob_inherits_entry_analytics(self) -> None:
+        broker = self._broker_with_position()
+        captured, sync = self._capture()
+        entry_mock = AsyncMock(return_value=dict(_ENTRY))
+        with patch("gimmes.store.queries.get_entry_analytics", entry_mock):
+            result, mock_console, _ = _run_order_cli(
+                broker, sync_side_effect=sync, cli_args=_SELL_CLI_ARGS,
+            )
+        assert result.exit_code == 0, _printed(mock_console)
+        t = captured["trade"]
+        assert t.action is TradeDecision.Action.CLOSE
+        assert t.model_probability == 0.9
+        assert t.gimme_score == 82.0
+        assert t.edge == 0.25
+        assert t.kelly_fraction == 0.03
+        entry_mock.assert_awaited_once()
+
+    def test_close_with_explicit_prob_keeps_close_time_semantics(
+        self,
+    ) -> None:
+        broker = self._broker_with_position()
+        captured, sync = self._capture()
+        entry_mock = AsyncMock(return_value=dict(_ENTRY))
+        with patch("gimmes.store.queries.get_entry_analytics", entry_mock):
+            result, mock_console, _ = _run_order_cli(
+                broker, sync_side_effect=sync,
+                cli_args=[*_SELL_CLI_ARGS, "--prob", "0.55"],
+            )
+        assert result.exit_code == 0, _printed(mock_console)
+        t = captured["trade"]
+        # Close-time prob/edge, no inherited analytics
+        assert t.model_probability == 0.55
+        assert t.edge == pytest.approx(0.55 - t.price)
+        assert t.gimme_score == 0.0
+        assert t.kelly_fraction == 0.0
+        entry_mock.assert_not_awaited()
+
+    def test_open_path_unchanged_no_entry_fetch(self) -> None:
+        broker = _make_mock_broker()
+        captured, sync = self._capture()
+        entry_mock = AsyncMock(return_value=dict(_ENTRY))
+        # The buy path fetches a thesis before building the trade —
+        # stub those DB lookups (they'd run against the mock DB).
+        with patch("gimmes.store.queries.get_entry_analytics", entry_mock), \
+                patch(
+                    "gimmes.store.queries.get_thesis_for_ticker",
+                    AsyncMock(return_value=""),
+                ), \
+                patch(
+                    "gimmes.store.queries.get_open_trade_for_ticker",
+                    AsyncMock(return_value=None),
+                ):
+            result, mock_console, _ = _run_order_cli(
+                broker, sync_side_effect=sync,
+            )
+        assert result.exit_code == 0, _printed(mock_console)
+        t = captured["trade"]
+        assert t.action is TradeDecision.Action.OPEN
+        # _ORDER_CLI_ARGS pass --prob 0.55: open semantics untouched
+        assert t.model_probability == 0.55
+        assert t.gimme_score == 0.0
+        entry_mock.assert_not_awaited()

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -989,3 +989,21 @@ class TestCloseInheritsEntryAnalytics:
         assert t.model_probability == 0.55
         assert t.gimme_score == 0.0
         entry_mock.assert_not_awaited()
+
+    def test_entry_fetch_failure_still_records_close(self) -> None:
+        """A transient DB error in the best-effort analytics fetch must
+        not become 'position sync failed' — the close records with
+        zeroed analytics (#656 Copilot review)."""
+        broker = self._broker_with_position()
+        captured, sync = self._capture()
+        entry_mock = AsyncMock(side_effect=sqlite3.OperationalError("locked"))
+        with patch("gimmes.store.queries.get_entry_analytics", entry_mock):
+            result, mock_console, _ = _run_order_cli(
+                broker, sync_side_effect=sync, cli_args=_SELL_CLI_ARGS,
+            )
+        assert result.exit_code == 0, _printed(mock_console)
+        t = captured["trade"]
+        assert t.action is TradeDecision.Action.CLOSE
+        assert t.model_probability == 0.0
+        assert t.edge == 0.0
+        assert "position sync failed" not in _printed(mock_console).lower()

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 
 from gimmes.models.portfolio import Position
 from gimmes.models.trade import TradeDecision
 from gimmes.store.database import Database
 from gimmes.store.queries import (
+    get_entry_analytics,
     get_positions,
     get_trades,
     insert_trade,
@@ -331,6 +334,109 @@ class TestReconcileDriftLogsSyntheticClose:
         assert len(trades) == 1
         assert trades[0]["price"] == 0.0
         assert trades[0]["agent"] == "reconcile"
+
+
+def _open_trade(
+    ticker: str,
+    *,
+    action: str = "open",
+    prob: float = 0.9,
+    score: float = 82.0,
+    edge: float = 0.25,
+    kelly: float = 0.03,
+    ts: str = "2026-04-20T12:00:00+00:00",
+) -> TradeDecision:
+    t = TradeDecision(
+        ticker=ticker,
+        action=TradeDecision.Action(action),
+        side="yes",
+        count=10,
+        price=0.60,
+        model_probability=prob,
+        gimme_score=score,
+        edge=edge,
+        kelly_fraction=kelly,
+        rationale="entry",
+        agent="closer",
+    )
+    t.timestamp = datetime.fromisoformat(ts)
+    return t
+
+
+class TestReconcileCloseCarriesEntryAnalytics:
+    """#656: synthetic drift closes inherit the entry decision's
+    analytics instead of TradeDecision's 0.0 defaults."""
+
+    async def test_drift_close_inherits_entry_analytics(self, db):
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=0.42),
+        )
+
+        await sync_positions(db, [])
+
+        closes = [
+            t for t in await get_trades(db) if t["action"] == "close"
+        ]
+        assert len(closes) == 1
+        c = closes[0]
+        assert c["agent"] == "reconcile"
+        assert c["model_probability"] == 0.9
+        assert c["gimme_score"] == 82.0
+        assert c["edge"] == 0.25
+        assert c["kelly_fraction"] == 0.03
+
+    async def test_drift_close_without_open_keeps_zeros(self, db):
+        """No entry on record (pre-#609 DBs, seeded positions) — the
+        drift close still writes, with honest zeros."""
+        await upsert_position(db, _pos("NO-HISTORY", count=10, price=0.42))
+
+        await sync_positions(db, [])
+
+        [c] = await get_trades(db)
+        assert c["action"] == "close"
+        assert c["model_probability"] == 0
+        assert c["gimme_score"] == 0
+        assert c["edge"] == 0
+
+
+class TestGetEntryAnalytics:
+    async def test_returns_latest_entry_row(self, db):
+        await insert_trade(db, _open_trade(
+            "T", prob=0.7, score=60.0, ts="2026-04-01T12:00:00+00:00",
+        ))
+        await insert_trade(db, _open_trade(
+            "T", action="size_up", prob=0.85, score=75.0, edge=0.18,
+            kelly=0.04, ts="2026-04-05T12:00:00+00:00",
+        ))
+
+        entry = await get_entry_analytics(db, "T", "yes")
+        assert entry == {
+            "model_probability": 0.85,
+            "gimme_score": 75.0,
+            "edge": 0.18,
+            "kelly_fraction": 0.04,
+        }
+
+    async def test_ignores_close_rows(self, db):
+        close = _open_trade("T", prob=0.0, score=0.0, edge=0.0, kelly=0.0,
+                            ts="2026-04-09T12:00:00+00:00")
+        close.action = TradeDecision.Action.CLOSE
+        await insert_trade(db, _open_trade(
+            "T", prob=0.9, ts="2026-04-01T12:00:00+00:00",
+        ))
+        await insert_trade(db, close)
+
+        entry = await get_entry_analytics(db, "T", "yes")
+        assert entry is not None
+        assert entry["model_probability"] == 0.9
+
+    async def test_none_when_no_entry(self, db):
+        assert await get_entry_analytics(db, "MISSING", "yes") is None
+
+    async def test_side_must_match(self, db):
+        await insert_trade(db, _open_trade("T"))  # side yes
+        assert await get_entry_analytics(db, "T", "no") is None
 
 
 def test_caddie_master_lockout_query_does_not_match_reconcile_body() -> None:


### PR DESCRIPTION
## Summary

**The strategy's automated tuning loop has never worked.** Every close row carried zeroed analytics (all synthetic and CLI close writers inherited `TradeDecision`'s 0.0 defaults), and every `gimmes lesson` analysis classified wins via `edge > 0` **on the close row** — always false, so all four analyses returned None on every run since the advisor shipped (recommendations table empty at N=31 closes). Merely copying entry edge onto closes would have inverted the bug: opens are min_edge-gated, so every close would have read as a win.

### The fix
- **`_pair_closes`** (advisor.py) derives outcomes by pairing closes to their opens — mirrors `calculate_pnl`'s (ticker, side) chronological walk (running avg cost, `size_up` roll-in, reconcile closes repriced at settlement value when resolution is known). `won` is resolution-first (`side == resolved_outcome`) with realized-return fallback. Threshold sweep/scanner consume won-lost (prediction quality); Kelly/edge-decay consume per-contract realized returns (money — entry edge is identical on both legs and cannot express payoff or decay). Pairing at analysis time fixes the 31 historical zero-analytics rows **with no backfill**.
- **`get_entry_analytics`** (queries.py) makes close rows self-descriptive going forward: settlement, reconcile, `order` close, and `log-trade` close inherit the entry's prob/score/edge/kelly; explicit `--prob`/`--score` still win; missing-entry settlement closes debug-log.
- **`gimmes trades`** gains **Prob** and **Outcome** columns — calibration audits (entry probability vs resolution) now work through the CLI.

## Review
Full pipeline + simplifier. Mutation-verified by the test analyzer on scratchpad copies: full revert kills the dead-loop regression test (old code provably yields zero recs on production-shaped data); 10+ targeted mutations killed including the anti-inversion case; three surviving mutations (per-analysis reverts hiding behind `if rec is not None:` guards) fixed by hardening those tests to hard asserts. Deferred hardening (lesson's 1000-row window orphaning, side-aware outcome keys, writer robustness) tracked in **#668**.

## Test plan
- `uv run pytest tests/unit/test_advisor.py tests/unit/test_sync_positions.py tests/unit/test_backfill_settlements.py tests/unit/test_cli_close_analytics.py tests/unit/test_order_error_handling.py tests/unit/test_cli_ticker_prefix.py`
- Full suite: 1666 passed; ruff clean.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB