### PR TITLE
Fix #662: win rate uses the weighted cost basis via calculate_pnl

### DIFF
--- a/src/gimmes/reporting/metrics.py
+++ b/src/gimmes/reporting/metrics.py
@@ -6,6 +6,8 @@ import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from gimmes.reporting.pnl import calculate_pnl
+
 
 @dataclass
 class PerformanceMetrics:
@@ -172,27 +174,15 @@ def calculate_metrics(
     """Calculate performance metrics from trades and snapshots."""
     metrics = PerformanceMetrics()
 
-    # Win rate — based on realized P&L (matching pnl.py definition)
-    # Group opens by ticker for P&L calculation
-    open_prices: dict[str, float] = {}
-    for t in trades:
-        if t.get("action") == "open":
-            open_prices.setdefault(t.get("ticker", ""), t.get("price", 0.0))
-
-    wins = 0
-    losses = 0
-    for t in trades:
-        if t.get("action") != "close":
-            continue
-        close_price = t.get("price", 0.0)
-        open_price = open_prices.get(t.get("ticker", ""), 0.0)
-        pnl = (close_price - open_price) * t.get("count", 0)
-        if pnl > 0:
-            wins += 1
-        elif pnl < 0:
-            losses += 1
-    total = wins + losses
-    metrics.win_rate = wins / total if total > 0 else 0.0
+    # Win rate — delegated to calculate_pnl (#662): (ticker, side)
+    # grouping, weighted-average cost basis across size_ups, #653
+    # reconcile repricing, and orphan-close handling — replacing the
+    # first-open-price, ticker-only walk that overstated wins (open
+    # 100@$0.60 + size_up 100@$0.90 closed at $0.70 classified as a
+    # win on the $0.60 basis; the weighted $0.75 basis says loss).
+    # Scratch trades (pnl == 0) stay excluded from numerator and
+    # denominator, matching the previous semantics.
+    metrics.win_rate = calculate_pnl(trades).win_rate
 
     # Edge accuracy
     predicted_edges = [t.get("edge", 0) for t in trades if t.get("action") == "open"]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -157,6 +157,110 @@ class TestCalculateMetrics:
         metrics = calculate_metrics([], [])
         assert metrics.win_rate == 0.0
 
+    def test_win_rate_uses_weighted_basis_across_size_ups(self) -> None:
+        """THE #662 case: first-open basis says WIN (+0.10 vs $0.60),
+        the weighted $0.75 basis says LOSS."""
+        trades = [
+            {"action": "open", "ticker": "A", "side": "yes",
+             "price": 0.60, "count": 100, "timestamp": "2026-01-01T10:00:00"},
+            {"action": "size_up", "ticker": "A", "side": "yes",
+             "price": 0.90, "count": 100, "timestamp": "2026-01-02T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "yes",
+             "price": 0.70, "count": 200, "timestamp": "2026-01-03T10:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        assert metrics.win_rate == 0.0
+
+    def test_win_rate_size_up_win_stays_win(self) -> None:
+        # The issue's own example: avg basis ~0.6167, close at 0.80
+        trades = [
+            {"action": "open", "ticker": "A", "side": "yes",
+             "price": 0.60, "count": 100, "timestamp": "2026-01-01T10:00:00"},
+            {"action": "size_up", "ticker": "A", "side": "yes",
+             "price": 0.65, "count": 50, "timestamp": "2026-01-02T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "yes",
+             "price": 0.80, "count": 150, "timestamp": "2026-01-03T10:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        assert metrics.win_rate == 1.0
+
+    def test_win_rate_separates_sides(self) -> None:
+        """The old ticker-only grouping matched a YES close against
+        whichever side's open came first."""
+        trades = [
+            {"action": "open", "ticker": "A", "side": "no",
+             "price": 0.30, "count": 10, "timestamp": "2026-01-01T09:00:00"},
+            {"action": "open", "ticker": "A", "side": "yes",
+             "price": 0.60, "count": 10, "timestamp": "2026-01-01T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "yes",
+             "price": 0.50, "count": 10, "timestamp": "2026-01-02T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "no",
+             "price": 0.20, "count": 10, "timestamp": "2026-01-02T11:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        # yes: 0.50 vs 0.60 basis -> loss; no: 0.20 vs 0.30 -> loss
+        assert metrics.win_rate == 0.0
+
+    def test_win_rate_gains_653_reconcile_repricing(self) -> None:
+        """Delegating to calculate_pnl brings the dashboard in line
+        with the CLI report: a reconcile drift close on a market that
+        resolved our way is repriced to settlement value."""
+        trades = [
+            {"action": "open", "ticker": "A", "side": "yes",
+             "price": 0.60, "count": 10, "resolved_outcome": "yes",
+             "timestamp": "2026-01-01T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "yes",
+             "price": 0.55, "count": 10, "agent": "reconcile",
+             "timestamp": "2026-01-02T10:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        assert metrics.win_rate == 1.0  # repriced to 1.0, not 0.55
+
+    def test_partial_closes_straddling_weighted_basis(self) -> None:
+        """Fractional win rate: two partial closes on either side of
+        the single weighted basis (0.75) — one win, one loss. Also
+        the only size-up fixture with a non-degenerate rate, so a
+        gross-P&L-sign shortcut cannot fake it (+$5 gross but 0.5
+        rate) (#662 review)."""
+        trades = [
+            {"action": "open", "ticker": "A", "side": "yes",
+             "price": 0.60, "count": 100, "timestamp": "2026-01-01T10:00:00"},
+            {"action": "size_up", "ticker": "A", "side": "yes",
+             "price": 0.90, "count": 100, "timestamp": "2026-01-02T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "yes",
+             "price": 0.70, "count": 100, "timestamp": "2026-01-03T10:00:00"},
+            {"action": "close", "ticker": "A", "side": "yes",
+             "price": 0.85, "count": 100, "timestamp": "2026-01-04T10:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        assert abs(metrics.win_rate - 0.5) < 0.001
+
+    def test_scratch_excluded_from_denominator(self) -> None:
+        """A close exactly at basis is a scratch — excluded from
+        BOTH sides of the rate (1 win + 1 scratch -> 1.0, not 0.5),
+        pinning the comment's claimed semantics (#662 review)."""
+        trades = [
+            {"action": "open", "ticker": "S", "side": "yes",
+             "price": 0.70, "count": 10, "timestamp": "2026-01-01T10:00:00"},
+            {"action": "close", "ticker": "S", "side": "yes",
+             "price": 0.70, "count": 10, "timestamp": "2026-01-02T10:00:00"},
+            {"action": "open", "ticker": "W", "side": "yes",
+             "price": 0.60, "count": 10, "timestamp": "2026-01-01T11:00:00"},
+            {"action": "close", "ticker": "W", "side": "yes",
+             "price": 0.80, "count": 10, "timestamp": "2026-01-02T11:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        assert metrics.win_rate == 1.0
+
+    def test_orphan_close_is_not_a_fake_win(self) -> None:
+        # Old code: zero basis -> pnl +8.0 -> win_rate 1.0
+        trades = [
+            {"action": "close", "ticker": "GHOST", "side": "yes",
+             "price": 0.80, "count": 10, "timestamp": "2026-01-01T10:00:00"},
+        ]
+        metrics = calculate_metrics(trades, [])
+        assert metrics.win_rate == 0.0
+
     def test_avg_edge_predicted(self) -> None:
         trades = [
             {"action": "open", "ticker": "A", "edge": 0.10},


### PR DESCRIPTION
## Summary

`calculate_metrics` classified wins against the **first open price per ticker** (`setdefault`): size-ups ignored (open 100@$0.60 + size_up 100@$0.90 closed at $0.70 read as a *win* on the $0.60 basis — the weighted $0.75 basis says *loss*), yes/no sides conflated, no #653 reconcile repricing, and orphan closes counted as fake wins at zero basis.

**The broken walk is deleted, not mirrored**: `win_rate` now delegates to `calculate_pnl` — the production-proven (ticker, side) weighted-basis walk the CLI report already uses — so the dashboard and the scorecard finally agree. Scratch closes stay excluded from both sides of the rate (unchanged semantics, now pinned). Dashboard win-rate values will shift on history containing size-ups, both-side tickers, reconcile closes, or orphans — that's the correction.

## Review
Full pipeline + simplifier (which found nothing to trim — one import, one line, walk deleted). Every intended delta replayed empirically against the old walk; no import cycles; consumers verified (clubhouse rows carry all needed columns; unmigrated read-only DBs degrade gracefully). Mutation testing: no suite-wide survivors; the review added a fractional partial-close case (defeats a gross-P&L-sign shortcut) and a scratch-denominator pin. Dashboard-input residuals (oldest-1000 window incl. skips — the #542 shape; orphan-warning render noise) in **#680**.

## Test plan
- `uv run pytest tests/unit/test_metrics.py` — 7 new tests: the weighted-basis discriminator (old code says 1.0, correct answer 0.0), the issue's example, side separation, #653 repricing, fractional partial closes (0.5), scratch exclusion, orphan not-a-fake-win.
- Full suite: 1788 passed; ruff clean.

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB