### PR TITLE
Fix #663: authoritative settlement source, resting-sell clamp, manual-close repricing

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1931,6 +1931,69 @@ def risk_check() -> None:
     _run(_check())
 
 
+async def _settle_removed_positions(
+    client, db, old_tickers, removed: set[str],
+) -> int:
+    """Write settlement closes for removed positions that match
+    authoritative settlement records (#663). Returns the number of
+    positions settled. Commit-per-ticker; residual <= 0 tickers are
+    skipped (the drift close is then also suppressed by the #653
+    dup-guard, and a history-less ticker must NOT be pre-written or
+    it would produce BOTH rows)."""
+    from datetime import datetime
+
+    from gimmes.kalshi.portfolio import get_settlements_for_tickers
+    from gimmes.store.queries import (
+        count_opened_closed,
+        log_settlement_close,
+    )
+
+    records = await get_settlements_for_tickers(client, removed)
+    settled = 0
+    for ticker, rec in records.items():
+        result = str(rec.get("market_result", ""))
+        if result not in ("yes", "no"):
+            continue  # unsettleable record — fall back to drift
+        pos = old_tickers[ticker]
+        opened, closed = await count_opened_closed(
+            db, ticker, pos.side,
+        )
+        residual = opened - closed
+        if opened <= 0 or residual <= 0:
+            continue
+        if residual != pos.count:
+            import logging
+
+            logging.getLogger("gimmes").warning(
+                "settlement residual mismatch for %s: ledger %d vs"
+                " broker %d — using the ledger (#663)",
+                ticker, residual, pos.count,
+            )
+        raw_time = str(rec.get("settled_time", ""))
+        try:
+            settled_time: datetime | None = datetime.fromisoformat(
+                raw_time.replace("Z", "+00:00"),
+            )
+        except ValueError:
+            settled_time = None
+        await log_settlement_close(
+            db,
+            ticker=ticker,
+            side=pos.side,
+            count=residual,
+            won=pos.side == result,
+            timestamp=settled_time,
+            rationale=(
+                "market settled — outcome consumed from the"
+                " authoritative portfolio settlements endpoint"
+                " during reconcile (#663)"
+            ),
+        )
+        await db.conn.commit()
+        settled += 1
+    return settled
+
+
 @app.command(rich_help_panel="Portfolio")
 def reconcile() -> None:
     """Sync local position data with the authoritative source.
@@ -1999,6 +2062,55 @@ def reconcile() -> None:
                 from gimmes.kalshi.portfolio import get_all_positions
                 fresh = await get_all_positions(client)
                 source = "Kalshi API"
+
+            # #663: championship-mode settlements are consumed from
+            # the AUTHORITATIVE portfolio settlements endpoint before
+            # the sync — a settled position gets a proper
+            # agent='settlement' close at the true 1.0/0.0 value
+            # instead of an agent='reconcile' drift row at the stale
+            # mark. The #653 dup-guard (closed >= opened) then
+            # suppresses the drift close for the pre-written tickers,
+            # so sync_positions needs no signature change, and the
+            # pre-write is crash-idempotent (a retry finds residual
+            # <= 0 and skips). Any settlements-API failure degrades
+            # to today's drift behavior — reconcile is never blocked.
+            if not broker:
+                prospective_removed = (
+                    old_tickers.keys() - {p.ticker for p in fresh}
+                )
+                if prospective_removed:
+                    try:
+                        settled_count = await _settle_removed_positions(
+                            client, db, old_tickers,
+                            prospective_removed,
+                        )
+                        if settled_count:
+                            console.print(
+                                f"  [green]{settled_count} removed"
+                                f" position(s) matched settlement"
+                                f" records — closed at settlement"
+                                f" value (#663)[/green]"
+                            )
+                    except Exception as exc:
+                        import logging
+
+                        # A mid-write failure leaves the per-ticker
+                        # implicit transaction open — without a
+                        # rollback, sync_positions' BEGIN IMMEDIATE
+                        # below would die on "cannot start a
+                        # transaction within a transaction" and the
+                        # promised drift fallback would never run.
+                        await db.conn.rollback()
+                        logging.getLogger("gimmes").warning(
+                            "settlements lookup failed — falling back"
+                            " to reconcile drift (#663): %s", exc,
+                            exc_info=True,
+                        )
+                        console.print(
+                            f"  [yellow]Warning: settlements lookup"
+                            f" failed ({exc}) — removed positions"
+                            f" fall back to drift closes[/yellow]"
+                        )
 
             await sync_positions(db, fresh)
 
@@ -2503,14 +2615,20 @@ def backfill_settlements(
         repaired: list[tuple[str, float, float]] = []
         conflicts: list[tuple[str, str, str]] = []
 
+        ran = False
         async with Database(config.db_path) as db:
             try:
-                await _apply(db, inserted, repaired, conflicts)
+                ran = await _apply(db, inserted, repaired, conflicts)
             except _DryRunRollbackError:
+                ran = True
                 console.print("[dim]Dry run — no changes written.[/dim]")
-        _print_summary(inserted, repaired, conflicts, dry_run)
+        # #663: a no-table run already explained itself — an
+        # "Inserted 0" summary after that reads as a second, wrong
+        # answer.
+        if ran:
+            _print_summary(inserted, repaired, conflicts, dry_run)
 
-    async def _apply(db, inserted, repaired, conflicts) -> None:  # type: ignore[no-untyped-def]
+    async def _apply(db, inserted, repaired, conflicts) -> bool:  # type: ignore[no-untyped-def]
         from datetime import UTC, datetime
 
         from gimmes.store.queries import (
@@ -2533,12 +2651,20 @@ def backfill_settlements(
                     " backfill (#653 applies to paper-mode"
                     " settlements).[/yellow]"
                 )
-                return
+                return False
+            # #663: cost_basis > 0 makes the fingerprint sound — at
+            # count = 0 only settle() leaves cost_basis intact (a full
+            # sell drives it to 0 via the count ratio, and mark
+            # updates only touch count > 0 rows). Do NOT also require
+            # realized_pnl < 0 for 0.0 marks: realized_pnl is
+            # cumulative, so a settled loss after profitable partial
+            # sells can end lifetime-positive.
             cursor = await db.conn.execute(
                 "SELECT ticker, side, avg_price, cost_basis,"
                 " market_price, updated_at"
                 " FROM paper_positions"
-                " WHERE count = 0 AND market_price IN (0.0, 1.0)",
+                " WHERE count = 0 AND cost_basis > 0"
+                " AND market_price IN (0.0, 1.0)",
             )
             settled = [dict(r) for r in await cursor.fetchall()]
 
@@ -2621,6 +2747,7 @@ def backfill_settlements(
                      ON p.ticker = t.ticker AND p.side = t.side
                    WHERE t.action = 'close' AND t.agent = 'reconcile'
                      AND p.count = 0
+                     AND p.cost_basis > 0
                      AND p.market_price IN (0.0, 1.0)
                      AND t.price != p.market_price""",
             )
@@ -2644,6 +2771,7 @@ def backfill_settlements(
 
             if dry_run:
                 raise _DryRunRollbackError
+        return True
 
     def _print_summary(inserted, repaired, conflicts, dry: bool) -> None:  # type: ignore[no-untyped-def]
         verb = "Would insert" if dry else "Inserted"

--- a/src/gimmes/kalshi/portfolio.py
+++ b/src/gimmes/kalshi/portfolio.py
@@ -108,3 +108,68 @@ async def get_settlements(
     settlements = data.get("settlements", [])
     next_cursor = data.get("cursor")
     return settlements, next_cursor
+
+
+async def get_settlements_for_tickers(
+    client: KalshiClient,
+    tickers: set[str],
+    *,
+    max_pages: int = 10,
+    lookback_days: int = 30,
+) -> dict[str, dict]:  # type: ignore[type-arg]
+    """Newest settlement record per requested ticker (#663).
+
+    The settlements endpoint returns account-lifetime records, newest
+    first (live-probed schema: ticker, market_result 'yes'|'no',
+    settled_time ISO-Z, yes/no_count_fp strings). Three stop
+    conditions bound the walk: every requested ticker matched, a
+    page's oldest settled_time older than the lookback window, or the
+    max_pages cap (the get_all_positions defensive pattern). Newest
+    record wins per ticker.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    if not tickers:
+        return {}
+    cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
+    found: dict[str, dict] = {}
+    cursor: str | None = None
+    for _ in range(max_pages):
+        settlements, cursor = await get_settlements(
+            client, limit=200, cursor=cursor,
+        )
+        if not settlements:
+            break
+        oldest_in_page: datetime | None = None
+        for rec in settlements:
+            ticker = rec.get("ticker", "")
+            settled_raw = str(rec.get("settled_time", ""))
+            try:
+                settled = datetime.fromisoformat(
+                    settled_raw.replace("Z", "+00:00"),
+                )
+            except ValueError:
+                settled = None
+            if settled is not None and (
+                oldest_in_page is None or settled < oldest_in_page
+            ):
+                oldest_in_page = settled
+            if ticker in tickers and ticker not in found:
+                found[ticker] = rec
+        if tickers <= found.keys():
+            break
+        if oldest_in_page is not None and oldest_in_page < cutoff:
+            break
+        if not cursor:
+            break
+    else:
+        missing = tickers - found.keys()
+        if missing:
+            import logging
+            logging.getLogger(__name__).warning(
+                "settlements pagination cap (%d pages) hit with %d"
+                " unmatched ticker(s): %s — they fall back to"
+                " reconcile drift (#663)",
+                max_pages, len(missing), sorted(missing),
+            )
+    return found

--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -598,7 +598,12 @@ class PaperBroker:
         if not rows:
             return
 
-        from gimmes.store.queries import log_settlement_close
+        from gimmes.store.queries import (
+            count_opened_closed,
+            fill_resolved_outcome,
+            log_settlement_close,
+            settlement_outcome,
+        )
 
         async with self._db.transaction():
             for row in rows:
@@ -623,10 +628,50 @@ class PaperBroker:
                 # #653: settlements are real outcomes — write the close
                 # trade at settlement value so the lifetime scorecard
                 # sees the W/L (previously only the balance knew).
-                await log_settlement_close(
-                    self._db, ticker=ticker, side=side,
-                    count=count, won=won,
+                # #663: clamp to the LEDGER residual — a resting sell
+                # logged its close row at placement without reducing
+                # the paper position, so a full-count settlement row
+                # would double-count the close in daily P&L (and the
+                # daily-loss trigger). opened == 0 (no local trade
+                # history: seeded/legacy positions) keeps the
+                # full-count behavior.
+                opened, closed = await count_opened_closed(
+                    self._db, ticker, side,
                 )
+                ledger_count = (
+                    count if opened <= 0
+                    else min(count, opened - closed)
+                )
+                # (ledger_count < count implies opened > 0 — the
+                # no-history branch sets ledger_count = count.)
+                if ledger_count < count:
+                    # Auditable divergence: the balance is credited
+                    # for the full broker count while the ledger row
+                    # covers less (a placement-time close row for a
+                    # never-filled resting sell also lands here).
+                    import logging
+
+                    logging.getLogger("gimmes").warning(
+                        "settlement close for %s %s clamped to ledger"
+                        " residual: opened=%d closed=%d broker"
+                        " count=%d -> row count=%d (#663)",
+                        ticker, side, opened, closed, count,
+                        max(ledger_count, 0),
+                    )
+                if ledger_count > 0:
+                    await log_settlement_close(
+                        self._db, ticker=ticker, side=side,
+                        count=ledger_count, won=won,
+                    )
+                else:
+                    # The ledger already covers the opens (e.g. a
+                    # placement-time close row for a resting sell) —
+                    # skip the trade row but keep the outcome
+                    # authoritative.
+                    await fill_resolved_outcome(
+                        self._db, ticker,
+                        settlement_outcome(side, won),
+                    )
 
             # #653: remove the mirror row in the main positions table
             # inside the SAME transaction — otherwise the next

--- a/src/gimmes/reporting/formatter.py
+++ b/src/gimmes/reporting/formatter.py
@@ -50,12 +50,15 @@ def format_pnl_summary(summary: PnLSummary) -> None:
     table.add_row("Total Trades", str(summary.total_trades))
     # #653: total = closed (W+L+scratch) + open — show the split so the
     # table is internally consistent instead of leaving readers to
-    # wonder where total - W - L - S trades went.
+    # wonder where total - W - L - S trades went. "Close Events" (#663):
+    # these are close trade rows, not distinct positions — a resting
+    # sell logs its close at placement, so the count can exceed the
+    # number of positions that actually exited.
     closed = (
         summary.winning_trades + summary.losing_trades
         + summary.scratch_trades
     )
-    table.add_row("Closed", str(closed))
+    table.add_row("Close Events", str(closed))
     table.add_row("Open Positions", str(summary.open_trades))
     table.add_row("Winning", str(summary.winning_trades))
     table.add_row("Losing", str(summary.losing_trades))

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -77,6 +77,14 @@ def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  
             ),
             None,
         )
+        # #663: a settlement close in the group means settlements were
+        # properly recorded for this position — any reconcile drift
+        # row alongside it is genuinely NON-settlement drift (e.g. a
+        # manual exit) and must keep its mark, not be repriced.
+        group_has_settlement = any(
+            e.get("agent") == "settlement" and e.get("action") == "close"
+            for e in events
+        )
 
         for e in events:
             action = e["action"]
@@ -93,6 +101,7 @@ def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  
                 action == "close"
                 and e.get("agent") == "reconcile"
                 and group_outcome is not None
+                and not group_has_settlement
             ):
                 price = 1.0 if side == group_outcome else 0.0
 

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -59,6 +59,12 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
             ),
             None,
         )
+        # #663: mirror calculate_pnl — drift rows in groups that carry
+        # a real settlement close keep their mark (manual exits).
+        group_has_settlement = any(
+            e.get("agent") == "settlement" and e.get("action") == "close"
+            for e in events
+        )
         remaining = 0
         avg_cost = 0.0
         entry_score = 0.0
@@ -85,7 +91,11 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
             remaining -= matched
             if matched <= 0:
                 continue
-            if e.get("agent") == "reconcile" and group_outcome is not None:
+            if (
+                e.get("agent") == "reconcile"
+                and group_outcome is not None
+                and not group_has_settlement
+            ):
                 price = 1.0 if side == group_outcome else 0.0
             realized = price - avg_cost
             won = (

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -198,6 +198,31 @@ class TestPairCloses:
         assert r["won"] is False
         assert r["realized_return"] == pytest.approx(-0.63)
 
+    def test_drift_keeps_mark_when_group_has_settlement(self) -> None:
+        """#663 mirror of calculate_pnl: a settlement close in the
+        group means the reconcile drift row is a manual exit — it
+        keeps its mark instead of being repriced to settlement."""
+        trades = _pair_group(
+            open_price=0.63, close_price=0.705, agent="reconcile",
+            resolved_outcome="no",  # yes side lost
+        )
+        trades[1]["count"] = 4
+        trades.append({
+            "ticker": trades[0]["ticker"], "action": "close",
+            "side": "yes", "count": 6, "price": 0.0,
+            "gimme_score": 0.0, "edge": 0.0,
+            "resolved_outcome": "no", "agent": "settlement",
+            "timestamp": "2026-01-03T10:00:00",
+        })
+        results = _pair_closes(trades)
+        drift = [
+            r for r in results
+            if r["timestamp"] == "2026-01-02T10:00:00"
+        ]
+        assert len(drift) == 1
+        # 0.705 mark kept — NOT repriced to the 0.0 settlement value.
+        assert drift[0]["realized_return"] == pytest.approx(0.705 - 0.63)
+
     def test_orphan_close_dropped(self) -> None:
         trades = [{
             "ticker": "GHOST", "action": "close", "side": "yes",

--- a/tests/unit/test_backfill_settlements.py
+++ b/tests/unit/test_backfill_settlements.py
@@ -64,6 +64,8 @@ def _seed(
     close_price: float = 0.9,
     paper_market_price: float = 1.0,
     paper_count: int = 0,
+    paper_cost_basis: float | None = None,
+    paper_realized_pnl: float | None = None,
 ) -> None:
     """Seed an open trade, an optional close, and a paper_positions row."""
 
@@ -94,9 +96,11 @@ def _seed(
                            '2026-04-24 12:00:00')""",
                 (
                     TICKER, paper_count, paper_market_price,
-                    open_count * 0.63,
-                    (open_count * 1.0 if paper_market_price == 1.0
-                     else 0.0) - open_count * 0.63,
+                    (open_count * 0.63 if paper_cost_basis is None
+                     else paper_cost_basis),
+                    (paper_realized_pnl if paper_realized_pnl is not None
+                     else (open_count * 1.0 if paper_market_price == 1.0
+                           else 0.0) - open_count * 0.63),
                 ),
             )
             await db.conn.commit()
@@ -356,3 +360,90 @@ def test_backfill_without_paper_positions_table(
     result = runner.invoke(app, ["backfill-settlements"])
     assert result.exit_code == 0, result.output
     assert "No paper_positions table" in result.output
+    # #663: the explanation is the whole answer — an "Inserted 0"
+    # summary after it reads as a second, contradictory report.
+    assert "Inserted" not in result.output
+
+
+def test_sold_out_position_not_mistaken_for_settlement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#663: a position fully SOLD before resolution ends at count=0
+    with cost_basis drained to 0 (the sell's count-ratio update). With
+    no local close rows (legacy/UI sell), the residual guard can't
+    save us — cost_basis > 0 must be the condition that stops the
+    old mark-only fingerprint from fabricating a settlement close."""
+    db_path = tmp_path / "test.db"
+    _seed(
+        db_path, open_count=100, paper_market_price=1.0,
+        paper_cost_basis=0.0, paper_realized_pnl=27.0,
+    )
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    assert _closes(db_path) == []  # nothing fabricated
+
+
+def test_partial_profit_then_settled_loss_still_backfilled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#663 review: realized_pnl is CUMULATIVE — a settled loss after
+    profitable partial sells ends lifetime-positive. The fingerprint
+    must not demand realized_pnl < 0 or this genuine #653 case is
+    silently dropped."""
+    db_path = tmp_path / "test.db"
+    _seed(
+        db_path, open_count=100, close_count=50, close_agent="closer",
+        close_price=0.8, paper_market_price=0.0,
+        paper_cost_basis=15.0, paper_realized_pnl=10.0,
+    )
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    closes = _closes(db_path)
+    settlement = [c for c in closes if c["agent"] == "settlement"]
+    assert len(settlement) == 1
+    assert settlement[0]["count"] == 50  # ledger residual
+    assert settlement[0]["price"] == 0.0
+
+
+def test_genuine_settlement_loss_still_backfilled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hardened fingerprint must not lose the case #653 exists
+    for: settled loss (mark 0.0, negative realized P&L, intact
+    cost basis) with no close row."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path, paper_market_price=0.0)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "settlement"
+    assert closes[0]["price"] == 0.0
+
+
+def test_drift_repair_skips_sold_out_position(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#663: the drift-repair phase carries the same cost_basis > 0
+    fingerprint — a fully-sold position whose stale mark sits at 0.0
+    must not have its reconcile close repriced to that mark."""
+    db_path = tmp_path / "test.db"
+    _seed(
+        db_path, open_count=100, close_count=100,
+        close_agent="reconcile", close_price=0.9,
+        paper_market_price=0.0, paper_cost_basis=0.0,
+        paper_realized_pnl=27.0,
+    )
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, ["backfill-settlements"])
+    assert result.exit_code == 0, result.output
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["price"] == 0.9  # untouched

--- a/tests/unit/test_cli_reconcile_settlements.py
+++ b/tests/unit/test_cli_reconcile_settlements.py
@@ -1,0 +1,487 @@
+"""Championship-mode reconcile consumes the authoritative portfolio
+settlements endpoint (#663).
+
+Before #663, a position that vanished from the Kalshi API between
+reconciles (i.e. it settled) got an `agent='reconcile'` drift close at
+its stale local mark — excluded from daily P&L (#622) and repriced
+only if Monitor's log-outcome happened to land first. Now reconcile
+asks GET /portfolio/settlements for the removed tickers and writes a
+proper `agent='settlement'` close at the true 1.0/0.0 value; the #653
+dup-guard then suppresses the drift close for those tickers. Any
+settlements failure degrades to the old drift behavior — reconcile is
+never blocked.
+
+Synchronous CLI tests (asyncio.run for setup) — CliRunner drives the
+command's own asyncio.run, which cannot nest. Pagination tests for
+`get_settlements_for_tickers` are plain async tests at the bottom.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.kalshi import portfolio as portfolio_module
+from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import get_trades, insert_trade, upsert_position
+
+runner = CliRunner()
+
+TICKER = "KXCPI-26APR-T0.5"
+SETTLED_TIME = "2026-06-20T14:00:00.123456Z"
+
+
+def _settlement_record(
+    ticker: str = TICKER, market_result: str = "no",
+    settled_time: str = SETTLED_TIME,
+) -> dict:
+    """Shape live-probed from GET /portfolio/settlements (#663)."""
+    return {
+        "ticker": ticker,
+        "event_ticker": ticker.rsplit("-", 1)[0],
+        "market_result": market_result,
+        "settled_time": settled_time,
+        "yes_count_fp": "0",
+        "no_count_fp": "10000",
+        "revenue": 10_000,
+        "value": 100,
+    }
+
+
+def _seed(db_path: Path, *, close_count: int | None = None) -> None:
+    """Seed the local state a settled championship position leaves
+    behind: an open trade row and a positions-table row that the next
+    API sync will find absent."""
+
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.OPEN,
+                side="no", count=100, price=0.63,
+            ))
+            if close_count is not None:
+                await insert_trade(db, TradeDecision(
+                    ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                    side="no", count=close_count, price=0.9,
+                ))
+            await upsert_position(db, Position(
+                ticker=TICKER,
+                title="CPI April NO",
+                side="no",
+                count=100,
+                avg_price=0.63,
+                market_price=0.705,
+                cost_basis=63.0,
+                market_value=70.5,
+                unrealized_pnl=7.5,
+                realized_pnl=0.0,
+            ))
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+
+
+def _wire_championship(
+    monkeypatch: pytest.MonkeyPatch, db_path: Path,
+) -> None:
+    """Point the CLI at the temp DB and route reconcile down the
+    championship branch (broker=None, mocked client) with the Kalshi
+    API reporting no open positions."""
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.is_championship = True
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    @asynccontextmanager
+    async def _ctx(_config):  # type: ignore[no-untyped-def]
+        db = Database(db_path)
+        await db.connect()
+        try:
+            yield MagicMock(), None, db
+        finally:
+            await db.close()
+
+    monkeypatch.setattr(cli_module, "trading_context", _ctx)
+
+    async def _no_positions(_client):  # type: ignore[no-untyped-def]
+        return []
+
+    monkeypatch.setattr(
+        portfolio_module, "get_all_positions", _no_positions,
+    )
+
+
+def _closes(db_path: Path) -> list[dict]:
+    async def _r() -> list[dict]:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            trades = await get_trades(db, ticker=TICKER)
+            return [t for t in trades if t["action"] == "close"]
+        finally:
+            await db.close()
+
+    return asyncio.run(_r())
+
+
+def _mock_settlements(
+    monkeypatch: pytest.MonkeyPatch, records: dict[str, dict],
+) -> None:
+    async def _fake(_client, _tickers, **_kw):  # type: ignore[no-untyped-def]
+        return records
+
+    monkeypatch.setattr(
+        portfolio_module, "get_settlements_for_tickers", _fake,
+    )
+
+
+def test_removed_position_closed_at_settlement_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The happy path: the settlement record says NO won → the NO
+    position gets an agent='settlement' close at 1.0 stamped with the
+    settlement time, and NO reconcile drift row is written."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {TICKER: _settlement_record()})
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "matched settlement" in result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "settlement"
+    assert closes[0]["price"] == 1.0  # NO side, market_result 'no'
+    assert closes[0]["count"] == 100
+    assert closes[0]["resolved_outcome"] == "no"
+    assert str(closes[0]["timestamp"]).startswith("2026-06-20")
+
+
+def test_losing_side_closed_at_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch, {TICKER: _settlement_record(market_result="yes")},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "settlement"
+    assert closes[0]["price"] == 0.0  # NO side lost
+    assert closes[0]["resolved_outcome"] == "yes"
+
+
+def test_no_settlement_record_falls_back_to_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A removed position with no settlement record (e.g. transferred
+    or endpoint lag) keeps today's behavior: a reconcile drift close
+    at the stale mark."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {})
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "reconcile"
+
+
+def test_settlements_api_failure_degrades_to_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A settlements-endpoint failure must never block reconcile —
+    warn and fall back to the drift close."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+
+    async def _boom(_client, _tickers, **_kw):  # type: ignore[no-untyped-def]
+        raise RuntimeError("settlements endpoint down")
+
+    monkeypatch.setattr(
+        portfolio_module, "get_settlements_for_tickers", _boom,
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "settlements lookup failed" in result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "reconcile"
+
+
+def test_unsettleable_market_result_falls_back_to_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A voided/scalar-settled record (market_result outside yes/no)
+    can't be priced 1.0/0.0 — leave it to the drift close."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch, {TICKER: _settlement_record(market_result="void")},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "reconcile"
+
+
+def test_ledger_already_covered_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Residual <= 0: the ledger already closed the opens (e.g. a
+    placement-time close row) — no settlement pre-write, and the #653
+    dup-guard suppresses the drift close too. Also proves the
+    pre-write is crash-idempotent: a reconcile retry lands here."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path, close_count=100)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {TICKER: _settlement_record()})
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1  # only the pre-existing close
+    assert closes[0]["agent"] != "settlement"
+
+
+def test_partial_residual_clamps_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The ledger already closed part of the position — the settlement
+    close covers only the residual, and the ledger-vs-broker mismatch
+    is warned about."""
+    import logging
+
+    db_path = tmp_path / "test.db"
+    _seed(db_path, close_count=40)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {TICKER: _settlement_record()})
+
+    with caplog.at_level(logging.WARNING, logger="gimmes"):
+        result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    settlement = [c for c in closes if c["agent"] == "settlement"]
+    assert len(settlement) == 1
+    assert settlement[0]["count"] == 60  # ledger residual, not broker 100
+    assert "settlement residual mismatch" in caplog.text
+
+
+def test_unparseable_settled_time_still_settles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed settled_time must not demote the position to a
+    drift close — the settlement is still written, just without the
+    backdated timestamp."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record(settled_time="not-a-date")},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "settlement"
+    assert closes[0]["price"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# get_settlements_for_tickers pagination
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+class TestGetSettlementsForTickers:
+    """Bounded pagination over the account-lifetime settlements list."""
+
+    def _pager(self, pages: list[tuple[list[dict], str | None]]):
+        """Fake get_settlements yielding scripted (records, cursor)
+        pages and counting calls."""
+        calls = {"n": 0}
+
+        async def _fake(_client, *, limit=200, cursor=None):  # type: ignore[no-untyped-def]
+            page = pages[min(calls["n"], len(pages) - 1)]
+            calls["n"] += 1
+            return page
+
+        return _fake, calls
+
+    async def test_empty_tickers_no_api_call(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake, calls = self._pager([([], None)])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        assert await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), set(),
+        ) == {}
+        assert calls["n"] == 0
+
+    async def test_stops_when_all_tickers_matched(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        now = datetime.now(UTC)
+        fake, calls = self._pager([
+            (
+                [
+                    _settlement_record("A", settled_time=_iso(now)),
+                    _settlement_record("B", settled_time=_iso(now)),
+                ],
+                "next-cursor",  # more pages exist — must not be read
+            ),
+        ])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        found = await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), {"A", "B"},
+        )
+        assert set(found) == {"A", "B"}
+        assert calls["n"] == 1
+
+    async def test_newest_record_wins_per_ticker(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The endpoint returns newest-first — a re-listed ticker's
+        first (newest) record is kept."""
+        now = datetime.now(UTC)
+        newest = _settlement_record(
+            "A", market_result="yes", settled_time=_iso(now),
+        )
+        older = _settlement_record(
+            "A", market_result="no",
+            settled_time=_iso(now - timedelta(days=1)),
+        )
+        fake, _calls = self._pager([([newest, older], None)])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        found = await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), {"A"},
+        )
+        assert found["A"]["market_result"] == "yes"
+
+    async def test_stops_at_lookback_window(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A page whose oldest record predates the lookback window ends
+        the walk — an unmatched ticker older than that can only be
+        stale local state, not a recent settlement."""
+        old = datetime.now(UTC) - timedelta(days=45)
+        fake, calls = self._pager([
+            (
+                [_settlement_record("OTHER", settled_time=_iso(old))],
+                "next-cursor",
+            ),
+        ])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        found = await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), {"WANTED"}, lookback_days=30,
+        )
+        assert found == {}
+        assert calls["n"] == 1
+
+    async def test_stops_at_max_pages_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Hitting the page cap with unmatched tickers is an operator
+        signal — those tickers silently degrade to drift closes."""
+        import logging
+
+        now = datetime.now(UTC)
+        fake, calls = self._pager([
+            (
+                [_settlement_record("OTHER", settled_time=_iso(now))],
+                "more",
+            ),
+        ])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.kalshi.portfolio",
+        ):
+            found = await portfolio_module.get_settlements_for_tickers(
+                MagicMock(), {"WANTED"}, max_pages=3,
+            )
+        assert found == {}
+        assert calls["n"] == 3
+        assert "pagination cap" in caplog.text
+        assert "WANTED" in caplog.text
+
+    async def test_stops_when_cursor_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cursor=None with tickers still unmatched ends the walk —
+        the account has no more history to read."""
+        now = datetime.now(UTC)
+        fake, calls = self._pager([
+            ([_settlement_record("OTHER", settled_time=_iso(now))], None),
+        ])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        found = await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), {"WANTED"},
+        )
+        assert found == {}
+        assert calls["n"] == 1
+
+    async def test_stops_on_empty_page(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty page ends the walk even if a cursor is present."""
+        fake, calls = self._pager([([], "more")])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        found = await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), {"WANTED"},
+        )
+        assert found == {}
+        assert calls["n"] == 1
+
+    async def test_unparseable_settled_time_does_not_crash(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A malformed timestamp neither crashes the walk nor
+        satisfies the lookback stop."""
+        rec = _settlement_record("A", settled_time="not-a-date")
+        fake, _calls = self._pager([([rec], None)])
+        monkeypatch.setattr(portfolio_module, "get_settlements", fake)
+        found = await portfolio_module.get_settlements_for_tickers(
+            MagicMock(), {"A"},
+        )
+        assert found["A"] is rec

--- a/tests/unit/test_daily_pnl.py
+++ b/tests/unit/test_daily_pnl.py
@@ -289,3 +289,45 @@ class TestGetDailyPnlIncludesSettlementCloses:
         pnl = await get_daily_pnl(db, today=now.strftime("%Y-%m-%d"))
         # (0.0 - 0.40) * 10 = -$4.00 — the settlement loss IS visible.
         assert pnl == pytest.approx(-4.0)
+
+
+class TestRestingSellNoDoubleCount:
+    """#663: a resting sell's close trade is logged at placement; the
+    later settlement must not add a second close for the same
+    contracts, or daily P&L (and the daily-loss trigger) counts the
+    exit twice. End-to-end through PaperBroker.settle()."""
+
+    async def test_settlement_after_placement_close_counts_once(
+        self, db: Database, tmp_path,
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from gimmes.paper.broker import PaperBroker
+
+        paper_cfg = MagicMock()
+        paper_cfg.starting_balance = 10_000.0
+        broker = PaperBroker(db, paper_cfg)
+        await broker.initialize()
+
+        # Ledger: the agent opened 10 @ 0.70 and its resting sell
+        # logged the close 10 @ 0.90 at placement (today).
+        await insert_trade(db, _trade(action="open", price=0.70))
+        await insert_trade(db, _trade(action="close", price=0.90))
+        # Broker state: the paper position was never reduced by the
+        # resting sell — it still holds all 10 contracts at settle.
+        await db.conn.execute(
+            """INSERT INTO paper_positions
+               (ticker, side, count, avg_price, market_price,
+                cost_basis, unrealized_pnl, realized_pnl, updated_at)
+               VALUES ('KXTEST', 'yes', 10, 0.70, 0.90,
+                       7.0, 2.0, 0.0, datetime('now'))""",
+        )
+        await db.conn.commit()
+
+        await broker.settle("KXTEST", "yes")
+
+        # Exactly the placement-time close counts — no settlement row
+        # doubled it.
+        assert await get_daily_pnl(db) == pytest.approx(
+            (0.90 - 0.70) * 10,
+        )

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -120,7 +120,7 @@ class TestFormatLocalTimestamp:
 
 
 class TestFormatPnlSummary:
-    """#653: the Closed/Open Positions rows make the P&L table
+    """#653/#663: the Close Events/Open Positions rows make the P&L table
     internally consistent — pin the arithmetic."""
 
     def test_closed_and_open_rows(self) -> None:
@@ -143,14 +143,14 @@ class TestFormatPnlSummary:
         ):
             format_pnl_summary(summary)
         out = buf.getvalue()
-        assert "Closed" in out and "Open Positions" in out
-        # Closed = W+L+S = 4; Open = 1; Total = 5.
+        assert "Close Events" in out and "Open Positions" in out
+        # Close Events = W+L+S = 4; Open = 1; Total = 5.
         lines = {
             line.split("│")[1].strip(): line.split("│")[2].strip()
             for line in out.splitlines()
             if line.count("│") >= 3
         }
-        assert lines.get("Closed") == "4"
+        assert lines.get("Close Events") == "4"
         assert lines.get("Open Positions") == "1"
         assert lines.get("Total Trades") == "5"
 

--- a/tests/unit/test_paper_broker.py
+++ b/tests/unit/test_paper_broker.py
@@ -1097,3 +1097,128 @@ class TestSettlementOverridesWrongOutcome:
         assert all(
             t["resolved_outcome"] == "yes" for t in trades
         ), trades
+
+
+class TestSettleLedgerClamp:
+    """#663: a resting sell logs its close trade at placement without
+    reducing the paper position, so settle() writing a FULL-count
+    settlement row would double-count the exit in daily P&L (and the
+    daily-loss trigger). The settlement row is clamped to the ledger
+    residual; balance and paper_positions updates stay full-count
+    because the broker's cash accounting is separate from the ledger.
+    """
+
+    async def _buy(
+        self, broker: PaperBroker, orderbook: Orderbook, count: int = 10,
+    ) -> None:
+        params = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.BUY,
+            side=OrderSide.YES, count=count, yes_price=0.70,
+            post_only=True,
+        )
+        await broker.create_order(params, orderbook)
+
+    async def _seed_ledger(
+        self, broker: PaperBroker, *, opened: int = 0, closed: int = 0,
+    ) -> None:
+        from gimmes.models.trade import TradeDecision
+        from gimmes.store.queries import insert_trade
+
+        if opened:
+            await insert_trade(broker._db, TradeDecision(
+                ticker="TEST-MKT", action=TradeDecision.Action.OPEN,
+                side="yes", count=opened, price=0.70,
+            ))
+        if closed:
+            await insert_trade(broker._db, TradeDecision(
+                ticker="TEST-MKT", action=TradeDecision.Action.CLOSE,
+                side="yes", count=closed, price=0.90,
+            ))
+
+    @pytest.mark.asyncio
+    async def test_settle_skips_trade_row_when_ledger_covered(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        """Placement-time close row already covers the opens — settle
+        writes NO second close, but the payout still lands in the
+        balance and the outcome is still recorded."""
+        from gimmes.store.queries import get_trades
+
+        await self._buy(broker, orderbook)
+        await self._seed_ledger(broker, opened=10, closed=10)
+        balance_before = await broker.get_balance()
+
+        await broker.settle("TEST-MKT", "yes")  # YES won → $1/contract
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        assert [
+            t for t in trades if t.get("agent") == "settlement"
+        ] == []
+        assert all(
+            t["resolved_outcome"] == "yes" for t in trades
+        ), trades
+        assert await broker.get_balance() == pytest.approx(
+            balance_before + 10 * 1.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_settle_clamps_to_ledger_residual(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        """A partial placement-time close: the settlement row covers
+        only the contracts the ledger hasn't closed yet."""
+        from gimmes.store.queries import get_trades
+
+        await self._buy(broker, orderbook)
+        await self._seed_ledger(broker, opened=10, closed=4)
+
+        await broker.settle("TEST-MKT", "yes")
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        settlement = [
+            t for t in trades if t.get("agent") == "settlement"
+        ]
+        assert len(settlement) == 1
+        assert settlement[0]["count"] == 6
+        assert settlement[0]["price"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_settle_full_count_without_trade_history(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        """opened == 0 (seeded/legacy position with no local trades)
+        keeps the pre-#663 full-count settlement row — a zero ledger
+        must not be mistaken for 'already covered'."""
+        from gimmes.store.queries import get_trades
+
+        await self._buy(broker, orderbook)  # broker writes no trades rows
+
+        await broker.settle("TEST-MKT", "no")  # YES lost
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        closes = [t for t in trades if t["action"] == "close"]
+        assert len(closes) == 1
+        assert closes[0]["agent"] == "settlement"
+        assert closes[0]["count"] == 10
+        assert closes[0]["price"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_settle_clamp_capped_at_broker_count(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        """A ledger residual LARGER than the broker position (size-ups
+        in trades, partially reduced paper position) must not inflate
+        the settlement row past the contracts that actually settled."""
+        from gimmes.store.queries import get_trades
+
+        await self._buy(broker, orderbook)
+        await self._seed_ledger(broker, opened=20, closed=0)
+
+        await broker.settle("TEST-MKT", "yes")
+
+        trades = await get_trades(broker._db, ticker="TEST-MKT")
+        settlement = [
+            t for t in trades if t.get("agent") == "settlement"
+        ]
+        assert len(settlement) == 1
+        assert settlement[0]["count"] == 10  # broker count, not 20

--- a/tests/unit/test_pnl.py
+++ b/tests/unit/test_pnl.py
@@ -245,6 +245,35 @@ class TestReconcileRepricing:
         ))
         assert summary.gross_pnl == pytest.approx((0.705 - 0.63) * 100)
 
+    def test_drift_keeps_mark_when_group_has_settlement_close(self) -> None:
+        """#663: an agent='settlement' close in the group proves
+        settlements were properly recorded for this position — a
+        reconcile drift row alongside it is genuine NON-settlement
+        drift (e.g. a manual exit) and keeps its mark instead of
+        being repriced to 1.0/0.0."""
+        trades = [
+            {
+                "ticker": "KX1", "side": "no", "action": "open",
+                "count": 100, "price": 0.63, "timestamp": "2026-04-20",
+                "agent": "closer", "resolved_outcome": "yes",
+            },
+            {  # manual-exit drift at the last-known mark
+                "ticker": "KX1", "side": "no", "action": "close",
+                "count": 40, "price": 0.705, "timestamp": "2026-04-22",
+                "agent": "reconcile", "resolved_outcome": None,
+            },
+            {  # the real settlement close for the remainder
+                "ticker": "KX1", "side": "no", "action": "close",
+                "count": 60, "price": 0.0, "timestamp": "2026-04-25",
+                "agent": "settlement", "resolved_outcome": "yes",
+            },
+        ]
+        summary = calculate_pnl(trades)
+        # Drift leg keeps 0.705; only the settlement leg is 0.0.
+        assert summary.gross_pnl == pytest.approx(
+            (0.705 - 0.63) * 40 + (0.0 - 0.63) * 60
+        )
+
     def test_settlement_price_close_has_no_close_fee(self) -> None:
         """Settlement closes at 1.0/0.0 are fee-free automatically via
         calculate_fee's price-range guard; open-leg fee remains."""


### PR DESCRIPTION
## Summary

Resolves the three #663 settlement-accounting refinements:

**1. Authoritative settlement source for championship reconcile.** Removed positions are now matched against `GET /portfolio/settlements` before `sync_positions`: a settled position gets a proper `agent='settlement'` close at the true 1.0/0.0 value (daily-P&L-visible, fee-free, `resolved_outcome` set, stamped with `settled_time`) instead of an `agent='reconcile'` drift row at the stale local mark. The #653 dup-guard suppresses the drift close for pre-written tickers, so `sync_positions` needs no signature change; the pre-write is commit-per-ticker and crash-idempotent. Any settlements failure rolls back the open transaction and degrades to today's drift behavior — reconcile is never blocked. New `get_settlements_for_tickers` walks the newest-first settlements list with four bounded stop conditions and warns when the page cap ends the walk with unmatched tickers.

**2. Resting-sell double-count clamp.** `PaperBroker.settle()` clamps the settlement trade row to the ledger residual (`opened − closed` from the trades table): a resting sell logs its close row at placement without reducing the paper position, so a full-count settlement row would double-count the exit in daily P&L and the daily-loss trigger. History-less positions (`opened == 0`) keep full-count behavior; a fully-covered ledger skips the row but still records the authoritative outcome. Balance/paper_positions accounting is unchanged; any clamp divergence is warned about for audit.

**3. Manual-close repricing restriction.** `calculate_pnl` and the advisor's `_pair_closes` no longer reprice a reconcile drift row to 1.0/0.0 when the group carries a real settlement close — a drift row alongside a recorded settlement is a genuine manual exit and keeps its mark.

Also: the `backfill-settlements` fingerprint is hardened to `cost_basis > 0` (provably sound — only `settle()` leaves cost basis intact at `count = 0`; a full sell drives it to 0 and mark updates only touch `count > 0` rows), the "Inserted 0" summary is suppressed after a no-table run, and the P&L table's "Closed" row is relabeled "Close Events".

Review pipeline (3 reviewers + simplifier) caught two real bugs pre-PR: a missing rollback in the fallback handler that would have crashed `sync_positions` with a nested-transaction error, and a `realized_pnl < 0` fingerprint condition that would have silently dropped settled losses following profitable partial sells. Deferred items are tracked in #684.

Closes #663

## Test plan

- 16 new tests in `tests/unit/test_cli_reconcile_settlements.py`: championship reconcile end-to-end (settlement close at 1.0/0.0 with settled_time, drift fallbacks for missing/unsettleable records and API failure, residual clamp + mismatch warning, ledger-covered idempotency, unparseable timestamps) and `get_settlements_for_tickers` pagination (all four stop conditions, newest-wins, cap warning).
- `TestSettleLedgerClamp` (4 tests) in `test_paper_broker.py`, `TestRestingSellNoDoubleCount` in `test_daily_pnl.py`, drift-keeps-mark tests in `test_pnl.py`/`test_advisor.py`, reworked fingerprint tests in `test_backfill_settlements.py` (including the partial-profit-then-settled-loss counterexample).
- Full suite: **1825 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB