### PR TITLE
Fix #668: lesson window orphaning, side-aware outcome keys, settlement writer robustness

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3714,7 +3714,14 @@ def lesson(
         from gimmes.strategy.advisor import run_all_analyses
 
         async with Database(config.db_path) as db:
-            all_trades = await get_trades(db, limit=1000)
+            # Fetch per-action so skip volume can't truncate older
+            # opens out from under their closes — orphaned closes are
+            # dropped by _pair_closes and the analyses silently degrade
+            # (#542 pattern, #668). Skips stay in the input:
+            # analyze_missed_opportunities consumes them.
+            all_trades: list[dict] = []  # type: ignore[type-arg]
+            for action in ("open", "close", "size_up", "skip"):
+                all_trades += await get_trades(db, action=action, limit=100_000)
             # Candidates not yet used (scoring correlation needs #20)
             candidates: list[dict] = []  # type: ignore[type-arg]
 

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -7,6 +7,8 @@ import os
 from datetime import datetime
 from typing import TypedDict
 
+from pydantic import ValidationError
+
 from gimmes.models.error import ErrorLogEntry
 from gimmes.models.portfolio import PortfolioSnapshot, Position
 from gimmes.models.recommendation import Recommendation
@@ -302,23 +304,45 @@ async def _log_reconcile_closes(
         # #656: carry the entry decision's analytics onto the synthetic
         # close so the trades table isn't blind to its own reasoning.
         entry = await get_entry_analytics(db, pos.ticker, pos.side) or {}
-        synth = TradeDecision(
-            ticker=pos.ticker,
-            action=TradeDecision.Action.CLOSE,
-            side=pos.side,
-            count=pos.count,
-            price=close_price,
-            model_probability=entry.get("model_probability", 0.0),
-            gimme_score=entry.get("gimme_score", 0.0),
-            edge=entry.get("edge", 0.0),
-            kelly_fraction=entry.get("kelly_fraction", 0.0),
-            rationale=(
-                "reconcile drift — broker removed position without local"
-                " close; price is last-known mark, not broker-confirmed"
-                " fill (#609)"
-            ),
-            agent="reconcile",
-        )
+
+        def _build(analytics: dict) -> TradeDecision:  # type: ignore[type-arg]
+            return TradeDecision(
+                ticker=pos.ticker,
+                action=TradeDecision.Action.CLOSE,
+                side=pos.side,
+                count=pos.count,
+                price=close_price,
+                model_probability=analytics.get("model_probability", 0.0),
+                gimme_score=analytics.get("gimme_score", 0.0),
+                edge=analytics.get("edge", 0.0),
+                kelly_fraction=analytics.get("kelly_fraction", 0.0),
+                rationale=(
+                    "reconcile drift — broker removed position without"
+                    " local close; price is last-known mark, not"
+                    " broker-confirmed fill (#609)"
+                ),
+                agent="reconcile",
+            )
+
+        try:
+            synth = _build(entry)
+        except ValidationError as exc:
+            # #668: same guard as log_settlement_close — corrupt
+            # analytics must not abort the sync_positions transaction
+            # every reconcile cycle. Retry before warning: count and
+            # close_price come from the positions row (unconstrained
+            # in the Position model), so a corrupt caller value
+            # re-raises out of the zeroed retry — fail-loud, with no
+            # lying "recorded" log line.
+            synth = _build({})
+            logging.getLogger(__name__).warning(
+                "entry analytics for %s/%s failed validation (%s) —"
+                " reconcile close recorded with zeroed analytics"
+                " (#668)", pos.ticker, pos.side,
+                ", ".join(
+                    str(e.get("loc", ("?",))[0]) for e in exc.errors()
+                ),
+            )
         await _insert_trade_row(db, synth)
 
         # IMPORTANT: this body MUST NOT contain the literal string
@@ -454,22 +478,44 @@ async def log_settlement_close(
             " analytics default to 0 (#656)", ticker, side,
         )
         entry = {}
-    synth = TradeDecision(
-        ticker=ticker,
-        action=TradeDecision.Action.CLOSE,
-        side=side,
-        count=count,
-        price=price,
-        model_probability=entry.get("model_probability", 0.0),
-        gimme_score=entry.get("gimme_score", 0.0),
-        edge=entry.get("edge", 0.0),
-        kelly_fraction=entry.get("kelly_fraction", 0.0),
-        rationale=rationale or (
-            "market settled — broker-confirmed outcome; close at"
-            " settlement value (#653)"
-        ),
-        agent="settlement",
-    )
+
+    def _build(analytics: dict) -> TradeDecision:  # type: ignore[type-arg]
+        return TradeDecision(
+            ticker=ticker,
+            action=TradeDecision.Action.CLOSE,
+            side=side,
+            count=count,
+            price=price,
+            model_probability=analytics.get("model_probability", 0.0),
+            gimme_score=analytics.get("gimme_score", 0.0),
+            edge=analytics.get("edge", 0.0),
+            kelly_fraction=analytics.get("kelly_fraction", 0.0),
+            rationale=rationale or (
+                "market settled — broker-confirmed outcome; close at"
+                " settlement value (#653)"
+            ),
+            agent="settlement",
+        )
+
+    try:
+        synth = _build(entry)
+    except ValidationError as exc:
+        # #668: corrupt stored analytics (manual SQL / legacy rows)
+        # must not abort the settlement transaction — that would
+        # re-fail every settle cycle. Honest zeros over fabricated
+        # in-range values. Retry BEFORE warning: caller-supplied
+        # fields (count, side) are validated too, and if one of those
+        # is the culprit the zeroed retry re-raises — fail-loud is
+        # correct there, and the log must not claim a row was written.
+        synth = _build({})
+        logging.getLogger(__name__).warning(
+            "entry analytics for %s/%s failed validation (%s) —"
+            " settlement close recorded with zeroed analytics (#668)",
+            ticker, side,
+            ", ".join(
+                str(e.get("loc", ("?",))[0]) for e in exc.errors()
+            ),
+        )
     if timestamp is not None:
         synth.timestamp = timestamp
     row_id = await _insert_trade_row(db, synth)

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -33,7 +33,11 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
     known (#653). ``won`` is resolution-first (side == resolved_outcome
     anywhere in the group), falling back to the realized return's sign.
     Orphan closes (no matched open on record) are dropped — they have
-    no entry decision to learn from.
+    no entry decision to learn from. Two conservative edges (#668):
+    a scratch close (realized == 0, no resolution) classifies as a
+    loss — not a win is the safe reading for tuning; and unresolved
+    reconcile drift feeds mark-priced returns until resolution
+    backfill repricing corrects them retroactively.
 
     Returns one record per matched close: ``{ticker, side, timestamp,
     won, realized_return, entry_score, entry_price}`` where
@@ -115,6 +119,24 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
     return paired
 
 
+def _outcomes_by_position(
+    paired: list[dict],  # type: ignore[type-arg]
+) -> dict[tuple[str, str], bool]:
+    """Map ``(ticker, side)`` -> ``won`` from paired closes (#668).
+
+    Keyed by side so both sides of a ticker stay distinct, and
+    multiple partial closes aggregate any-loss = loss: a position that
+    realized a loss on any tranche was not a clean win — bias down.
+    When resolution is known every tranche carries the same ``won``,
+    so aggregation only bites on PnL-fallback partials.
+    """
+    outcomes: dict[tuple[str, str], bool] = {}
+    for r in paired:
+        key = (r["ticker"], r["side"])
+        outcomes[key] = outcomes.get(key, True) and r["won"]
+    return outcomes
+
+
 # ---------------------------------------------------------------------------
 # Analysis 1: Threshold Sweep
 # ---------------------------------------------------------------------------
@@ -135,18 +157,19 @@ def analyze_threshold_sweep(
     if len(paired) < MIN_TRADES_THRESHOLD:
         return None
 
-    # Build outcome map: ticker -> won (True/False). Resolution-first
-    # via _pair_closes — close-row edge is an entry artifact, not an
-    # outcome (#656).
-    outcomes: dict[str, bool] = {r["ticker"]: r["won"] for r in paired}
+    # Build outcome map. Resolution-first via _pair_closes —
+    # close-row edge is an entry artifact, not an outcome (#656).
+    # Any-loss aggregation (#668) is conservative here because the
+    # sweep only loosens on win-rate improvement.
+    outcomes = _outcomes_by_position(paired)
 
     # Build score map from opens
     scored: list[dict] = []  # type: ignore[type-arg]
     for t in opens:
-        ticker = t.get("ticker", "")
+        key = (t.get("ticker", ""), t.get("side", "yes"))
         score = t.get("gimme_score", 0)
-        if ticker in outcomes:
-            scored.append({"score": score, "won": outcomes[ticker]})
+        if key in outcomes:
+            scored.append({"score": score, "won": outcomes[key]})
 
     if len(scored) < MIN_TRADES_THRESHOLD:
         return None
@@ -412,17 +435,18 @@ def analyze_scanner_parameters(
     if len(paired) < MIN_TRADES_SCANNER:
         return None
 
-    # Build outcome map — resolution-first via _pair_closes (#656)
-    outcomes: dict[str, bool] = {r["ticker"]: r["won"] for r in paired}
+    # Build outcome map — resolution-first via _pair_closes (#656),
+    # with any-loss aggregation for partial closes (#668).
+    outcomes = _outcomes_by_position(paired)
 
     # Get prices from opens
     winner_prices: list[float] = []
     loser_prices: list[float] = []
     for t in opens:
-        ticker = t.get("ticker", "")
+        key = (t.get("ticker", ""), t.get("side", "yes"))
         price = t.get("price", 0)
-        if ticker in outcomes and price > 0:
-            if outcomes[ticker]:
+        if key in outcomes and price > 0:
+            if outcomes[key]:
                 winner_prices.append(price)
             else:
                 loser_prices.append(price)

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -407,6 +407,142 @@ class TestScannerParameters:
         assert "strategy.m" in rec.parameter_path
 
 
+class TestSideAwareOutcomes:
+    """#668: outcome maps key by (ticker, side) — both sides of a
+    ticker stay distinct, and multiple partial closes of one position
+    aggregate any-loss = loss instead of last-wins."""
+
+    def _both_sides(self, ticker: str = "BOTH") -> list[dict]:
+        """A yes-side WIN then a no-side LOSS on the same ticker.
+        Ticker-only last-wins would mark BOTH opens as losses."""
+        return [
+            {
+                "ticker": ticker, "action": "open", "side": "yes",
+                "count": 10, "price": 0.72, "gimme_score": 85.0,
+                "edge": 0.15, "agent": "closer",
+                "timestamp": "2026-03-01T10:00:00",
+            },
+            {
+                "ticker": ticker, "action": "close", "side": "yes",
+                "count": 10, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T18:00:00",
+            },
+            {
+                "ticker": ticker, "action": "open", "side": "no",
+                "count": 10, "price": 0.58, "gimme_score": 85.0,
+                "edge": 0.15, "agent": "closer",
+                "timestamp": "2026-03-02T10:00:00",
+            },
+            {
+                "ticker": ticker, "action": "close", "side": "no",
+                "count": 10, "price": 0.30, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-02T18:00:00",
+            },
+        ]
+
+    def test_threshold_sweep_keeps_sides_distinct(
+        self, config: GimmesConfig,
+    ) -> None:
+        trades = _make_trades(
+            n_wins=25, n_losses=5, win_score=70, loss_score=85,
+        ) + self._both_sides()
+        rec = analyze_threshold_sweep(trades, config)
+        assert rec is not None
+        sweep = {
+            row["threshold"]: row
+            for row in json.loads(rec.supporting_data)
+        }
+        # At threshold 85: the 5 baseline losses + BOTH's two opens.
+        # The yes-side win must survive the no-side loss.
+        assert sweep[85]["trades_taken"] == 7
+        assert sweep[85]["wins"] == 1
+
+    def test_threshold_sweep_partial_closes_any_loss(
+        self, config: GimmesConfig,
+    ) -> None:
+        """Loss tranche first, win tranche last — last-wins would call
+        the position a win; any-loss keeps it a loss."""
+        trades = _make_trades(
+            n_wins=25, n_losses=5, win_score=70, loss_score=85,
+        ) + [
+            {
+                "ticker": "PARTIAL", "action": "open", "side": "yes",
+                "count": 10, "price": 0.50, "gimme_score": 85.0,
+                "edge": 0.15, "agent": "closer",
+                "timestamp": "2026-03-01T10:00:00",
+            },
+            {
+                "ticker": "PARTIAL", "action": "close", "side": "yes",
+                "count": 5, "price": 0.20, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T12:00:00",
+            },
+            {
+                "ticker": "PARTIAL", "action": "close", "side": "yes",
+                "count": 5, "price": 0.70, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T18:00:00",
+            },
+        ]
+        rec = analyze_threshold_sweep(trades, config)
+        assert rec is not None
+        sweep = {
+            row["threshold"]: row
+            for row in json.loads(rec.supporting_data)
+        }
+        # 5 baseline losses + PARTIAL at threshold 85 — no wins.
+        assert sweep[85]["trades_taken"] == 6
+        assert sweep[85]["wins"] == 0
+
+    def test_scanner_parameters_partial_closes_any_loss(
+        self, config: GimmesConfig,
+    ) -> None:
+        """Any-loss must hold in the scanner too: the PARTIAL open's
+        price lands in the loser bucket even though its last (winning)
+        tranche would put it in the winners under last-wins."""
+        trades = _make_trades(
+            n_wins=20, n_losses=15, win_price=0.72, loss_price=0.58,
+        ) + [
+            {
+                "ticker": "PARTIAL", "action": "open", "side": "yes",
+                "count": 10, "price": 0.50, "gimme_score": 85.0,
+                "edge": 0.15, "agent": "closer",
+                "timestamp": "2026-03-01T10:00:00",
+            },
+            {
+                "ticker": "PARTIAL", "action": "close", "side": "yes",
+                "count": 5, "price": 0.20, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T12:00:00",
+            },
+            {
+                "ticker": "PARTIAL", "action": "close", "side": "yes",
+                "count": 5, "price": 0.70, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T18:00:00",
+            },
+        ]
+        rec = analyze_scanner_parameters(trades, config)
+        assert rec is not None
+        # 20 baseline winners; 15 baseline losers + PARTIAL.
+        assert "n=20" in rec.rationale
+        assert "n=16" in rec.rationale
+
+    def test_scanner_parameters_keep_sides_distinct(
+        self, config: GimmesConfig,
+    ) -> None:
+        trades = _make_trades(
+            n_wins=20, n_losses=15, win_price=0.72, loss_price=0.58,
+        ) + self._both_sides()
+        rec = analyze_scanner_parameters(trades, config)
+        assert rec is not None
+        # 20 baseline winners + BOTH's yes win; 15 losers + no loss.
+        assert "n=21" in rec.rationale
+        assert "n=16" in rec.rationale
+
+
 class TestScoringCorrelation:
     def test_returns_none_without_component_data(self, config: GimmesConfig) -> None:
         trades = _make_trades(n_wins=30, n_losses=20)

--- a/tests/unit/test_lesson_window.py
+++ b/tests/unit/test_lesson_window.py
@@ -1,0 +1,83 @@
+"""`gimmes lesson` fetches trades per-action, not through a shared
+display limit (#668).
+
+The old single `get_trades(limit=1000)` window (timestamp DESC) let
+skip volume push the oldest opens out from under their closes once the
+trades table passed 1000 rows — `_pair_closes` then dropped those
+closes as orphans and the analyses silently degraded to "insufficient
+data". The #542 per-action pattern (already used by `report`) fetches
+each action under its own generous limit; `lesson` additionally keeps
+`skip` rows because `analyze_missed_opportunities` consumes them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.store import queries as queries_module
+
+runner = CliRunner()
+
+
+def test_lesson_fetches_per_action_with_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = MagicMock()
+    cfg.db_path = tmp_path / "test.db"
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    calls: list[dict] = []
+
+    async def _spy(_db, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(kwargs)
+        return []
+
+    monkeypatch.setattr(queries_module, "get_trades", _spy)
+
+    result = runner.invoke(app, ["lesson"])
+    assert result.exit_code == 0, result.output
+
+    actions = {c.get("action") for c in calls}
+    assert actions == {"open", "close", "size_up", "skip"}
+    # Per-action limits generous enough that display-style caps can't
+    # orphan old opens; no un-scoped legacy fetch remains.
+    assert all(c.get("limit") == 100_000 for c in calls)
+    assert not any(c.get("action") is None for c in calls)
+
+
+def test_lesson_feeds_all_actions_to_analyses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The four fetches must actually reach run_all_analyses —
+    dropping skips from the concatenation would starve
+    analyze_missed_opportunities."""
+    from gimmes.strategy import advisor as advisor_module
+
+    cfg = MagicMock()
+    cfg.db_path = tmp_path / "test.db"
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    async def _sentinels(_db, **kwargs):  # type: ignore[no-untyped-def]
+        return [{"action": kwargs["action"], "ticker": f"S-{kwargs['action']}"}]
+
+    monkeypatch.setattr(queries_module, "get_trades", _sentinels)
+
+    captured: list[list] = []
+
+    def _capture(trades, _candidates, _config):  # type: ignore[no-untyped-def]
+        captured.append(trades)
+        return []
+
+    monkeypatch.setattr(advisor_module, "run_all_analyses", _capture)
+
+    result = runner.invoke(app, ["lesson"])
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    fed_actions = {t["action"] for t in captured[0]}
+    assert fed_actions == {"open", "close", "size_up", "skip"}

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -598,3 +598,92 @@ class TestReconcileDuplicateGuard:
         trades = await get_trades(db, ticker="KX4")
         reconcile = [t for t in trades if t.get("agent") == "reconcile"]
         assert len(reconcile) == 1
+
+
+class TestCorruptAnalyticsGuard:
+    """#668: corrupt stored entry analytics (manual SQL / legacy rows)
+    must not abort the settlement or reconcile transaction — the write
+    degrades to honest zeros with a warning instead of re-failing
+    every cycle."""
+
+    async def test_settlement_close_survives_corrupt_analytics(
+        self, db, caplog,
+    ):
+        import logging
+
+        from gimmes.store.queries import log_settlement_close
+
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        # Out-of-range probability can only arrive via manual SQL —
+        # insert_trade validates, so corrupt the row underneath it.
+        await db.conn.execute(
+            "UPDATE trades SET model_probability = 1.7"
+            " WHERE ticker = 'KXCPI-26APR-T0.5'",
+        )
+        await db.conn.commit()
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
+            async with db.transaction():
+                row_id = await log_settlement_close(
+                    db, ticker="KXCPI-26APR-T0.5", side="yes",
+                    count=10, won=True,
+                )
+        assert row_id > 0
+        assert "failed validation" in caplog.text
+
+        closes = [
+            t for t in await get_trades(db) if t["action"] == "close"
+        ]
+        assert len(closes) == 1
+        assert closes[0]["agent"] == "settlement"
+        assert closes[0]["price"] == 1.0
+        assert closes[0]["model_probability"] == 0.0
+        assert closes[0]["gimme_score"] == 0.0
+
+    async def test_drift_close_survives_corrupt_analytics(
+        self, db, caplog,
+    ):
+        import logging
+
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        await db.conn.execute(
+            "UPDATE trades SET gimme_score = 250.0"
+            " WHERE ticker = 'KXCPI-26APR-T0.5'",
+        )
+        await db.conn.commit()
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=0.42),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
+            await sync_positions(db, [])
+        assert "failed validation" in caplog.text
+
+        closes = [
+            t for t in await get_trades(db) if t["action"] == "close"
+        ]
+        assert len(closes) == 1
+        assert closes[0]["agent"] == "reconcile"
+        assert closes[0]["gimme_score"] == 0.0
+        assert closes[0]["model_probability"] == 0.0
+
+    async def test_corrupt_caller_value_still_fails_loud(
+        self, db, caplog,
+    ):
+        """A corrupt POSITIONS row (mark > 1.0) is not an analytics
+        problem — the zeroed retry re-raises, and the guard must not
+        log a 'recorded with zeroed analytics' line for a row that was
+        rolled back."""
+        import logging
+
+        from pydantic import ValidationError
+
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=1.7),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
+            with pytest.raises(ValidationError):
+                await sync_positions(db, [])
+        assert "recorded with zeroed analytics" not in caplog.text


### PR DESCRIPTION
## Summary

Resolves the three actionable #668 hardening items deferred from #656:

**1. `lesson` window orphaning.** The single `get_trades(limit=1000)` window (timestamp DESC) let skip volume push the oldest opens out from under their closes once the trades table passed 1000 rows — `_pair_closes` dropped those closes as orphans and the analyses silently degraded to "insufficient data". `lesson` now fetches per-action at 100k each (the #542 pattern `report` already uses), and keeps `skip` rows because `analyze_missed_opportunities` consumes them.

**2. Side-aware outcome keys.** `analyze_threshold_sweep` and `analyze_scanner_parameters` collapsed `_pair_closes` records into `outcomes[ticker]` — both sides of a ticker and multiple partial closes overwrote last-wins. Outcome maps are now keyed by `(ticker, side)` with any-loss aggregation (factored into a shared `_outcomes_by_position` helper): a position that realized a loss on any tranche was not a clean win, and the rule biases win rates down while both consumers only issue recommendations on measured improvement — it suppresses false recommendations rather than creating them. When resolution is known every tranche carries the same outcome, so aggregation only bites on PnL-fallback partials.

**3. Settlement writer robustness.** `log_settlement_close` and `_log_reconcile_closes` fed stored entry analytics into pydantic-validated `TradeDecision` — a corrupt stored value (manual SQL / legacy rows) raised `ValidationError` inside the settlement/`sync_positions` transaction and re-failed every cycle with no escalation. Both writers now retry with honest zeros (not clamped fabrications) and warn naming the failing fields. The retry runs before the warning: caller-supplied fields (`count`, `close_price`, `side`) are validated too, and if one of those is the culprit the zeroed retry re-raises — fail-loud is preserved for genuinely bad closes, with no lying "recorded" log line (review finding, empirically verified).

Verified already fixed on main (no-op): the order-path analytics fetch degrades log-only (#668 item 4), and edge-decay keys were already renamed to `*_avg_return` (item 5). The remaining conservative edges (scratch-as-loss, unresolved drift marks) are documented in the `_pair_closes` docstring. Deferred design questions — all-time analysis window vs recency, lifecycle-ratchet aggregation, caller-value corruption handling — are tracked in #686.

Closes #668

## Test plan

- `tests/unit/test_lesson_window.py` (new): fetch-shape spy (four action-scoped calls at 100k, no legacy un-scoped fetch) + wiring test proving all four actions reach `run_all_analyses`.
- `test_advisor.py` `TestSideAwareOutcomes` (4 tests): both-sides distinction in threshold sweep and scanner, partial-closes any-loss in both (each empirically shown to fail under ticker-only or last-wins mutations).
- `test_sync_positions.py` `TestCorruptAnalyticsGuard` (3 tests): settlement and drift writers survive corrupt analytics with zeroed rows + field-naming warning; corrupt caller value (mark > 1.0) still fails loud with no misleading log.
- Full suite: **1834 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB