### PR TITLE
Fix #657: skip rows backfill candidate analytics + structured reasons

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -272,7 +272,7 @@ Evaluate the output using these rules (where `gimme_threshold` is from Step 0.5,
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Cooldown: prior score SCORE (below cutoff), skipping re-research
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --price 0 --prob 0 --score 0 \
+   gimmes log-trade TICKER --action skip --reason cooldown \
      --rationale-file "$RATIONALE_FILE" --agent caddie-master
    rm -f "$RATIONALE_FILE"
    ```
@@ -308,7 +308,7 @@ RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
 cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
 Caddie failed to research after retry
 GIMMES_EOF
-gimmes log-trade TICKER --action skip --price 0 --prob 0 --score 0 \
+gimmes log-trade TICKER --action skip --reason research_failed \
   --rationale-file "$RATIONALE_FILE" --agent caddie-master
 rm -f "$RATIONALE_FILE"
 ```
@@ -413,7 +413,7 @@ For each PROCEED candidate:
      --body-file "$BODY_FILE"
    rm -f "$BODY_FILE"
    ```
-   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate.
+   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with `--reason review_reject` and rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate.
 
 6. **Log rejected candidates as skips** so the decision is auditable (use the `--rationale-file` heredoc pattern, #589):
    ```bash
@@ -421,7 +421,7 @@ For each PROCEED candidate:
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Caddie Master review: REJECT — [brief reason]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --price 0 --prob P --score S \
+   gimmes log-trade TICKER --action skip --reason review_reject \
      --rationale-file "$RATIONALE_FILE" --agent caddie-master
    rm -f "$RATIONALE_FILE"
    ```

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -27,7 +27,7 @@ For each approved candidate (GimmeScore >= configured `strategy.gimme_threshold`
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    [which check failed and why]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --prob P --score S --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason validation_failed --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
    If the command fails, note the failure in your output and continue. Do not retry.
@@ -51,7 +51,7 @@ When Caddie Master dispatches you for a SIZE UP (adding to an existing position)
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    SIZE UP rejected: [which check failed]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --prob P --score 0 --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason validation_failed --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
 
@@ -67,7 +67,7 @@ When Caddie Master dispatches you to CLOSE a position (sell all held contracts),
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Close skipped: no open position found
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason no_position --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
 2. **Cancel resting orders**: If any resting orders exist for TICKER, cancel them first with `gimmes cancel ORDER_ID --yes`.
@@ -79,7 +79,7 @@ When Caddie Master dispatches you to CLOSE a position (sell all held contracts),
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Close order failed: [error from CLI output]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason close_failed --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
    If the command fails, note the failure in your output and continue. Do not retry.
@@ -106,7 +106,7 @@ If the order command fails (non-zero exit code or error output), MUST:
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Order failed: [error from CLI output]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --prob P --score S --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason order_failed --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
 2. If the log-trade command itself fails, note the failure in your output and continue. Do not retry failed log commands.

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2085,6 +2085,11 @@ def log_trade(
             f" {', '.join(sorted(_SKIP_REASONS))}",
             param_hint="--reason",
         )
+    if reason and action != "skip":
+        raise typer.BadParameter(
+            f"--reason is a skip cause; not valid with --action {action}",
+            param_hint="--reason",
+        )
     rationale_val = _resolve_prose_arg(
         rationale, rationale_file, "--rationale", "--rationale-file",
     )

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2037,6 +2037,21 @@ def market_info(
     _run(_info())
 
 
+# #657: the closed vocabulary for `log-trade --reason`. A SQL-queryable
+# column beats prose rationales for the Pro agent's proceed-conversion
+# and skip audits.
+_SKIP_REASONS = frozenset({
+    "cooldown", "research_failed", "review_reject", "validation_failed",
+    "order_failed", "close_failed", "no_position", "price_moved",
+    "liquidity",
+})
+
+# Close-workflow skips carry no entry decision — backfilling scan-time
+# candidate analytics onto them would fabricate a "missed entry" the
+# advisor then audits (#657 review). They keep honest zeros instead.
+_NON_ENTRY_REASONS = frozenset({"no_position", "close_failed"})
+
+
 @app.command(name="log-trade", hidden=True)
 def log_trade(
     ticker: str = typer.Argument(..., help="Market ticker"),
@@ -2056,18 +2071,35 @@ def log_trade(
             " (#589)."
         ),
     ),
+    reason: str = typer.Option(
+        "", "--reason",
+        help="Structured skip cause (#657): " + "|".join(sorted(_SKIP_REASONS)),
+    ),
     agent: str = typer.Option("manual", "--agent"),
 ) -> None:
     """Log a trade decision to the database."""
     config = load_config()
+    if reason and reason not in _SKIP_REASONS:
+        raise typer.BadParameter(
+            f"unknown --reason {reason!r}; expected one of:"
+            f" {', '.join(sorted(_SKIP_REASONS))}",
+            param_hint="--reason",
+        )
     rationale_val = _resolve_prose_arg(
         rationale, rationale_file, "--rationale", "--rationale-file",
     )
 
     async def _log() -> None:
+        import logging
+        import sqlite3
+
         from gimmes.models.trade import TradeDecision
         from gimmes.store.database import Database
-        from gimmes.store.queries import get_entry_analytics, insert_trade
+        from gimmes.store.queries import (
+            get_candidate_for_ticker,
+            get_entry_analytics,
+            insert_trade,
+        )
         from gimmes.strategy.scanner import effective_price
 
         resolved_side = side if side else config.strategy.side
@@ -2082,6 +2114,7 @@ def log_trade(
             gimme_score=score_val,
             edge=(prob - eff) if prob is not None else 0.0,
             rationale=rationale_val,
+            reason=reason,
             agent=agent,
         )
 
@@ -2096,6 +2129,57 @@ def log_trade(
                     trade.kelly_fraction = entry["kelly_fraction"]
                     if not score_val:
                         trade.gimme_score = entry["gimme_score"]
+            # #657: a skip with missing/zeroed analytics inherits the
+            # latest candidate row's scan-time values — degenerate
+            # skips (prob 0 -> edge = price - 100%) were polluting the
+            # missed-opportunity audit. prob <= 0 counts as "unknown"
+            # HERE ONLY: a probability of 0 is never a meaningful
+            # model estimate for a skip. Do NOT extend that rule to
+            # open/size_up — prob=0 bypassing validation gates was
+            # bug #180. Explicit nonzero args win, field by field.
+            elif trade.action is TradeDecision.Action.SKIP and (
+                (prob_missing := prob is None or prob <= 0)
+                or price_val <= 0 or score_val <= 0
+            ) and reason not in _NON_ENTRY_REASONS:
+                # Best-effort: a failed read degrades to zeros — a
+                # degenerate skip row beats a missing one (log-trade
+                # is the agents' logger of last resort).
+                try:
+                    rows = await get_candidate_for_ticker(db, ticker)
+                except sqlite3.Error:
+                    logging.getLogger(__name__).error(
+                        "candidate lookup failed for %s skip;"
+                        " analytics default to 0 (#657)",
+                        ticker, exc_info=True,
+                    )
+                    rows = []
+                if rows:
+                    cand = rows[0]
+                    if prob_missing:
+                        trade.model_probability = (
+                            cand["model_probability"] or 0.0
+                        )
+                    if price_val <= 0:
+                        trade.price = cand["market_price"] or 0.0
+                    if score_val <= 0:
+                        trade.gimme_score = cand["gimme_score"] or 0.0
+                else:
+                    logging.getLogger(__name__).debug(
+                        "skip for %s found no candidate row —"
+                        " analytics default to 0 (#657)", ticker,
+                    )
+                # Normalize edge UNCONDITIONALLY: the constructor
+                # value was computed from the pre-backfill args, and
+                # with prob 0 it is the degenerate -effective_price
+                # (the price - 100% signature this fix exists to
+                # kill). Unknown probability -> unknown edge, not a
+                # fabricated one.
+                trade.edge = (
+                    trade.model_probability
+                    - effective_price(trade.price, resolved_side)
+                    if trade.model_probability > 0 and trade.price > 0
+                    else 0.0
+                )
             row_id = await insert_trade(db, trade)
             console.print(f"[green]Logged trade #{row_id}: {action} {ticker}[/green]")
 

--- a/src/gimmes/models/trade.py
+++ b/src/gimmes/models/trade.py
@@ -29,6 +29,9 @@ class TradeDecision(BaseModel):
     kelly_fraction: float = 0.0
     rationale: str = ""
     thesis: str = ""
+    # Structured skip cause (#657) — machine-queryable, unlike the
+    # prose rationale. Empty for non-skip rows and legacy data.
+    reason: str = ""
     agent: str = ""  # Which agent made the decision
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC)

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -109,6 +109,13 @@ _V17_COLUMNS: list[str] = [
     "ALTER TABLE positions ADD COLUMN rules_primary TEXT NOT NULL DEFAULT ''",
 ]
 
+# Version 18 (#657): structured skip reason on trades — lets the Pro
+# agent and the advisor query WHY a skip happened (validation_failed,
+# cooldown, ...) instead of grepping prose rationales.
+_V18_COLUMNS: list[str] = [
+    "ALTER TABLE trades ADD COLUMN reason TEXT NOT NULL DEFAULT ''",
+]
+
 
 
 async def get_schema_version(db: Database) -> int:
@@ -340,5 +347,14 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 17
+
+    # Version 18 (#657): structured skip reason column on trades.
+    if current < 18:
+        await _run_alter_columns(db, _V18_COLUMNS)
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (18,)
+        )
+        await db.conn.commit()
+        current = 18
 
     return current

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -44,8 +44,9 @@ async def _insert_trade_row(db: Database, trade: TradeDecision) -> int:
     cursor = await db.conn.execute(
         """INSERT INTO trades
            (ticker, action, side, count, price, model_probability,
-            gimme_score, edge, kelly_fraction, rationale, thesis, agent, order_id, timestamp)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            gimme_score, edge, kelly_fraction, rationale, thesis, reason,
+            agent, order_id, timestamp)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             trade.ticker,
             trade.action.value,
@@ -58,6 +59,7 @@ async def _insert_trade_row(db: Database, trade: TradeDecision) -> int:
             trade.kelly_fraction,
             trade.rationale,
             trade.thesis,
+            trade.reason,
             trade.agent,
             trade.order_id,
             trade.timestamp.isoformat(),

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -482,14 +482,22 @@ def analyze_missed_opportunities(
     # #657: exclude degenerate skip rows (no probability AND no price
     # recorded) — they carry no signal but inflate the denominator of
     # false_negative_rate and the MIN_SKIPS_AUDIT gate, suppressing
-    # legitimate recommendations. The excluded count is surfaced in
+    # legitimate recommendations. Close-workflow skips (no_position,
+    # close_failed — cli._NON_ENTRY_REASONS) are excluded outright:
+    # a failed close is never a missed ENTRY, whatever analytics the
+    # row carries. Both exclusion counts are surfaced in
     # supporting_data so an audit reconciles against the raw table.
     all_skips = [t for t in trades if t.get("action") == "skip"]
-    skips = [
+    entry_skips = [
         t for t in all_skips
+        if t.get("reason", "") not in ("no_position", "close_failed")
+    ]
+    skips = [
+        t for t in entry_skips
         if t.get("model_probability", 0) > 0 or t.get("price", 0) > 0
     ]
-    excluded_degenerate = len(all_skips) - len(skips)
+    excluded_non_entry = len(all_skips) - len(entry_skips)
+    excluded_degenerate = len(entry_skips) - len(skips)
     if len(skips) < MIN_SKIPS_AUDIT:
         return None
 
@@ -535,6 +543,7 @@ def analyze_missed_opportunities(
             "missed_wins": len(missed_wins),
             "total_skips": len(skips),
             "excluded_degenerate": excluded_degenerate,
+            "excluded_non_entry": excluded_non_entry,
             "near_misses": len(near_misses),
             "avg_missed_score": round(avg_missed_score, 1),
         }),

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -479,7 +479,17 @@ def analyze_missed_opportunities(
 
     Requires skip logging to be in place (see issue #20).
     """
-    skips = [t for t in trades if t.get("action") == "skip"]
+    # #657: exclude degenerate skip rows (no probability AND no price
+    # recorded) — they carry no signal but inflate the denominator of
+    # false_negative_rate and the MIN_SKIPS_AUDIT gate, suppressing
+    # legitimate recommendations. The excluded count is surfaced in
+    # supporting_data so an audit reconciles against the raw table.
+    all_skips = [t for t in trades if t.get("action") == "skip"]
+    skips = [
+        t for t in all_skips
+        if t.get("model_probability", 0) > 0 or t.get("price", 0) > 0
+    ]
+    excluded_degenerate = len(all_skips) - len(skips)
     if len(skips) < MIN_SKIPS_AUDIT:
         return None
 
@@ -524,6 +534,7 @@ def analyze_missed_opportunities(
             "false_negative_rate": round(false_negative_rate, 3),
             "missed_wins": len(missed_wins),
             "total_skips": len(skips),
+            "excluded_degenerate": excluded_degenerate,
             "near_misses": len(near_misses),
             "avg_missed_score": round(avg_missed_score, 1),
         }),

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -397,26 +398,115 @@ class TestMissedOpportunities:
         trades = _make_trades(n_wins=20, n_losses=10)
         assert analyze_missed_opportunities(trades, config) is None
 
-    def test_detects_false_negatives(self, config: GimmesConfig) -> None:
+    @staticmethod
+    def _real_skips(n_wins: int = 15, n_losses: int = 10) -> list[dict]:
+        """Production-shaped skips: price and prob recorded (#657)."""
         trades: list[dict] = []
         # Skips that would have won (score just below threshold of 75)
-        for i in range(15):
+        for i in range(n_wins):
             trades.append({
                 "ticker": f"SKIP-WIN-{i}", "action": "skip",
-                "gimme_score": 72, "edge": 0.15,
+                "gimme_score": 72, "edge": 0.15, "price": 0.65,
+                "model_probability": 0.85,
                 "timestamp": f"2026-01-{(i % 28) + 1:02d}T10:00:00",
             })
         # Skips that correctly lost
-        for i in range(10):
+        for i in range(n_losses):
             trades.append({
                 "ticker": f"SKIP-LOSS-{i}", "action": "skip",
-                "gimme_score": 60, "edge": -0.05,
+                "gimme_score": 60, "edge": -0.05, "price": 0.60,
+                "model_probability": 0.55,
                 "timestamp": f"2026-02-{(i % 28) + 1:02d}T10:00:00",
             })
-        rec = analyze_missed_opportunities(trades, config)
-        if rec is not None:
-            assert rec.analysis_type == AnalysisType.MISSED_OPPORTUNITY
-            assert int(rec.recommended_value) < 75
+        return trades
+
+    @staticmethod
+    def _degenerate_skips(n: int) -> list[dict]:
+        """The #657 rows: no probability, no price recorded."""
+        return [{
+            "ticker": f"DEGEN-{i}", "action": "skip",
+            "gimme_score": 0, "edge": 0.0, "price": 0.0,
+            "model_probability": 0.0,
+            "timestamp": f"2026-03-{(i % 28) + 1:02d}T10:00:00",
+        } for i in range(n)]
+
+    def test_detects_false_negatives(self, config: GimmesConfig) -> None:
+        # Hard assert — this data fires the analysis (25 skips, 60%
+        # false-negative rate, near-misses averaging 72).
+        rec = analyze_missed_opportunities(self._real_skips(), config)
+        assert rec is not None
+        assert rec.analysis_type == AnalysisType.MISSED_OPPORTUNITY
+        assert int(rec.recommended_value) < 75
+
+    def test_degenerate_skips_excluded_from_denominator(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#657: zero-prob/zero-price rows must not dilute the
+        false-negative rate or the sample gate — the analysis output
+        is identical with or without 40 degenerate rows mixed in,
+        and the exclusion is visible in supporting_data."""
+        clean = analyze_missed_opportunities(self._real_skips(), config)
+        polluted = analyze_missed_opportunities(
+            self._real_skips() + self._degenerate_skips(40), config,
+        )
+        assert clean is not None
+        assert polluted is not None
+        assert polluted.recommended_value == clean.recommended_value
+        clean_data = json.loads(clean.supporting_data)
+        polluted_data = json.loads(polluted.supporting_data)
+        # The 40 junk rows dilute the old code to fnr 15/65 = 0.231;
+        # excluded, the rate stays 0.6.
+        assert polluted_data["false_negative_rate"] == pytest.approx(0.6)
+        assert polluted_data["total_skips"] == clean_data["total_skips"]
+        # The exclusion is auditable, not silent (#668 lesson).
+        assert clean_data["excluded_degenerate"] == 0
+        assert polluted_data["excluded_degenerate"] == 40
+
+    def test_half_degenerate_rows_are_retained(
+        self, config: GimmesConfig,
+    ) -> None:
+        """A skip with EITHER a probability OR a price recorded still
+        carries signal — only rows missing both are excluded."""
+        prob_only = [{
+            "ticker": f"PROB-{i}", "action": "skip", "gimme_score": 72,
+            "edge": 0.15, "price": 0.0, "model_probability": 0.85,
+            "timestamp": f"2026-04-{(i % 28) + 1:02d}T10:00:00",
+        } for i in range(3)]
+        price_only = [{
+            "ticker": f"PRICE-{i}", "action": "skip", "gimme_score": 60,
+            "edge": -0.05, "price": 0.60, "model_probability": 0.0,
+            "timestamp": f"2026-05-{(i % 28) + 1:02d}T10:00:00",
+        } for i in range(3)]
+        rec = analyze_missed_opportunities(
+            self._real_skips() + prob_only + price_only, config,
+        )
+        assert rec is not None
+        data = json.loads(rec.supporting_data)
+        assert data["total_skips"] == 31  # 25 real + 3 + 3
+        assert data["excluded_degenerate"] == 0
+
+    def test_degenerate_rows_do_not_satisfy_the_gate(
+        self, config: GimmesConfig,
+    ) -> None:
+        """19 real skips + 40 degenerate: the old code passed the
+        MIN_SKIPS_AUDIT gate on the raw count (59 >= 20); after
+        exclusion the real sample (19) is honestly insufficient."""
+        rec = analyze_missed_opportunities(
+            self._real_skips(n_wins=12, n_losses=7)
+            + self._degenerate_skips(40),
+            config,
+        )
+        assert rec is None
+
+    def test_degenerate_skips_alone_are_insufficient(
+        self, config: GimmesConfig,
+    ) -> None:
+        """40 degenerate rows carry no signal — below the audit gate
+        after exclusion."""
+        rec = analyze_missed_opportunities(
+            self._degenerate_skips(40), config,
+        )
+        assert rec is None
 
 
 class TestRunAllAnalyses:

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -498,6 +498,31 @@ class TestMissedOpportunities:
         )
         assert rec is None
 
+    def test_non_entry_reason_skips_excluded_despite_analytics(
+        self, config: GimmesConfig,
+    ) -> None:
+        """A failed close is never a missed ENTRY — no_position and
+        close_failed skips stay out of the audit even when the row
+        carries full analytics (#657 review)."""
+        non_entry = [{
+            "ticker": f"CLOSEFAIL-{i}", "action": "skip",
+            "gimme_score": 90, "edge": 0.30, "price": 0.65,
+            "model_probability": 0.95,
+            "reason": "close_failed" if i % 2 else "no_position",
+            "timestamp": f"2026-06-{(i % 28) + 1:02d}T10:00:00",
+        } for i in range(10)]
+        clean = analyze_missed_opportunities(self._real_skips(), config)
+        polluted = analyze_missed_opportunities(
+            self._real_skips() + non_entry, config,
+        )
+        assert clean is not None
+        assert polluted is not None
+        data = json.loads(polluted.supporting_data)
+        # The phantom "missed entries" (edge 0.30) did not inflate
+        # missed_wins or the denominator.
+        assert data["false_negative_rate"] == pytest.approx(0.6)
+        assert data["excluded_non_entry"] == 10
+
     def test_degenerate_skips_alone_are_insufficient(
         self, config: GimmesConfig,
     ) -> None:

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -1824,3 +1824,74 @@ def test_no_agent_uses_inline_memo_body_rationale_for_prose() -> None:
         " heredoc instead. Offending sites:\n  "
         + "\n  ".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# #657: skip templates must not write degenerate analytics
+# ---------------------------------------------------------------------------
+
+_CLOSER = AGENTS_DIR / "closer.md"
+_SCOUT = AGENTS_DIR / "scout.md"
+
+
+def test_no_zeroed_skip_analytics_in_templates(
+    caddie_master_text: str,
+) -> None:
+    """The degenerate batches (#657) came from templates passing
+    explicit zeros. Skips now omit analytics flags — the CLI backfills
+    from the candidates table."""
+    import re
+
+    zero_flag = re.compile(r"--(?:prob|price|score) 0(?:\s|\\|$)")
+    closer_text = _CLOSER.read_text()
+    for text, name in (
+        (caddie_master_text, "caddie-master.md"),
+        (closer_text, "closer.md"),
+    ):
+        hits = [
+            line.strip() for line in text.splitlines()
+            if zero_flag.search(line)
+        ]
+        assert not hits, (
+            f"{name} passes explicit zero analytics to log-trade —"
+            f" that produced edge = price - 100% skip batches (#657):"
+            f" {hits}"
+        )
+
+
+def test_skip_templates_carry_structured_reason(
+    caddie_master_text: str,
+) -> None:
+    """Every skip template names a --reason so proceed→no-trade
+    conversions are queryable (#657)."""
+    closer_text = _CLOSER.read_text()
+    for fragment, text, name in (
+        ("--action skip --reason cooldown", caddie_master_text,
+         "caddie-master.md"),
+        ("--action skip --reason research_failed", caddie_master_text,
+         "caddie-master.md"),
+        ("--action skip --reason review_reject", caddie_master_text,
+         "caddie-master.md"),
+        ("--action skip --reason validation_failed", closer_text,
+         "closer.md"),
+        ("--action skip --reason order_failed", closer_text,
+         "closer.md"),
+        ("--action skip --reason close_failed", closer_text,
+         "closer.md"),
+        ("--action skip --reason no_position", closer_text,
+         "closer.md"),
+    ):
+        assert fragment in text, f"{name} lost the template: {fragment}"
+
+
+def test_scout_and_caddie_skip_templates_keep_real_analytics(
+    caddie_text: str,
+) -> None:
+    """Scout/Caddie skips happen at scan/research time when the agent
+    HAS the real values — their templates must keep passing them
+    (the CLI backfill is the fallback, not the primary path)."""
+    scout_text = _SCOUT.read_text()
+    for text, name in ((scout_text, "scout.md"), (caddie_text, "caddie.md")):
+        assert "--price 0.XX --prob 0.XX --score NN" in text, (
+            f"{name} skip template no longer passes real analytics"
+        )

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -250,6 +250,26 @@ def test_unknown_reason_rejected(
     assert result.exit_code != 0
 
 
+def test_reason_rejected_on_non_skip_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--reason is a skip cause — an open/close carrying one would be
+    semantically invalid data (#657 review)."""
+    db_path = tmp_path / "test.db"
+    _bare_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    for action in ("open", "close"):
+        result = runner.invoke(app, [
+            "log-trade", TICKER, "--action", action,
+            "--price", "0.6", "--prob", "0.8",
+            "--rationale", "test", "--reason", "cooldown",
+        ])
+        assert result.exit_code != 0, action
+    assert _trade_rows(db_path, "open") == []
+    assert _trade_rows(db_path, "close") == []
+
+
 def test_open_with_zero_args_does_not_backfill(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -1,0 +1,350 @@
+"""Skip rows inherit candidate analytics and carry a structured
+reason (#657).
+
+Degenerate skips (prob 0 → edge = price − 100%, $0.00 prices) came
+from agent templates passing zeros or omitting args; `log-trade` now
+backfills missing/zeroed skip analytics from the latest candidate row
+(the #656 CLOSE-inheritance precedent), and `--reason` persists a
+machine-queryable cause. Real seeded DB + CliRunner, following the
+test_cli_close_analytics pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.store.database import Database
+from gimmes.store.queries import get_trades, insert_candidate
+from gimmes.strategy.scanner import effective_price
+
+runner = CliRunner()
+
+TICKER = "KXCPI-26APR-T0.5"
+
+# Candidate row seeded at scan time: price 0.70, prob 0.85, score 82.
+CAND_PRICE = 0.70
+CAND_PROB = 0.85
+CAND_SCORE = 82.0
+
+
+def _patch_config(
+    monkeypatch: pytest.MonkeyPatch, db_path: Path, side: str = "no",
+) -> None:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.strategy.side = side
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+
+def _db_run(db_path: Path, fn: Callable[[Database], Awaitable[Any]]) -> Any:
+    """Open (creating/migrating) the DB, run `fn(db)`, close."""
+    async def _go() -> Any:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await fn(db)
+        finally:
+            await db.close()
+
+    return asyncio.run(_go())
+
+
+def _seed_candidate(
+    db_path: Path, side: str = "no", prob: float = CAND_PROB,
+) -> None:
+    async def _insert(db: Database) -> None:
+        edge = prob - effective_price(CAND_PRICE, side) if prob > 0 else 0.0
+        await insert_candidate(
+            db, TICKER, "CPI April", CAND_PRICE, prob, edge,
+            CAND_SCORE, "memo", recommendation="proceed",
+        )
+
+    _db_run(db_path, _insert)
+
+
+def _bare_db(db_path: Path) -> None:
+    """Create an empty (candidate-free) migrated database."""
+    async def _noop(db: Database) -> None:
+        pass
+
+    _db_run(db_path, _noop)
+
+
+def _trade_rows(db_path: Path, action: str = "skip") -> list[dict]:
+    async def _query(db: Database) -> list[dict]:
+        trades = await get_trades(db, ticker=TICKER)
+        return [t for t in trades if t["action"] == action]
+
+    return _db_run(db_path, _query)
+
+
+def _skip_row(db_path: Path) -> dict:
+    [s] = _trade_rows(db_path)
+    return s
+
+
+def _invoke_skip(*extra: str) -> object:
+    return runner.invoke(app, [
+        "log-trade", TICKER, "--action", "skip",
+        "--rationale", "test skip",
+        *extra,
+    ])
+
+
+def test_skip_without_args_inherits_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["model_probability"] == CAND_PROB
+    assert s["price"] == CAND_PRICE
+    assert s["gimme_score"] == CAND_SCORE
+    assert s["edge"] == pytest.approx(
+        CAND_PROB - effective_price(CAND_PRICE, "no"),
+    )
+
+
+def test_explicit_zeros_backfilled_like_omitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact degenerate template form (`--price 0 --prob 0
+    --score 0`) that produced edge = price − 100% batches."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip(
+        "--price", "0", "--prob", "0", "--score", "0",
+    )
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["model_probability"] == CAND_PROB
+    assert s["price"] == CAND_PRICE
+    assert s["gimme_score"] == CAND_SCORE
+    # The #657 symptom: NO-side edge must not be price - 100%
+    assert s["edge"] != pytest.approx(CAND_PRICE - 1.0)
+    assert s["edge"] > 0
+
+
+def test_explicit_nonzero_args_win(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip(
+        "--price", "0.55", "--prob", "0.75", "--score", "64",
+    )
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["model_probability"] == 0.75
+    assert s["price"] == 0.55
+    assert s["gimme_score"] == 64.0
+    assert s["edge"] == pytest.approx(
+        0.75 - effective_price(0.55, "no"),
+    )
+
+
+def test_mixed_explicit_prob_backfilled_price_score(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip("--prob", "0.8")
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["model_probability"] == 0.8
+    assert s["price"] == CAND_PRICE
+    assert s["gimme_score"] == CAND_SCORE
+    # Edge recomputed from the mixed final values
+    assert s["edge"] == pytest.approx(
+        0.8 - effective_price(CAND_PRICE, "no"),
+    )
+
+
+def test_no_candidate_row_keeps_zeros(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _bare_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["model_probability"] == 0.0
+    assert s["price"] == 0.0
+    assert s["edge"] == 0.0
+
+
+def test_yes_side_edge_uses_effective_price(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path, side="yes")
+    _patch_config(monkeypatch, db_path, side="yes")
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["edge"] == pytest.approx(
+        CAND_PROB - effective_price(CAND_PRICE, "yes"),
+    )
+
+
+def test_reason_persists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip("--reason", "validation_failed")
+    assert result.exit_code == 0, result.output
+    assert _skip_row(db_path)["reason"] == "validation_failed"
+
+
+def test_reason_defaults_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    assert _skip_row(db_path)["reason"] == ""
+
+
+def test_unknown_reason_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip("--reason", "vibes")
+    assert result.exit_code != 0
+
+
+def test_open_with_zero_args_does_not_backfill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#180 guard rail: prob<=0-as-unknown is a SKIP-only rule. An
+    open logged with zeros must keep them — a zero probability
+    bypassing validation gates was the original #180 bug."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, [
+        "log-trade", TICKER, "--action", "open",
+        "--price", "0", "--prob", "0", "--score", "0",
+        "--rationale", "test open",
+    ])
+    assert result.exit_code == 0, result.output
+
+    [o] = _trade_rows(db_path, action="open")
+    assert o["model_probability"] == 0.0
+    assert o["price"] == 0.0
+    assert o["gimme_score"] == 0.0
+
+
+def test_zero_prob_candidate_does_not_persist_degenerate_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The residual corner (#657 review): explicit --prob 0 --price 0
+    with a candidate row whose prob is also 0 must not keep the
+    constructor's edge = -effective_price(0) = -100%. Unknown
+    probability -> edge 0, not a fabricated one."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path, prob=0.0)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip("--price", "0", "--prob", "0")
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["price"] == CAND_PRICE  # backfilled
+    assert s["model_probability"] == 0.0  # candidate had none
+    assert s["edge"] == 0.0  # NOT -1.0
+
+
+def test_scout_shape_prob_zero_real_price_no_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scout logs skips before any candidate row exists and passes
+    --prob 0 when it has no estimate. The recorded edge must be 0,
+    not -effective_price(price) (the price - 100% signature)."""
+    db_path = tmp_path / "test.db"
+    _bare_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip("--price", "0.65", "--prob", "0")
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["price"] == 0.65
+    assert s["model_probability"] == 0.0
+    assert s["edge"] == 0.0
+
+
+def test_non_entry_reason_skips_backfill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Close-workflow skips (no_position, close_failed) carry no entry
+    decision — the candidate row must NOT be fabricated onto them,
+    else the missed-opportunity audit counts a failed close as a
+    missed entry (#657 review)."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    for reason in ("no_position", "close_failed"):
+        result = _invoke_skip("--reason", reason)
+        assert result.exit_code == 0, result.output
+
+    rows = _trade_rows(db_path)
+    assert len(rows) == 2
+    for s in rows:
+        assert s["model_probability"] == 0.0
+        assert s["price"] == 0.0
+        assert s["edge"] == 0.0
+
+
+def test_migration_v18_adds_reason_column(tmp_path: Path) -> None:
+    async def _check(db: Database) -> tuple[int, list[str]]:
+        cursor = await db.conn.execute(
+            "SELECT MAX(version) FROM schema_version",
+        )
+        version = (await cursor.fetchone())[0]
+        cursor = await db.conn.execute("PRAGMA table_info(trades)")
+        cols = [row[1] for row in await cursor.fetchall()]
+        return version, cols
+
+    version, cols = _db_run(tmp_path / "test.db", _check)
+    assert version >= 18
+    assert "reason" in cols


### PR DESCRIPTION
## Summary

**Whole scan batches logged degenerate skips** — probability 0, edge exactly price − 100%, some at $0.00 — and proceed→no-trade conversions (only ~1 of 7 proceeds converted) left no queryable trace. Root cause was writer-side: agent templates passed explicit `--prob 0`/`--price 0` or omitted the flags, and `log-trade`'s constructor computed `edge = 0 − effective_price`.

### The fix
- **Candidate-row backfill**: `log-trade` treats missing/zeroed SKIP analytics as unknown and fills from the ticker's latest candidates-table row (scan-time price/prob/score — the #656 CLOSE-inheritance precedent), then **normalizes edge unconditionally**: recomputed when prob and price are both known, `0.0` otherwise — the fabricated −100% signature can no longer land, even through the zero-prob-candidate corner the reviewers found. The `prob<=0`-as-unknown rule is **SKIP-only** (prob 0 bypassing validation gates was bug #180; a guard-rail test pins that opens never backfill).
- **Non-entry exemption**: close-workflow skips (`no_position`, `close_failed`) carry no entry decision — backfilling scan-time analytics onto them would turn failed closes into phantom missed entries. They keep honest zeros.
- **Structured reasons**: new `trades.reason` column (migration v18) + validated `--reason` flag with a closed 9-value vocabulary. All nine degenerate caddie-master/closer skip templates rewritten to omit analytics flags (DB truth beats LLM transcription; omission is fail-safe) and name their cause — proceed→no-trade conversion is now `SELECT ... WHERE reason='validation_failed'`.
- **Advisor guard**: `analyze_missed_opportunities` excludes skips with neither probability nor price — junk rows were diluting `false_negative_rate` (15/65 vs the true 0.6) and satisfying the 20-skip gate. The excluded count is surfaced in `supporting_data` (no silent truncation, #668 lesson).

## Review
Full pipeline + simplifier. Mutation-verified on scratchpad copies: pre-fix code fails the backfill tests (4) and the template zero-check; 6+ targeted mutations killed; the two review-found holes (residual −1.0 edge through the zero-prob-candidate corner; close-skip cross-contamination) are fixed and regression-tested. Deferred hardening in **#670**.

## Test plan
- `uv run pytest tests/unit/test_cli_skip_analytics.py tests/unit/test_advisor.py tests/unit/test_agent_prompts.py` — 14 CLI tests (backfill matrix, degenerate corners, reason persistence/validation, #180 guard-rail, migration v18), advisor exclusion invariance/gate-dilution/half-degenerate tests, template regression tests.
- Full suite: 1688 passed; ruff clean.

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB