### PR TITLE
Fix #658: clamp candidate edge to zero at price bounds

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -27,6 +27,8 @@ You are the Caddie — the research agent in the GIMMES trading pipeline. You ta
 
    **Side awareness:** When `trading_side` is `no`, you are evaluating the NO outcome. Your true probability estimate (`--prob`) should reflect the probability of the NO outcome (i.e., 1 - P(YES)). The `--price` argument should still be the YES price as shown by `market-info` — the CLI converts it internally.
 
+   **Untradeable at the bound:** If `market-info` shows the tradeable side priced within one tick of a bound (effective price <= $0.01 or >= $0.99), the market is untradeable at the bound — there is no realizable edge, whatever the arithmetic says. Still log the candidate (the record feeds cooldown), but set `--recommendation pass` and note untradeable-at-bound in the memo. A bound-priced sibling is also excluded from the sibling-strike lowest-price comparison — an untradeable strike does not dominate its event.
+
 1. For each candidate (or event group) from the Scout's shortlist:
    - Run `gimmes market-info TICKER` for detailed market data
    - Research the underlying event using web search

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2105,10 +2105,9 @@ def log_trade(
             get_entry_analytics,
             insert_trade,
         )
-        from gimmes.strategy.scanner import effective_price
+        from gimmes.strategy.scanner import tradeable_edge
 
         resolved_side = side if side else config.strategy.side
-        eff = effective_price(price_val, resolved_side)
         trade = TradeDecision(
             ticker=ticker,
             action=TradeDecision.Action(action),
@@ -2117,7 +2116,11 @@ def log_trade(
             price=price_val,
             model_probability=0.0 if prob is None else prob,
             gimme_score=score_val,
-            edge=(prob - eff) if prob is not None else 0.0,
+            edge=(
+                tradeable_edge(prob, price_val, resolved_side)
+                if prob is not None
+                else 0.0
+            ),
             rationale=rationale_val,
             reason=reason,
             agent=agent,
@@ -2178,10 +2181,10 @@ def log_trade(
                 # with prob 0 it is the degenerate -effective_price
                 # (the price - 100% signature this fix exists to
                 # kill). Unknown probability -> unknown edge, not a
-                # fabricated one.
+                # fabricated one. tradeable_edge additionally clamps
+                # bound-priced markets to 0 (#658).
                 trade.edge = (
-                    trade.model_probability
-                    - effective_price(trade.price, resolved_side)
+                    tradeable_edge(trade.model_probability, trade.price, resolved_side)
                     if trade.model_probability > 0 and trade.price > 0
                     else 0.0
                 )
@@ -2227,10 +2230,12 @@ def log_candidate(
     async def _log() -> None:
         from gimmes.store.database import Database
         from gimmes.store.queries import insert_candidate as _insert
-        from gimmes.strategy.scanner import effective_price
+        from gimmes.strategy.scanner import tradeable_edge
 
-        eff = effective_price(price_val, config.strategy.side)
-        edge = prob - eff
+        # #658: edge on the side actually bought, clamped to 0 when
+        # that side is priced within one tick of a bound (unfillable;
+        # prob - 0 would fabricate an edge equal to the probability).
+        edge = tradeable_edge(prob, price_val, config.strategy.side)
 
         async with Database(config.db_path) as db:
             row_id = await _insert(

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -16,7 +16,7 @@ from gimmes.risk.limits import (
 )
 from gimmes.risk.settlement import scan_settlement_rules
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, edge_after_fees
-from gimmes.strategy.scanner import effective_price
+from gimmes.strategy.scanner import effective_price, price_at_bound
 
 
 @dataclass
@@ -165,12 +165,23 @@ def validate_trade(
     if true_probability is not None:
         raw_price = market.midpoint if market.midpoint > 0 else market.last_price
         price = effective_price(raw_price, config.strategy.side)
-        edge = edge_after_fees(price, true_probability, is_taker=is_taker, fees=fees)
-        min_edge = config.strategy.min_edge_after_fees
-        if edge >= min_edge:
-            checks.append(f"Edge OK ({edge:.1%} >= {min_edge:.1%})")
+        # #658: within one tick of a bound the edge formula collapses
+        # to `prob - 0` — a fabricated "Edge OK (88%)" would wave an
+        # unfillable order through the last pre-capital gate. The
+        # price can drift to the bound between Caddie research and
+        # Closer execution, so the live check must catch it.
+        if price_at_bound(price):
+            failures.append(
+                f"Price at bound: effective price ${price:.2f} is"
+                f" untradeable — no realizable edge (#658)"
+            )
         else:
-            failures.append(f"Insufficient edge: {edge:.1%} < {min_edge:.1%} minimum")
+            edge = edge_after_fees(price, true_probability, is_taker=is_taker, fees=fees)
+            min_edge = config.strategy.min_edge_after_fees
+            if edge >= min_edge:
+                checks.append(f"Edge OK ({edge:.1%} >= {min_edge:.1%})")
+            else:
+                failures.append(f"Insufficient edge: {edge:.1%} < {min_edge:.1%} minimum")
     else:
         checks.append("Edge check skipped (no probability provided)")
 

--- a/src/gimmes/strategy/scanner.py
+++ b/src/gimmes/strategy/scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 from gimmes.config import GimmesConfig
@@ -17,6 +18,35 @@ def effective_price(yes_price: float, side: str) -> float:
     if side == "no":
         return round(1.0 - yes_price, 4)
     return yes_price
+
+
+# Kalshi's cent tick. A side priced within one tick of a bound is
+# untradeable in practice (at $0.00 an order isn't even placeable).
+BOUND_TICK = 0.01
+
+
+def price_at_bound(price: float) -> bool:
+    """True when a price sits at or within one tick of $0.00 / $1.00."""
+    return price <= BOUND_TICK or price >= 1.0 - BOUND_TICK
+
+
+def tradeable_edge(prob: float, yes_price: float, side: str) -> float:
+    """Edge on the side actually being bought, 0.0 at the price bounds.
+
+    ``prob - effective_price`` degenerates when the tradeable side sits
+    at or within one tick of a bound: at YES $1.00 the NO side costs
+    $0.00 and the formula collapses to ``prob`` — a meaningless +88%
+    "edge" on an unfillable order that inflates every aggregate edge
+    statistic (#658). Bound-priced markets have no realizable edge.
+    """
+    eff = effective_price(yes_price, side)
+    if price_at_bound(eff):
+        logging.getLogger(__name__).debug(
+            "edge clamped to 0: %s side priced at bound"
+            " (yes %.2f -> eff %.2f) (#658)", side, yes_price, eff,
+        )
+        return 0.0
+    return prob - eff
 
 
 def days_until(dt: datetime | None) -> float | None:

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -1895,3 +1895,12 @@ def test_scout_and_caddie_skip_templates_keep_real_analytics(
         assert "--price 0.XX --prob 0.XX --score NN" in text, (
             f"{name} skip template no longer passes real analytics"
         )
+
+
+def test_caddie_untradeable_at_bound_rule(caddie_text: str) -> None:
+    """#658: Caddie must recognize bound-priced markets as untradeable
+    and log them with recommendation pass (record feeds cooldown)."""
+    assert "Untradeable at the bound" in caddie_text
+    assert "within one tick of a bound" in caddie_text
+    assert "--recommendation pass" in caddie_text
+    assert "sibling-strike" in caddie_text  # bound strikes don't dominate

--- a/tests/unit/test_buy_no.py
+++ b/tests/unit/test_buy_no.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from gimmes.config import GimmesConfig, Mode, StrategyConfig
 from gimmes.models.market import Market, MarketStatus
-from gimmes.strategy.scanner import effective_price, filter_markets
+from gimmes.strategy.scanner import (
+    effective_price,
+    filter_markets,
+    tradeable_edge,
+)
 from gimmes.strategy.scorer import quick_score
 
 # ---------------------------------------------------------------------------
@@ -34,6 +40,46 @@ class TestEffectivePrice:
         # 1 - 0.333 = 0.667 — should round to 4 decimal places
         result = effective_price(0.333, "no")
         assert result == 0.667
+
+    def test_no_side_at_one_dollar(self) -> None:
+        # YES at $1.00 → NO costs $0.00 (the #658 bound)
+        assert effective_price(1.00, "no") == 0.0
+
+    def test_no_side_at_zero(self) -> None:
+        assert effective_price(0.0, "no") == 1.0
+
+
+class TestTradeableEdge:
+    """#658: edge is 0 when the tradeable side sits at/within one
+    tick of a price bound — `prob - effective_price` collapses to
+    `prob` there (edge +88% at YES $1.00 on the NO side), an
+    unfillable order with a fabricated edge."""
+
+    def test_no_side_at_one_dollar_clamps(self) -> None:
+        # The KXCPIYOY-26JUL-T3.7 shape: prob 0.88 at YES $1.00
+        assert tradeable_edge(0.88, 1.00, "no") == 0.0
+
+    def test_no_side_at_floor_tick_clamps(self) -> None:
+        # YES 0.99 → NO eff 0.01, exactly one tick — clamped
+        assert tradeable_edge(0.88, 0.99, "no") == 0.0
+
+    def test_no_side_at_ceiling_clamps(self) -> None:
+        # YES 0.00 → NO eff 1.00 — mirror bound
+        assert tradeable_edge(0.88, 0.00, "no") == 0.0
+
+    def test_yes_side_bounds_clamp(self) -> None:
+        assert tradeable_edge(0.90, 0.01, "yes") == 0.0
+        assert tradeable_edge(0.90, 0.99, "yes") == 0.0
+
+    def test_one_tick_inside_is_real_edge(self) -> None:
+        # YES 0.98 → NO eff 0.02 — thin but placeable; arithmetic
+        # stands (documented residual: the $0.97 case is 3 ticks in)
+        assert tradeable_edge(0.88, 0.98, "no") == pytest.approx(0.86)
+
+    def test_mid_range_unchanged(self) -> None:
+        # NO at YES 0.70 → eff 0.30
+        assert tradeable_edge(0.85, 0.70, "no") == pytest.approx(0.55)
+        assert tradeable_edge(0.90, 0.70, "yes") == pytest.approx(0.20)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -368,3 +368,72 @@ def test_migration_v18_adds_reason_column(tmp_path: Path) -> None:
     version, cols = _db_run(tmp_path / "test.db", _check)
     assert version >= 18
     assert "reason" in cols
+
+
+def test_bound_price_candidate_backfills_zero_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#658: a candidate stuck at YES $1.00 (NO side costs $0.00)
+    backfills its price onto the skip, but the edge clamps to 0 —
+    prob - effective_price would fabricate edge = prob there."""
+    db_path = tmp_path / "test.db"
+
+    async def _insert(db: Database) -> None:
+        await insert_candidate(
+            db, TICKER, "CPI YoY", 1.00, 0.88, 0.88, 80.0, "memo",
+        )
+
+    _db_run(db_path, _insert)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+
+    s = _skip_row(db_path)
+    assert s["price"] == 1.00
+    assert s["model_probability"] == 0.88
+    assert s["edge"] == 0.0
+
+
+def test_bound_price_open_records_zero_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """log-trade opens at a bound price record edge 0 too (#658)."""
+    db_path = tmp_path / "test.db"
+    _bare_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, [
+        "log-trade", TICKER, "--action", "open",
+        "--price", "1.00", "--prob", "0.88",
+        "--rationale", "bound open",
+    ])
+    assert result.exit_code == 0, result.output
+
+    [o] = _trade_rows(db_path, "open")
+    assert o["model_probability"] == 0.88  # explicit prob untouched
+    assert o["edge"] == 0.0
+
+
+def test_bound_price_close_with_explicit_prob_records_zero_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Documented behavior change (#658): a manually logged close at a
+    bound price with explicit --prob records edge 0, not prob - eff —
+    a settlement-priced close has no fabricated edge either. (No
+    production writer takes this path; settlement/reconcile closes
+    copy entry analytics in queries.py.)"""
+    db_path = tmp_path / "test.db"
+    _bare_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, [
+        "log-trade", TICKER, "--action", "close",
+        "--price", "1.00", "--prob", "0.9",
+        "--rationale", "bound close",
+    ])
+    assert result.exit_code == 0, result.output
+
+    [c] = _trade_rows(db_path, "close")
+    assert c["model_probability"] == 0.9
+    assert c["edge"] == 0.0

--- a/tests/unit/test_data_collection.py
+++ b/tests/unit/test_data_collection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -19,6 +20,11 @@ from gimmes.store.queries import (
     insert_trade,
     update_trade_outcome,
 )
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock
+
+    from click.testing import Result
 
 
 @pytest.fixture
@@ -289,6 +295,62 @@ class TestLogCandidateCommand:
         _, ticker, title, price, prob, edge, score, memo = mock_insert.call_args[0]
         assert ticker == "EDGE-TEST"
         assert abs(edge - 0.20) < 1e-9
+
+    @staticmethod
+    def _invoke_no_side(
+        tmp_path: Path, argv: list[str],
+    ) -> tuple[Result, AsyncMock]:
+        """Run a log-candidate argv with the strategy side pinned to a
+        real 'no' literal and insert_candidate mocked (#658 harness)."""
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        mock_insert = AsyncMock(return_value=1)
+        runner = CliRunner()
+
+        with (
+            patch("gimmes.cli.load_config") as mock_cfg,
+            patch("gimmes.store.queries.insert_candidate", mock_insert),
+        ):
+            mock_cfg.return_value.db_path = tmp_path / "test.db"
+            mock_cfg.return_value.strategy.side = "no"
+            result = runner.invoke(app, argv)
+        return result, mock_insert
+
+    def test_bound_price_clamps_edge_to_zero(self, tmp_path: Path) -> None:
+        """#658: YES $1.00 on a BUY NO strategy is untradeable (NO
+        costs $0.00) — the stored edge must be 0, not prob - 0 = +88%.
+        A zero edge auto-fails Caddie Master's cm_min_edge_after_fees
+        pre-filter."""
+        result, mock_insert = self._invoke_no_side(tmp_path, [
+            "log-candidate", "KXCPIYOY-26JUL-T3.7",
+            "--price", "1.00", "--prob", "0.88", "--score", "80",
+            "--memo", "bound test",
+        ])
+
+        assert result.exit_code == 0
+        _, _, _, price, prob, edge, _, _ = mock_insert.call_args[0]
+        assert price == 1.00
+        assert prob == 0.88
+        assert edge == 0.0
+
+    def test_no_side_mid_range_edge(self, tmp_path: Path) -> None:
+        """Side plumbing through log-candidate with a real 'no'
+        literal at a NON-bound price: edge = prob - (1 - price).
+        (The pre-existing test's MagicMock side pins neither literal;
+        a double-conversion mutant survived it — #658 review.)"""
+        result, mock_insert = self._invoke_no_side(tmp_path, [
+            "log-candidate", "MIDRANGE-NO",
+            "--price", "0.70", "--prob", "0.85", "--score", "80",
+            "--memo", "mid-range no side",
+        ])
+
+        assert result.exit_code == 0
+        edge = mock_insert.call_args[0][5]
+        assert abs(edge - 0.55) < 1e-9  # 0.85 - (1 - 0.70)
 
     def test_memo_file_preserves_dollar_zero(self, tmp_path: Path) -> None:
         """Regression test for #589: --memo-file content with `$0.41` reaches

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -357,3 +357,60 @@ class TestValidateTrade:
         )
         assert result.approved is True
         assert any("bankroll ok" in c.lower() for c in result.checks)
+
+
+class TestPriceBoundGate:
+    """#658: within one tick of a bound the edge formula collapses to
+    prob - 0 — the validator must reject, not print 'Edge OK (88%)'
+    for an unfillable order. Prices drift to the bound between Caddie
+    research and Closer execution, so the live check is the backstop."""
+
+    def test_no_side_floor_rejected(self, config: GimmesConfig) -> None:
+        config.strategy.side = "no"
+        market = _make_market(yes_bid=1.0, yes_ask=1.0, last_price=1.0)
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=0.88,
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert result.approved is False
+        assert any("Price at bound" in f for f in result.failures)
+        assert not any("Edge OK" in c for c in result.checks)
+
+    def test_yes_side_ceiling_rejected(self, config: GimmesConfig) -> None:
+        config.strategy.side = "yes"
+        market = _make_market(yes_bid=0.99, yes_ask=0.99, last_price=0.99)
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=0.999,
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert result.approved is False
+        assert any("Price at bound" in f for f in result.failures)
+
+    def test_mid_range_edge_check_unchanged(
+        self, config: GimmesConfig,
+    ) -> None:
+        market = _make_market()  # midpoint 0.70
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=0.90,
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert not any("Price at bound" in f for f in result.failures)
+        assert any("Edge" in c for c in result.checks)


### PR DESCRIPTION
## Summary

Candidate rows recorded **edge +88% at YES $1.00** — the strategy buys NO, so the tradeable side costs $0.00 and `prob − effective_price` collapses to `prob`: a fabricated edge on an unfillable order, inflating aggregate edge statistics and sailing through Caddie Master's stored-edge pre-filter.

### The fix
- **`tradeable_edge`** (scanner.py, with `price_at_bound`/`BOUND_TICK = 0.01`): returns 0.0 when the bought side sits at or within one cent tick of a bound. Wired into all three stored-edge writers — `log-candidate`, the `log-trade` constructor (#180 guard preserved), and the #657 skip-backfill recompute (guards preserved). Clamps debug-log.
- **Validator backstop**: check 6 now REJECTS "Price at bound" instead of computing `edge_after_fees(0, prob)` = "Edge OK (88%)". The price can drift to the bound between Caddie research and Closer execution — this was the issue's "could reach sizing if gates loosen" scenario, and the NO-side floor was otherwise uncaught (review finding). Scan and backtest entry already band-gate bounds and are untouched — verified, not assumed.
- **caddie.md rule**: bound candidates still get logged (the record feeds cooldown) but with `--recommendation pass`; bound-priced siblings are excluded from the #591 lowest-price sibling comparison so an untradeable strike can't dominate its event.

**Documented residual:** the issue's $0.97 example (NO cost $0.03, three ticks inside) is placeable and deliberately NOT clamped, per the issue's one-tick direction. That policy question plus the scorer/`size`-display fabrications are tracked in **#672**.

## Review
Full pipeline + simplifier. Mutation-verified: all six targeted mutations killed with a 1:1 site-to-test mapping (each of the three CLI sites independently pinned); zero vacuous tests; exactly-one-tick boundary and float stability verified empirically (`round(1−0.99,4)` comparisons are exact). A surviving side-plumbing mutant through log-candidate was killed with a mid-range no-side literal test.

## Test plan
- `uv run pytest tests/unit/test_buy_no.py tests/unit/test_validator.py tests/unit/test_data_collection.py tests/unit/test_cli_skip_analytics.py tests/unit/test_agent_prompts.py` — TestTradeableEdge boundary matrix, validator bound rejections (both sides) + mid-range unchanged, log-candidate bound clamp + side plumbing, skip-backfill/open/close bound records, caddie.md rule pin.
- Full suite: 1706 passed; ruff clean.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB