### PR TITLE
Fix #666: backtest selects candidates through the entry-day lens

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -556,14 +556,15 @@ async def run_backtest(
             )
             continue
         if candle_midpoint(candle) <= 0:
-            # One-sided quote: no priceable midpoint; trade-price
-            # OHLC stays deliberately rejected as a fallback (stale on
-            # thin days, #655). Counted separately because these skips
-            # can bias the sample away from near-certain late-life
-            # contracts — exactly the gimme population (#666).
+            # One-sided OR empty quote (either/both closes zero): no
+            # priceable midpoint; trade-price OHLC stays deliberately
+            # rejected as a fallback (stale on thin days, #655).
+            # Counted separately because these skips can bias the
+            # sample away from near-certain late-life contracts —
+            # exactly the gimme population (#666).
             skipped_one_sided += 1
             logger.debug(
-                "one-sided entry quote for %s (bid=%s ask=%s)",
+                "unusable entry quote for %s (bid=%s ask=%s)",
                 m.ticker, candle.yes_bid_close, candle.yes_ask_close,
             )
             continue

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -83,6 +83,8 @@ class BacktestResult:
     skipped_concentration: int = 0
     skipped_balance: int = 0
     skipped_no_candle: int = 0
+    skipped_one_sided: int = 0
+    fetch_failures: int = 0
     skipped_entry_gates: int = 0
     truncated_chunks: list[str] = field(default_factory=list)
 
@@ -239,9 +241,9 @@ def synthesize_orderbook(ticker: str, candle: Candle, depth: int = 100) -> Order
 def candle_midpoint(candle: Candle) -> float:
     """Bid/ask midpoint of a candle — the backtest analog of
     Market.midpoint. Returns 0.0 unless both quote sides are positive
-    (a market with no two-sided quote could not have been maker-filled;
-    the candle's trade-price OHLC can be stale on thin days, so it is
-    deliberately NOT used as a fallback) (#655)."""
+    (a one-sided book has no priceable midpoint; the candle's
+    trade-price OHLC can be stale on thin days, so it is deliberately
+    NOT used as a fallback) (#655)."""
     if candle.yes_bid_close > 0 and candle.yes_ask_close > 0:
         return (candle.yes_bid_close + candle.yes_ask_close) / 2
     return 0.0
@@ -263,19 +265,19 @@ def entry_candle_at(candles: list[Candle], entry_ts: int) -> Candle | None:
     return chosen
 
 
-async def _entry_day_mid(
+async def _fetch_entry_candle(
     client: KalshiClient,
     ticker: str,
     entry_ts: int,
     cache: dict[str, list[Candle]],
-) -> float:
-    """Entry-day candle midpoint for ticker, or 0.0 when no usable
-    candle exists. The fetch window ends AT entry_ts, so future data
-    structurally cannot leak into the engine (#655). The distinct
-    unusable cases (no history, fetch failure, one-sided quote) are
-    debug-logged so the residual can be audited (#666: one-sided
-    quotes late in life would bias the sample away from the strongest
-    gimmes)."""
+    failed: set[str],
+) -> Candle | None:
+    """The ticker's entry-day candle, or None when no candle ends at
+    or before entry_ts. The fetch window ends AT entry_ts, so future
+    data structurally cannot leak into the engine (#655). Fetch
+    failures degrade to None (debug-logged); classification of the
+    unusable cases (no history vs one-sided quote) happens at the
+    call site so the funnel can count them separately (#666)."""
     if ticker not in cache:
         try:
             cache[ticker] = await get_candlesticks(
@@ -287,44 +289,49 @@ async def _entry_day_mid(
         except Exception as exc:  # noqa: BLE001
             logger.debug("candle fetch failed for %s: %s", ticker, exc)
             cache[ticker] = []
-    candle = entry_candle_at(cache[ticker], entry_ts)
-    mid = candle_midpoint(candle) if candle else 0.0
-    if mid <= 0:
-        logger.debug(
-            "no usable entry candle for %s: %s", ticker,
-            "no candles <= entry_ts" if candle is None
-            else (
-                f"one-sided quote (bid={candle.yes_bid_close}"
-                f" ask={candle.yes_ask_close})"
-            ),
-        )
-    return mid
+            # A FAILED fetch is not empty history — the caller
+            # keeps systemic API failures (the #655 endpoint 404
+            # signature) out of the data-sparsity counters (#666).
+            failed.add(ticker)
+    return entry_candle_at(cache[ticker], entry_ts)
 
 
-# ---------------------------------------------------------------------------
-# Adapt historical markets for filter_markets()
-# ---------------------------------------------------------------------------
+def _entry_day_view(
+    market: Market, candle: Candle, close_time: datetime,
+) -> Market:
+    """A Market as it looked on ENTRY DAY, built from the entry-day
+    candle — the selection lens the scanner/scorer see (#666).
 
-
-def _adapt_for_filter(
-    markets: list[Market],
-    max_days: float = 90.0,
-) -> list[Market]:
-    """Adapt settled markets so they pass through filter_markets().
-
-    Sets status to ACTIVE and close_time to a synthetic future value
-    within the configured max_days_to_resolution window.
+    Field mapping (all price/liquidity data comes from the candle so
+    filter_markets and quick_score run unchanged with no settlement
+    leak):
+    - yes_bid/yes_ask from the candle closes — Market.midpoint and
+      Market.spread then reproduce candle_midpoint and the
+      candle-derived spread with no new arithmetic.
+    - last_price is 0.0: the midpoint must never fall back to stale
+      trade prices (the same rationale candle_midpoint uses, #655).
+    - volume AND volume_24h from the daily candle's per-period volume
+      — for period_interval=1440 that IS the day's 24h volume, and
+      setting both makes the scanner/scorer's `volume_24h or volume`
+      branches read the candle value either way.
+    - open_interest at candle close.
+    - status ACTIVE + close_time at now + ENTRY_OFFSET_DAYS: the
+      honest days-to-resolution at the backtest's fixed-offset entry
+      is exactly ENTRY_OFFSET_DAYS by construction (the +60s margin
+      makes the min_days == ENTRY_OFFSET_DAYS boundary
+      deterministic).
     """
-    days = max(1.0, min(max_days - 1, 30.0))
-    future = datetime.now(UTC) + timedelta(days=days)
-    adapted = []
-    for m in markets:
-        adapted.append(m.model_copy(update={
-            "status": MarketStatus.ACTIVE,
-            "close_time": future,
-            "expiration_time": future,
-        }))
-    return adapted
+    return market.model_copy(update={
+        "status": MarketStatus.ACTIVE,
+        "yes_bid": candle.yes_bid_close,
+        "yes_ask": candle.yes_ask_close,
+        "last_price": 0.0,
+        "volume": candle.volume,
+        "volume_24h": candle.volume,
+        "open_interest": candle.open_interest,
+        "close_time": close_time,
+        "expiration_time": close_time,
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -380,11 +387,14 @@ async def run_backtest(
 ) -> BacktestResult:
     """Run a backtest over historical settled markets.
 
-    Algorithm:
+    Algorithm (#666: selection happens through the entry-day lens):
     1. Fetch all settled historical markets
-    2. Filter by scanner criteria (price, volume, OI)
-    3. Score with quick_score, gate on gimme_threshold
-    4. For each qualifying market, fetch candles, simulate entry, settle
+    2. Fetch the ENTRY-DAY candle for every settled market and build
+       entry-day views (settlement data never reaches selection)
+    3. Filter by scanner criteria and score with quick_score on the
+       entry-day views, gate on gimme_threshold
+    4. For each qualifying market, gate true-prob/edge and size at the
+       entry-day price; settlement supplies only the payout
     5. Return aggregated results
     """
     gc = config.gimmes_config
@@ -482,14 +492,107 @@ async def run_backtest(
         len(all_markets), len(settled),
     )
 
-    # --- 2-4. Filter, Score, Identify trades — per side ---
-    adapted = _adapt_for_filter(
-        settled, max_days=gc.scanner.max_days_to_resolution,
-    )
+    # --- 2. Entry-day candle pass (#666) ---
+    # Selection must see the market as it looked ON ENTRY DAY: the
+    # settled snapshot's price/volume/OI/spread encode settlement-time
+    # information (in-band-at-entry markets that drifted out by
+    # settlement were invisible; end-of-life liquidity gated
+    # optimistically). One candle fetch per settled market, behind the
+    # client's token bucket (~3 min for a full multi-series run).
     original_by_ticker = {m.ticker: m for m in settled}
-    pending: list[_PendingTrade] = []
     candle_cache: dict[str, list[Candle]] = {}
+    entry_candles: dict[str, Candle] = {}
+    entry_times: dict[str, datetime] = {}
     skipped_no_candle = 0
+    skipped_one_sided = 0
+    fetch_failures = 0
+    failed_fetches: set[str] = set()
+    if (
+        gc.scanner.min_days_to_resolution > ENTRY_OFFSET_DAYS
+        or gc.scanner.max_days_to_resolution <= ENTRY_OFFSET_DAYS
+    ):
+        logger.warning(
+            "min_days_to_resolution (%.1f) / max_days_to_resolution"
+            " (%.1f) exclude the backtest's fixed %d-day entry offset"
+            " — the days filter will select NOTHING (#666)",
+            gc.scanner.min_days_to_resolution,
+            gc.scanner.max_days_to_resolution, ENTRY_OFFSET_DAYS,
+        )
+    for i, m in enumerate(settled):
+        if m.close_time is None:
+            continue
+        if i and i % 250 == 0:
+            logger.info(
+                "entry candles: %d/%d processed", i, len(settled),
+            )
+        close_time = (
+            m.close_time if m.close_time.tzinfo
+            else m.close_time.replace(tzinfo=UTC)
+        )
+        entry_time = close_time - timedelta(days=ENTRY_OFFSET_DAYS)
+        entry_ts = int(entry_time.timestamp())
+        candle = await _fetch_entry_candle(
+            client, m.ticker, entry_ts, candle_cache,
+            failed=failed_fetches,
+        )
+        if candle is None and m.ticker in failed_fetches:
+            # Distinguish a FAILED fetch from genuinely-empty history:
+            # a systemic failure (the #655 endpoint 404 produced
+            # exactly this signature) must not masquerade as data
+            # sparsity in the funnel.
+            fetch_failures += 1
+            if fetch_failures == 1:
+                logger.warning(
+                    "entry-candle fetch FAILED for %s — if this"
+                    " repeats, the skip counts reflect an API"
+                    " problem, not data sparsity (#666)", m.ticker,
+                )
+            continue
+        if candle is None:
+            skipped_no_candle += 1
+            logger.debug(
+                "no entry candle for %s: no candles <= entry_ts",
+                m.ticker,
+            )
+            continue
+        if candle_midpoint(candle) <= 0:
+            # One-sided quote: no priceable midpoint; trade-price
+            # OHLC stays deliberately rejected as a fallback (stale on
+            # thin days, #655). Counted separately because these skips
+            # can bias the sample away from near-certain late-life
+            # contracts — exactly the gimme population (#666).
+            skipped_one_sided += 1
+            logger.debug(
+                "one-sided entry quote for %s (bid=%s ask=%s)",
+                m.ticker, candle.yes_bid_close, candle.yes_ask_close,
+            )
+            continue
+        if entry_ts - candle.end_period_ts > 86400:
+            logger.debug(
+                "entry candle for %s is %.1f days older than"
+                " entry_ts — stale-quote pricing (#666 residual)",
+                m.ticker, (entry_ts - candle.end_period_ts) / 86400,
+            )
+        entry_candles[m.ticker] = candle
+        entry_times[m.ticker] = entry_time
+
+    # Build the views AFTER the fetch pass: the synthetic close must
+    # be honest RELATIVE TO FILTER TIME — computing it before a
+    # multi-minute fetch pass would leave days-to-resolution just
+    # under ENTRY_OFFSET_DAYS and silently zero out configs with
+    # min_days_to_resolution == ENTRY_OFFSET_DAYS (review-found).
+    synthetic_close = datetime.now(UTC) + timedelta(
+        days=ENTRY_OFFSET_DAYS, seconds=60,
+    )
+    entry_views: dict[str, Market] = {
+        ticker: _entry_day_view(
+            original_by_ticker[ticker], candle, synthetic_close,
+        )
+        for ticker, candle in entry_candles.items()
+    }
+
+    # --- 3-4. Filter, Score, Identify trades — per side ---
+    pending: list[_PendingTrade] = []
     skipped_entry_gates = 0
     seen_tickers: set[str] = set()
     total_passed = 0
@@ -500,25 +603,24 @@ async def run_backtest(
         side_threshold = side_cfg.strategy.gimme_threshold
         side_series = side_cfg.scanner.series
 
-        # --- 2. Filter (restrict to this side's series) ---
+        # --- 3. Filter + Score on the entry-day views (#666) ---
         # series_ticker may be empty on settled markets, so match
         # by ticker prefix (e.g., "KXCPI" matches "KXCPI-26MAR-T1.3")
         side_prefixes = tuple(s + "-" for s in side_series) if side_series else ()
-        side_adapted = [
-            m for m in adapted
-            if not side_prefixes or m.ticker.startswith(side_prefixes)
+        side_views = [
+            v for v in entry_views.values()
+            if not side_prefixes or v.ticker.startswith(side_prefixes)
         ]
-        passed = filter_markets(side_adapted, side_cfg)
+        passed = filter_markets(side_views, side_cfg)
         total_passed += len(passed)
 
-        # --- 3. Score ---
         # Mirror live gating (validator.py:152-175): gimme_threshold +
-        # min_true_probability + min_edge_after_fees (#592).
+        # min_true_probability + min_edge_after_fees (#592). The
+        # price band already ran inside filter_markets on the SAME
+        # entry-day midpoint, so pass 1 keeps only the gates the
+        # filter doesn't apply: true-prob and edge-after-fees.
         min_true_prob = side_cfg.strategy.min_true_probability
         min_edge = side_cfg.strategy.min_edge_after_fees
-        # #655: NO price/prob/edge gating here — those gates now run on
-        # the ENTRY-DAY candle price in pass 1, not the settlement-time
-        # snapshot. total_scored counts score-threshold passers.
         scored: list[tuple[Market, Market, float]] = []
         for m in passed:
             s = quick_score(m, side_cfg)
@@ -534,33 +636,18 @@ async def run_backtest(
         )
 
         # --- 4. Pass 1: identify qualifying trades ---
-        # #655: entry is priced, gated, and sized on the ENTRY-DAY
-        # candle — settlement data is used only for the payout.
-        for _, orig_m, _score in scored:
+        # #655/#666: everything the engine decides is decided at the
+        # entry-day price — settlement supplies only the payout.
+        for view, orig_m, _score in scored:
             if orig_m.ticker in seen_tickers:
                 continue
             if orig_m.close_time is None:
                 continue
 
-            entry_time = orig_m.close_time - timedelta(
-                days=ENTRY_OFFSET_DAYS,
-            )
-            entry_ts = int(entry_time.timestamp())
             ticker = orig_m.ticker
-            mid = await _entry_day_mid(
-                client, ticker, entry_ts, candle_cache,
-            )
-            if mid <= 0:
-                skipped_no_candle += 1
-                continue
+            entry_time = entry_times[ticker]
+            mid = view.midpoint
             entry_eff = effective_price(mid, scan_side)
-            if not (
-                side_cfg.strategy.min_market_price
-                <= entry_eff
-                <= side_cfg.strategy.max_market_price
-            ):
-                skipped_entry_gates += 1
-                continue
             true_prob = min(entry_eff + config.assumed_edge, 0.99)
             true_prob = apply_base_rate_floor(
                 true_prob, ticker, side=scan_side,
@@ -692,6 +779,8 @@ async def run_backtest(
         markets_traded=traded_count,
         skipped_concentration=skipped_concentration,
         skipped_no_candle=skipped_no_candle,
+        skipped_one_sided=skipped_one_sided,
+        fetch_failures=fetch_failures,
         skipped_entry_gates=skipped_entry_gates,
         skipped_balance=skipped_balance,
         truncated_chunks=truncated_chunks,

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -116,7 +116,7 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         )
     if result.skipped_one_sided > 0:
         funnel.add_row(
-            "Skipped (one-sided entry-day quote)",
+            "Skipped (one-sided/empty entry-day quote)",
             str(result.skipped_one_sided),
         )
     if result.fetch_failures > 0:
@@ -145,7 +145,10 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
             f" ENTRY-DAY values (they are typically lower than"
             f" settlement-time values) (#666).[/yellow]"
         )
-    candle_skips = result.skipped_no_candle + result.skipped_one_sided
+    candle_skips = (
+        result.skipped_no_candle + result.skipped_one_sided
+        + result.fetch_failures
+    )
     if (
         result.markets_scanned > 0
         and candle_skips > 0.5 * result.markets_scanned
@@ -153,7 +156,8 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         console.print(
             f"[yellow]Caution: the selection replay skipped"
             f" {candle_skips} of {result.markets_scanned} scanned"
-            f" markets for missing or one-sided entry candles —"
+            f" markets for missing, unusable, or fetch-failed entry"
+            f" candles —"
             f" results cover a subset of the scanned universe, and"
             f" one-sided skips can under-represent near-certain"
             f" late-life contracts (#666).[/yellow]"

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -91,7 +91,12 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
     funnel.add_column("Label", style="cyan")
     funnel.add_column("Count", justify="right")
     funnel.add_row("Settled markets fetched", str(result.markets_scanned))
-    funnel.add_row("Passed scanner filters", str(result.markets_passed_filter))
+    usable_views = (
+        result.markets_scanned - result.skipped_no_candle
+        - result.skipped_one_sided - result.fetch_failures
+    )
+    funnel.add_row("Usable entry-day views", str(usable_views))
+    funnel.add_row("Passed entry-day filters", str(result.markets_passed_filter))
     funnel.add_row("Scored above threshold", str(result.markets_scored))
     funnel.add_row("Traded", str(result.markets_traded))
     if result.skipped_concentration > 0:
@@ -106,24 +111,52 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         )
     if result.skipped_no_candle > 0:
         funnel.add_row(
-            "Skipped (no usable entry-day candle)",
+            "Skipped (no entry-day candle history)",
             str(result.skipped_no_candle),
+        )
+    if result.skipped_one_sided > 0:
+        funnel.add_row(
+            "Skipped (one-sided entry-day quote)",
+            str(result.skipped_one_sided),
+        )
+    if result.fetch_failures > 0:
+        funnel.add_row(
+            "Candle fetch FAILURES (API problem)",
+            str(result.fetch_failures),
         )
     if result.skipped_entry_gates > 0:
         funnel.add_row(
-            "Skipped (entry-day price gates)",
+            "Skipped (entry-day prob/edge gates)",
             str(result.skipped_entry_gates),
         )
     console.print(funnel)
+    if result.fetch_failures > 0:
+        console.print(
+            f"[red]Warning: {result.fetch_failures} candle fetches"
+            f" FAILED — the skip counts may reflect an API problem,"
+            f" not data sparsity (#666). The #655 endpoint regression"
+            f" produced exactly this signature.[/red]"
+        )
+    if result.markets_passed_filter == 0 and usable_views > 0:
+        console.print(
+            f"[yellow]Note: all {usable_views} entry-day views failed"
+            f" the scanner filters — check min_volume /"
+            f" min_open_interest / days-to-resolution against"
+            f" ENTRY-DAY values (they are typically lower than"
+            f" settlement-time values) (#666).[/yellow]"
+        )
+    candle_skips = result.skipped_no_candle + result.skipped_one_sided
     if (
-        result.markets_scored > 0
-        and result.skipped_no_candle > 0.5 * result.markets_scored
+        result.markets_scanned > 0
+        and candle_skips > 0.5 * result.markets_scanned
     ):
         console.print(
-            "[yellow]Caution: entry-day candle data missing or"
-            " unusable (e.g. one-sided quotes) for most candidates —"
-            " results cover a subset of the scored markets"
-            " (#655).[/yellow]"
+            f"[yellow]Caution: the selection replay skipped"
+            f" {candle_skips} of {result.markets_scanned} scanned"
+            f" markets for missing or one-sided entry candles —"
+            f" results cover a subset of the scanned universe, and"
+            f" one-sided skips can under-represent near-certain"
+            f" late-life contracts (#666).[/yellow]"
         )
     if result.truncated_chunks:
         console.print(
@@ -225,6 +258,8 @@ def backtest_result_to_json(result: BacktestResult) -> dict:  # type: ignore[typ
             "markets_scored": result.markets_scored,
             "markets_traded": result.markets_traded,
             "skipped_no_candle": result.skipped_no_candle,
+            "skipped_one_sided": result.skipped_one_sided,
+            "fetch_failures": result.fetch_failures,
             "skipped_entry_gates": result.skipped_entry_gates,
             "truncated_chunks": result.truncated_chunks,
         },

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3844,6 +3844,18 @@ def backtest(
             f"[dim]Running backtest: {start} to {end}, "
             f"${balance:,.0f} starting balance...[/dim]"
         )
+        # #666: the selection replay fetches candles for every scanned
+        # market (~minutes) — surface the engine's progress logs so
+        # the run doesn't look hung. Scoped to the backtest logger;
+        # INFO records are otherwise dropped (no root handler).
+        import logging
+
+        bt_logger = logging.getLogger("gimmes.backtest.engine")
+        if not bt_logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            bt_logger.addHandler(handler)
+            bt_logger.setLevel(logging.INFO)
         async with KalshiClient(config) as client:
             result = await run_backtest(client, bt_config)
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3851,11 +3851,14 @@ def backtest(
         import logging
 
         bt_logger = logging.getLogger("gimmes.backtest.engine")
+        bt_logger.setLevel(logging.INFO)
         if not bt_logger.handlers:
             handler = logging.StreamHandler()
             handler.setFormatter(logging.Formatter("%(message)s"))
             bt_logger.addHandler(handler)
-            bt_logger.setLevel(logging.INFO)
+            # our handler owns the output — don't also propagate to
+            # ancestor handlers (duplicate lines)
+            bt_logger.propagate = False
         async with KalshiClient(config) as client:
             result = await run_backtest(client, bt_config)
 

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -595,10 +595,9 @@ class TestEntryDayPricing:
     the ENTRY-DAY candle — settlement data reaches only the payout."""
 
     def _markets(self):
-        # Settlement quotes 0.25/0.35 → NO eff at settlement = 0.70
-        # (inside the scanner band — selection still reads settlement
-        # data by design; only entry pricing/gating moved to the
-        # entry-day candle in #655).
+        # Settlement quotes 0.25/0.35 → NO eff at settlement = 0.70.
+        # Since #666 selection ALSO runs on the entry-day candle, the
+        # settlement quotes are payout-only context here.
         return [_settled_market("KXCPI-26MAR-T0.5",
                                 yes_bid=0.25, yes_ask=0.35)]
 
@@ -701,7 +700,11 @@ class TestEntryDayPricing:
 
         result = await self._run()
         assert result.trades == []
-        assert result.skipped_entry_gates == 1
+        # #666: the price band now runs inside filter_markets on the
+        # entry-day view — the market never passes the filter, so it
+        # never reaches the pass-1 prob/edge gates.
+        assert result.markets_passed_filter == 0
+        assert result.skipped_entry_gates == 0
 
     @pytest.mark.asyncio
     async def test_no_candle_dropped(self, monkeypatch) -> None:
@@ -724,7 +727,10 @@ class TestEntryDayPricing:
 
         result = await self._run()
         assert result.trades == []
-        assert result.skipped_no_candle == 1
+        # #666: a FAILED fetch is counted apart from empty history —
+        # a systemic API failure must not masquerade as data sparsity.
+        assert result.fetch_failures == 1
+        assert result.skipped_no_candle == 0
 
     @pytest.mark.asyncio
     async def test_degenerate_quote_dropped(self, monkeypatch) -> None:
@@ -737,7 +743,11 @@ class TestEntryDayPricing:
 
         result = await self._run()
         assert result.trades == []
-        assert result.skipped_no_candle == 1
+        # #666: one-sided quotes get their own counter — they can
+        # bias the sample away from near-certain late-life contracts
+        # and must be visible separately from missing history.
+        assert result.skipped_one_sided == 1
+        assert result.skipped_no_candle == 0
 
     @pytest.mark.asyncio
     async def test_future_candle_not_used(self, monkeypatch) -> None:
@@ -773,3 +783,223 @@ class TestEntryCandleHelpers:
         assert entry_candle_at([c1, c2, c3], 250) is c2
         assert entry_candle_at([c1, c2, c3], 50) is None
         assert entry_candle_at([], 100) is None
+
+
+class TestEntryDaySelection:
+    """#666 regression suite: the candidate SET is selected through
+    the entry-day lens — settlement snapshots never reach
+    filter_markets/quick_score."""
+
+    _pricing = TestEntryDayPricing()
+
+    def _stub(self, monkeypatch, markets, candles_by_ticker):
+        return self._pricing._stub(monkeypatch, markets, candles_by_ticker)
+
+    async def _run(self, config=None):
+        return await self._pricing._run(config)
+
+    @pytest.mark.asyncio
+    async def test_pessimistic_omission_fixed(self, monkeypatch) -> None:
+        """A market OUT of band at settlement but IN band on entry day
+        must now be selected and traded — the settlement lens made it
+        invisible."""
+        m = _settled_market(
+            "KXCPI-26MAR-T0.5", yes_bid=0.01, yes_ask=0.03,
+        )  # settlement NO eff ~0.98 — outside the band
+        candles = {m.ticker: [_make_candle(
+            ts=self._pricing._entry_ts(m),
+            yes_bid_close=0.30, yes_ask_close=0.40,  # entry NO eff 0.65
+        )]}
+        self._stub(monkeypatch, [m], candles)
+
+        result = await self._run()
+        assert len(result.trades) == 1
+        assert result.trades[0].entry_price == pytest.approx(0.65)
+
+    @pytest.mark.asyncio
+    async def test_optimistic_volume_gating_fixed(self, monkeypatch) -> None:
+        """Settlement volume passes the min but the ENTRY-DAY candle
+        volume doesn't — the market must be filtered out (end-of-life
+        liquidity was gating optimistically)."""
+        m = _settled_market(
+            "KXCPI-26MAR-T0.5", yes_bid=0.25, yes_ask=0.35,
+        )  # settlement volume_24h=1000 (helper default)
+        candles = {m.ticker: [_make_candle(
+            ts=self._pricing._entry_ts(m),
+            yes_bid_close=0.25, yes_ask_close=0.35,
+            volume=0,  # no entry-day liquidity
+        )]}
+        self._stub(monkeypatch, [m], candles)
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.markets_passed_filter == 0
+
+    @pytest.mark.asyncio
+    async def test_optimistic_oi_gating_fixed(self, monkeypatch) -> None:
+        m = _settled_market(
+            "KXCPI-26MAR-T0.5", yes_bid=0.25, yes_ask=0.35,
+        )  # settlement OI=5000
+        candles = {m.ticker: [_make_candle(
+            ts=self._pricing._entry_ts(m),
+            yes_bid_close=0.25, yes_ask_close=0.35,
+            open_interest=0,
+        )]}
+        self._stub(monkeypatch, [m], candles)
+
+        result = await self._run()
+        assert result.trades == []
+        assert result.markets_passed_filter == 0
+
+    @pytest.mark.asyncio
+    async def test_counter_split_mixed_population(self, monkeypatch) -> None:
+        close = _FIXED_CLOSE_TIME
+        healthy = _settled_market(
+            "KXCPI-26MAR-T0.5", yes_bid=0.25, yes_ask=0.35,
+            close_time=close,
+        )
+        one_sided = _settled_market(
+            "KXCPI-26MAR-T0.6", yes_bid=0.25, yes_ask=0.35,
+            close_time=close,
+        )
+        no_history = _settled_market(
+            "KXCPI-26MAR-T0.7", yes_bid=0.25, yes_ask=0.35,
+            close_time=close,
+        )
+        entry_ts = self._pricing._entry_ts(healthy)
+        candles = {
+            healthy.ticker: [_make_candle(
+                ts=entry_ts, yes_bid_close=0.25, yes_ask_close=0.35,
+            )],
+            one_sided.ticker: [_make_candle(
+                ts=entry_ts, yes_bid_close=0.30, yes_ask_close=0.0,
+            )],
+            no_history.ticker: [],
+        }
+        self._stub(monkeypatch, [healthy, one_sided, no_history], candles)
+
+        result = await self._run()
+        assert result.skipped_one_sided == 1
+        assert result.skipped_no_candle == 1
+        assert len(result.trades) == 1
+
+    @pytest.mark.asyncio
+    async def test_one_fetch_per_unique_ticker(self, monkeypatch) -> None:
+        """The selection replay fetches each ticker's candles exactly
+        once — the cache absorbs the side loop and pass 1."""
+        markets = [
+            _settled_market(
+                f"KXCPI-26MAR-T0.{i}", yes_bid=0.25, yes_ask=0.35,
+            )
+            for i in range(1, 4)
+        ]
+        entry_ts = self._pricing._entry_ts(markets[0])
+        candles = {
+            m.ticker: [_make_candle(
+                ts=entry_ts, yes_bid_close=0.25, yes_ask_close=0.35,
+            )]
+            for m in markets
+        }
+        calls = self._stub(monkeypatch, markets, candles)
+
+        await self._run()
+        fetched = [c["ticker"] for c in calls]
+        assert sorted(fetched) == sorted(m.ticker for m in markets)
+        assert len(fetched) == len(set(fetched))
+
+    @pytest.mark.asyncio
+    async def test_score_reads_candle_liquidity(self, monkeypatch) -> None:
+        """quick_score must consume the ENTRY-DAY view, not the
+        settlement snapshot: with the threshold pinned between the
+        settlement score (~rich liquidity) and the entry-day score
+        (thin volume/OI, wide spread), a settlement-lens regression
+        would trade; the entry-day lens must not (#666 review — the
+        one-token-away mutant feeding original_by_ticker into
+        quick_score)."""
+        m = _settled_market(
+            "KXCPI-26MAR-T0.5", yes_bid=0.25, yes_ask=0.35,
+        )  # settlement: volume_24h=1000, OI=5000, spread 0.10
+        candles = {m.ticker: [_make_candle(
+            ts=self._pricing._entry_ts(m),
+            yes_bid_close=0.20, yes_ask_close=0.40,  # wide spread
+            volume=120, open_interest=60,  # passes filter mins, thin
+        )]}
+        self._stub(monkeypatch, [m], candles)
+
+        config = _backtest_config_with_overrides(
+            min_true_probability=0.0, min_edge_after_fees=-1.0,
+        )
+        from gimmes.strategy.scorer import quick_score
+
+        # Pin the threshold strictly between the two lens scores.
+        settlement_score = quick_score(m, config.gimmes_config)
+        entry_view_score = quick_score(
+            m.model_copy(update={
+                "yes_bid": 0.20, "yes_ask": 0.40, "last_price": 0.0,
+                "volume": 120, "volume_24h": 120, "open_interest": 60,
+            }),
+            config.gimmes_config,
+        )
+        assert entry_view_score < settlement_score
+        config.gimmes_config.strategy.gimme_threshold = (
+            entry_view_score + settlement_score
+        ) / 2
+
+        result = await self._run(config)
+        assert result.trades == []
+        assert result.markets_scored == 0
+        assert result.markets_passed_filter == 1  # filter passed; score gated
+
+    @pytest.mark.asyncio
+    async def test_min_days_above_offset_warns_and_selects_nothing(
+        self, monkeypatch, caplog,
+    ) -> None:
+        """The honest synthetic close (now + ENTRY_OFFSET_DAYS) means
+        a min_days_to_resolution above the fixed offset selects
+        nothing — that must be loud, not a silent data outage."""
+        m = _settled_market("KXCPI-26MAR-T0.5", yes_bid=0.25, yes_ask=0.35)
+        candles = {m.ticker: [_make_candle(
+            ts=self._pricing._entry_ts(m),
+            yes_bid_close=0.25, yes_ask_close=0.35,
+        )]}
+        self._stub(monkeypatch, [m], candles)
+
+        config = _backtest_config_with_overrides(
+            min_true_probability=0.0, min_edge_after_fees=-1.0,
+        )
+        config.gimmes_config.scanner.min_days_to_resolution = 2.0
+        with caplog.at_level("WARNING", logger="gimmes.backtest.engine"):
+            result = await self._run(config)
+        assert result.trades == []
+        assert result.markets_passed_filter == 0
+        assert any(
+            "min_days_to_resolution" in r.message for r in caplog.records
+        )
+
+
+class TestEntryDayView:
+    """Unit pins for the #666 synthetic entry-day Market."""
+
+    def test_field_mapping(self) -> None:
+        from gimmes.backtest.engine import _entry_day_view
+
+        m = _settled_market("KXCPI-26MAR-T0.5", yes_bid=0.10, yes_ask=0.20)
+        candle = _make_candle(
+            yes_bid_close=0.30, yes_ask_close=0.42,
+            volume=77, open_interest=88,
+        )
+        close = datetime(2027, 1, 1, tzinfo=UTC)
+        view = _entry_day_view(m, candle, close)
+
+        assert view.yes_bid == 0.30
+        assert view.yes_ask == 0.42
+        assert view.midpoint == pytest.approx(0.36)
+        assert view.spread == pytest.approx(0.12)
+        assert view.last_price == 0.0  # never fall back to stale trades
+        assert view.volume == 77
+        assert view.volume_24h == 77
+        assert view.open_interest == 88
+        assert view.close_time == close
+        assert view.status.value == "active"
+        # the settled original is untouched
+        assert m.yes_bid == 0.10

--- a/tests/unit/test_backtest_report.py
+++ b/tests/unit/test_backtest_report.py
@@ -119,6 +119,7 @@ class TestFormatBacktestReport:
         output = buf.getvalue()
         assert "Backtest Config" in output
         assert "Performance Summary" in output
+        assert "Usable entry-day views" in output  # #666 funnel row
 
     def test_handles_no_trades(self) -> None:
         from io import StringIO
@@ -201,19 +202,69 @@ class TestSkipCountersInReport:
     def test_json_carries_skip_counters(self) -> None:
         result = _make_result()
         result.skipped_no_candle = 3
+        result.skipped_one_sided = 2
         result.skipped_entry_gates = 5
         data = backtest_result_to_json(result)
         assert data["funnel"]["skipped_no_candle"] == 3
+        assert data["funnel"]["skipped_one_sided"] == 2
         assert data["funnel"]["skipped_entry_gates"] == 5
+
+    def test_fetch_failures_render_red_warning(self) -> None:
+        """#666: FAILED fetches are an API-problem signal (the #655
+        endpoint 404 signature), never silent data sparsity."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.fetch_failures = 7
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        out = buf.getvalue()
+        assert "FAILED" in out
+        assert "API problem" in out
+
+    def test_json_carries_fetch_failures(self) -> None:
+        result = _make_result()
+        result.fetch_failures = 3
+        data = backtest_result_to_json(result)
+        assert data["funnel"]["fetch_failures"] == 3
+
+    def test_zero_passed_note_names_the_lens(self) -> None:
+        """#666: passed=0 with usable views must explain itself —
+        entry-day values are typically lower than settlement."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.markets_passed_filter = 0
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "ENTRY-DAY values" in buf.getvalue()
+
+    def test_one_sided_funnel_row_renders(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.skipped_one_sided = 4
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "one-sided" in buf.getvalue()
 
     def test_coverage_warning_fires_above_half(self) -> None:
         from io import StringIO
 
         from rich.console import Console
 
+        # #666: the caution denominator is the SCANNED universe now —
+        # candle skips happen before scoring.
         result = _make_result()
-        result.markets_scored = 10
-        result.skipped_no_candle = 6
+        result.markets_scanned = 10
+        result.skipped_no_candle = 4
+        result.skipped_one_sided = 2
         buf = StringIO()
         format_backtest_report(result, Console(file=buf, width=120))
         assert "Caution" in buf.getvalue()
@@ -224,8 +275,9 @@ class TestSkipCountersInReport:
         from rich.console import Console
 
         result = _make_result()
-        result.markets_scored = 10
-        result.skipped_no_candle = 5
+        result.markets_scanned = 10
+        result.skipped_no_candle = 3
+        result.skipped_one_sided = 2
         buf = StringIO()
         format_backtest_report(result, Console(file=buf, width=120))
         assert "Caution" not in buf.getvalue()


### PR DESCRIPTION
## Summary

**The last known look-ahead in the backtest.** #655 moved entry pricing/gating/sizing to entry-day candles, but the candidate *set* was still chosen from settlement-time snapshots — `filter_markets`/`quick_score` read midpoint, volume, OI, and spread from the settled market. In-band-at-entry markets that drifted out by settlement were invisible (pessimistic omission); end-of-life liquidity gated optimistically.

### The fix
- **Selection replay on entry-day views**: one candle fetch per scanned market, then filter+score on synthetic Markets whose bid/ask/spread/volume/OI all come from the entry-day candle (daily candle volume IS the day's 24h volume; `last_price=0.0` so the midpoint can never fall back to stale trades). The scanner/scorer are **untouched** — live trading sees zero change. Pass 1's duplicate price-band check is deleted (the filter applies the identical band to the identical midpoint).
- **Honest synthetic close, computed after the fetch pass** — the review caught that computing it before the multi-minute pass left days-to-resolution just under the 1-day entry offset, silently zeroing `min_days_to_resolution=1.0` configs (a value the config help text itself suggests). A warning fires when the days config excludes the fixed offset.
- **Three-way skip counter split** (the issue-comment ask): `skipped_no_candle` (no history) / `skipped_one_sided` (one-sided quote — the bias against near-certain late-life gimmes, now quantified) / `fetch_failures` (API problems — the #655 endpoint-404 signature gets a red report warning and can never masquerade as data sparsity). Funnel gains a Usable-views row and a zero-passed explanation; all existing JSON keys kept, two added.
- Progress surfaced via a scoped CLI log handler (the engine's INFO logs were previously dropped — multi-minute silence looked hung).

### Live-verified (May 1–20)
1044 scanned → 489 no-candle + 398 one-sided → **15 passed entry-day filters → 12 scored → 7 traded, net −$1,432**. 85% of the settled universe lacks usable entry-day data — visible honestly for the first time, with the coverage caution naming the one-sided bias.

## Review
Full pipeline + simplifier. 11/11 new tests fix-discriminating (verified against pre-fix code on scratchpad copies); mutations killed incl. the settlement-volume view, counter merge, and honest-close revert; the surviving score-lens mutant got a threshold-straddling killing test. Review-found bugs (synthetic-close timing, fetch-failure conflation, dead progress logging, zero-passed opacity) all fixed in-pass. Deferred items in **#682**.

## Test plan
- `uv run pytest tests/unit/test_backtest_engine.py tests/unit/test_backtest_report.py` — TestEntryDaySelection (pessimistic-omission, volume/OI optimistic-gating, score-lens, counter split, one-fetch-per-ticker, days-config warning), TestEntryDayView field-mapping pins, updated #655 suite, report/JSON pins.
- Full suite: 1800 passed; ruff clean. Live smoke run attached above.

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB