### PR TITLE
Fix #670: skip-backfill staleness bound, reason vocabulary polish

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -286,9 +286,18 @@ Evaluate the output using these rules (where `gimme_threshold` is from Step 0.5,
      --rationale-file "$RATIONALE_FILE" --agent caddie-master
    rm -f "$RATIONALE_FILE"
    ```
-3. **Prior score between cooldown_cutoff and (gimme_threshold - 1)** (borderline) → re-research ONLY if the current market price (from the Scout's shortlist) differs from the prior `Price` by more than 5 cents. Otherwise skip with rationale noting price unchanged.
+3. **Prior score between cooldown_cutoff and (gimme_threshold - 1)** (borderline) → re-research ONLY if the current market price (from the Scout's shortlist) differs from the prior `Price` by more than 5 cents. Otherwise log the skip with the criterion-2 template above using `--reason cooldown`, with rationale noting the borderline prior score and that the price is unchanged.
 3b. **Prior research flagged STALE-CLOSE** (a `STALE-CLOSE:` banner or `STALE` Status in `gimmes candidates --ticker TICKER --limit 3`) → treat as NO valid prior research regardless of score: the research predates the ticker's most recent close, and the close happened on information that research cannot contain (#661). Send to the Caddie for fresh research before the ticker may proceed.
-4. **Prior score >= gimme_threshold with open position** (check `gimmes positions` for the ticker) → skip, already traded
+4. **Prior score >= gimme_threshold with open position** (check `gimmes positions` for the ticker) → skip; log it so the decision is auditable (no analytics flags — the open trade row carries the real analytics):
+   ```bash
+   RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
+   cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
+   Already traded: open position held, prior score SCORE
+   GIMMES_EOF
+   gimmes log-trade TICKER --action skip --reason already_traded \
+     --rationale-file "$RATIONALE_FILE" --agent caddie-master
+   rm -f "$RATIONALE_FILE"
+   ```
 5. **Prior score >= gimme_threshold, no open position** → check the Status column for "CAP BLOCKED". If cap-blocked, prioritize: send to Caddie first with context that this is a cap-blocked re-evaluation. If not cap-blocked (rejected for other reasons), send to Caddie with context that prior research exists.
 
 **If all candidates were skipped by cooldown** (zero candidates to send to Caddie), MUST log the skip and skip directly to Step 6. NEVER run Steps 4b-5.
@@ -426,7 +435,7 @@ For each PROCEED candidate:
      --body-file "$BODY_FILE"
    rm -f "$BODY_FILE"
    ```
-   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with `--reason review_reject` and rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate.
+   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with `--reason infra_failed` and rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate — this is a tooling casualty, not a review verdict, and `infra_failed` keeps it out of the review-reject audits.
 
 6. **Log rejected candidates as skips** so the decision is auditable (use the `--rationale-file` heredoc pattern, #589):
    ```bash

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2448,6 +2448,7 @@ def log_trade(
                 # Best-effort: a failed read degrades to zeros — a
                 # degenerate skip row beats a missing one (log-trade
                 # is the agents' logger of last resort).
+                cause_logged = False
                 try:
                     rows = await get_candidate_for_ticker(db, ticker)
                 except sqlite3.Error:
@@ -2457,6 +2458,7 @@ def log_trade(
                         ticker, exc_info=True,
                     )
                     rows = []
+                    cause_logged = True
                 if rows:
                     # #670: a candidate scanned >48h ago is a
                     # different market — zeros beat stale analytics.
@@ -2480,6 +2482,7 @@ def log_trade(
                             ticker, raw_scan,
                         )
                         rows = []
+                        cause_logged = True
                     elif datetime.now(UTC) - scanned > timedelta(
                         hours=_BACKFILL_MAX_AGE_HOURS,
                     ):
@@ -2490,6 +2493,7 @@ def log_trade(
                             ticker, _BACKFILL_MAX_AGE_HOURS,
                         )
                         rows = []
+                        cause_logged = True
                 if rows:
                     cand = rows[0]
                     if prob_missing:
@@ -2500,7 +2504,11 @@ def log_trade(
                         trade.price = cand["market_price"] or 0.0
                     if score_val <= 0:
                         trade.gimme_score = cand["gimme_score"] or 0.0
-                else:
+                elif not cause_logged:
+                    # Only when there truly was no row — the stale and
+                    # unparseable paths logged their own cause above
+                    # and must not be misreported as "no candidate"
+                    # (#670 review).
                     logging.getLogger(__name__).debug(
                         "skip for %s found no candidate row —"
                         " analytics default to 0 (#657)", ticker,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2329,13 +2329,23 @@ def market_info(
 _SKIP_REASONS = frozenset({
     "cooldown", "research_failed", "review_reject", "validation_failed",
     "order_failed", "close_failed", "no_position", "price_moved",
-    "liquidity",
+    "liquidity", "infra_failed", "already_traded",
 })
 
-# Close-workflow skips carry no entry decision — backfilling scan-time
+# Non-entry skips carry no entry decision — backfilling scan-time
 # candidate analytics onto them would fabricate a "missed entry" the
 # advisor then audits (#657 review). They keep honest zeros instead.
-_NON_ENTRY_REASONS = frozenset({"no_position", "close_failed"})
+# infra_failed (a proceed that died to tooling) and already_traded
+# (position held — the open row carries the real analytics) joined in
+# #670. Aliased from the advisor's single source of truth so the CLI
+# and the missed-opportunity audit can never drift.
+from gimmes.strategy.advisor import (  # noqa: E402
+    NON_ENTRY_SKIP_REASONS as _NON_ENTRY_REASONS,
+)
+
+# #670: backfill freshness bound — mirrors caddie-master's 48h
+# research-void rule; a scan older than that is a different market.
+_BACKFILL_MAX_AGE_HOURS = 48
 
 
 @app.command(name="log-trade", hidden=True)
@@ -2447,6 +2457,39 @@ def log_trade(
                         ticker, exc_info=True,
                     )
                     rows = []
+                if rows:
+                    # #670: a candidate scanned >48h ago is a
+                    # different market — zeros beat stale analytics.
+                    # parse_scanned_at is the canonical parser for
+                    # this column (one parser per column; an inline
+                    # fromisoformat would silently rewrite the
+                    # offset of an aware timestamp).
+                    from datetime import UTC, datetime, timedelta
+
+                    from gimmes.store.observation_validator import (
+                        parse_scanned_at,
+                    )
+
+                    raw_scan = str(rows[0].get("scanned_at") or "")
+                    scanned = parse_scanned_at(raw_scan)
+                    if scanned is None:
+                        logging.getLogger(__name__).warning(
+                            "candidate for %s has unparseable"
+                            " scanned_at %r — treating as stale;"
+                            " analytics default to 0 (#670)",
+                            ticker, raw_scan,
+                        )
+                        rows = []
+                    elif datetime.now(UTC) - scanned > timedelta(
+                        hours=_BACKFILL_MAX_AGE_HOURS,
+                    ):
+                        logging.getLogger(__name__).info(
+                            "candidate for %s scanned >%dh ago —"
+                            " too stale to backfill; analytics"
+                            " default to 0 (#670)",
+                            ticker, _BACKFILL_MAX_AGE_HOURS,
+                        )
+                        rows = []
                 if rows:
                     cand = rows[0]
                     if prob_missing:

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -141,6 +141,13 @@ def _outcomes_by_position(
 # Analysis 1: Threshold Sweep
 # ---------------------------------------------------------------------------
 
+# Non-entry skip reasons (#657/#670): a failed close, a tooling
+# casualty, or a position we already hold is never a missed ENTRY.
+# Single source of truth — cli._NON_ENTRY_REASONS aliases this set.
+NON_ENTRY_SKIP_REASONS = frozenset({
+    "no_position", "close_failed", "infra_failed", "already_traded",
+})
+
 MIN_TRADES_THRESHOLD = 30
 
 
@@ -513,22 +520,25 @@ def analyze_missed_opportunities(
 
     Requires skip logging to be in place (see issue #20).
     """
-    # #657: exclude degenerate skip rows (no probability AND no price
-    # recorded) — they carry no signal but inflate the denominator of
-    # false_negative_rate and the MIN_SKIPS_AUDIT gate, suppressing
-    # legitimate recommendations. Close-workflow skips (no_position,
-    # close_failed — cli._NON_ENTRY_REASONS) are excluded outright:
-    # a failed close is never a missed ENTRY, whatever analytics the
-    # row carries. Both exclusion counts are surfaced in
-    # supporting_data so an audit reconciles against the raw table.
+    # #657/#670: exclude skip rows missing EITHER probability or
+    # price — log-trade's edge normalization zeroes edge unless both
+    # are positive, so such a row can NEVER classify as a missed win
+    # (edge > 0); it only inflates the denominator of
+    # false_negative_rate and the MIN_SKIPS_AUDIT gate. Legacy
+    # prob-only rows are worse: their constructor edge was fabricated
+    # against a price that was never recorded, inflating the
+    # NUMERATOR. Non-entry skips (NON_ENTRY_SKIP_REASONS) are
+    # excluded outright, whatever analytics the row carries. Both
+    # exclusion counts are surfaced in supporting_data so an audit
+    # reconciles against the raw table.
     all_skips = [t for t in trades if t.get("action") == "skip"]
     entry_skips = [
         t for t in all_skips
-        if t.get("reason", "") not in ("no_position", "close_failed")
+        if t.get("reason", "") not in NON_ENTRY_SKIP_REASONS
     ]
     skips = [
         t for t in entry_skips
-        if t.get("model_probability", 0) > 0 or t.get("price", 0) > 0
+        if t.get("model_probability", 0) > 0 and t.get("price", 0) > 0
     ]
     excluded_non_entry = len(all_skips) - len(entry_skips)
     excluded_degenerate = len(entry_skips) - len(skips)

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -623,14 +623,17 @@ class TestMissedOpportunities:
         assert clean_data["excluded_degenerate"] == 0
         assert polluted_data["excluded_degenerate"] == 40
 
-    def test_half_degenerate_rows_are_retained(
+    def test_half_degenerate_rows_excluded_both_ways(
         self, config: GimmesConfig,
     ) -> None:
-        """A skip with EITHER a probability OR a price recorded still
-        carries signal — only rows missing both are excluded."""
+        """#670: a skip missing EITHER probability or price persists
+        with edge = 0 (log-trade's normalization), so it can NEVER
+        classify as a missed win — and a legacy prob-only row's
+        fabricated constructor edge must not inflate the numerator.
+        Both half-degenerate shapes are excluded."""
         prob_only = [{
             "ticker": f"PROB-{i}", "action": "skip", "gimme_score": 72,
-            "edge": 0.15, "price": 0.0, "model_probability": 0.85,
+            "edge": 0.85, "price": 0.0, "model_probability": 0.85,
             "timestamp": f"2026-04-{(i % 28) + 1:02d}T10:00:00",
         } for i in range(3)]
         price_only = [{
@@ -643,8 +646,31 @@ class TestMissedOpportunities:
         )
         assert rec is not None
         data = json.loads(rec.supporting_data)
-        assert data["total_skips"] == 31  # 25 real + 3 + 3
-        assert data["excluded_degenerate"] == 0
+        assert data["total_skips"] == 25  # the real rows only
+        assert data["excluded_degenerate"] == 6
+        # The legacy fabricated edges (0.85) did not reach the rate.
+        assert data["false_negative_rate"] == pytest.approx(0.6)
+
+    def test_price_only_rows_do_not_dilute_the_rate(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#670 mirror of the degenerate-dilution test: N price-only
+        rows leave the recommendation and rate untouched."""
+        price_only = [{
+            "ticker": f"PRICE-{i}", "action": "skip", "gimme_score": 60,
+            "edge": 0.0, "price": 0.60, "model_probability": 0.0,
+            "timestamp": f"2026-05-{(i % 28) + 1:02d}T10:00:00",
+        } for i in range(15)]
+        clean = analyze_missed_opportunities(self._real_skips(), config)
+        polluted = analyze_missed_opportunities(
+            self._real_skips() + price_only, config,
+        )
+        assert clean is not None
+        assert polluted is not None
+        assert polluted.recommended_value == clean.recommended_value
+        data = json.loads(polluted.supporting_data)
+        assert data["false_negative_rate"] == pytest.approx(0.6)
+        assert data["excluded_degenerate"] == 15
 
     def test_degenerate_rows_do_not_satisfy_the_gate(
         self, config: GimmesConfig,
@@ -662,16 +688,20 @@ class TestMissedOpportunities:
     def test_non_entry_reason_skips_excluded_despite_analytics(
         self, config: GimmesConfig,
     ) -> None:
-        """A failed close is never a missed ENTRY — no_position and
-        close_failed skips stay out of the audit even when the row
-        carries full analytics (#657 review)."""
+        """A failed close, a tooling casualty, or a held position is
+        never a missed ENTRY — every non-entry reason stays out of
+        the audit even when the row carries full analytics
+        (#657 review, #670)."""
+        from gimmes.strategy.advisor import NON_ENTRY_SKIP_REASONS
+
+        reasons = tuple(sorted(NON_ENTRY_SKIP_REASONS))
         non_entry = [{
-            "ticker": f"CLOSEFAIL-{i}", "action": "skip",
+            "ticker": f"NONENTRY-{i}", "action": "skip",
             "gimme_score": 90, "edge": 0.30, "price": 0.65,
             "model_probability": 0.95,
-            "reason": "close_failed" if i % 2 else "no_position",
+            "reason": reasons[i % len(reasons)],
             "timestamp": f"2026-06-{(i % 28) + 1:02d}T10:00:00",
-        } for i in range(10)]
+        } for i in range(12)]
         clean = analyze_missed_opportunities(self._real_skips(), config)
         polluted = analyze_missed_opportunities(
             self._real_skips() + non_entry, config,
@@ -682,7 +712,7 @@ class TestMissedOpportunities:
         # The phantom "missed entries" (edge 0.30) did not inflate
         # missed_wins or the denominator.
         assert data["false_negative_rate"] == pytest.approx(0.6)
-        assert data["excluded_non_entry"] == 10
+        assert data["excluded_non_entry"] == 12
 
     def test_degenerate_skips_alone_are_insufficient(
         self, config: GimmesConfig,
@@ -815,3 +845,13 @@ class TestMigrationV4:
         )
         row = await cursor.fetchone()
         assert row[0] >= 4
+
+
+def test_non_entry_reasons_single_source_of_truth() -> None:
+    """#670 review: the CLI's --reason gate and the advisor's audit
+    exclusion must never drift — the CLI aliases the advisor set."""
+    from gimmes import cli
+    from gimmes.strategy.advisor import NON_ENTRY_SKIP_REASONS
+
+    assert cli._NON_ENTRY_REASONS is NON_ENTRY_SKIP_REASONS
+    assert NON_ENTRY_SKIP_REASONS <= cli._SKIP_REASONS

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -1872,6 +1872,12 @@ def test_skip_templates_carry_structured_reason(
          "caddie-master.md"),
         ("--action skip --reason review_reject", caddie_master_text,
          "caddie-master.md"),
+        # #670: already_traded template (criterion 4) and the
+        # infra_failed decision-note-failure instruction.
+        ("--action skip --reason already_traded", caddie_master_text,
+         "caddie-master.md"),
+        ("--reason infra_failed", caddie_master_text,
+         "caddie-master.md"),
         ("--action skip --reason validation_failed", closer_text,
          "closer.md"),
         ("--action skip --reason order_failed", closer_text,

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -185,13 +185,20 @@ def test_mixed_explicit_prob_backfilled_price_score(
 
 def test_no_candidate_row_keeps_zeros(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    import logging
+
     db_path = tmp_path / "test.db"
     _bare_db(db_path)
     _patch_config(monkeypatch, db_path)
 
-    result = _invoke_skip()
+    with caplog.at_level(logging.DEBUG, logger="gimmes.cli"):
+        result = _invoke_skip()
     assert result.exit_code == 0, result.output
+    # The genuine no-row path — the fallback debug names the true
+    # cause (guards against inverting the cause_logged flag, #670).
+    assert "found no candidate row" in caplog.text
 
     s = _skip_row(db_path)
     assert s["model_probability"] == 0.0
@@ -506,6 +513,59 @@ def test_unparseable_scanned_at_not_backfilled(
         result = _invoke_skip()
     assert result.exit_code == 0, result.output
     assert "unparseable" in caplog.text
+    s = _skip_row(db_path)
+    assert s["model_probability"] == 0.0
+    assert s["price"] == 0.0
+
+
+def test_stale_candidate_logs_staleness_not_no_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#670 review: the stale path logs its own cause (INFO) and must
+    NOT also emit the misleading 'found no candidate row' fallback
+    (DEBUG capture is required — at INFO the absence assertion would
+    be vacuous)."""
+    import logging
+
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _age_candidate(db_path, "datetime('now', '-49 hours')")
+    _patch_config(monkeypatch, db_path)
+
+    with caplog.at_level(logging.DEBUG, logger="gimmes.cli"):
+        result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    assert "too stale to backfill" in caplog.text
+    assert "found no candidate row" not in caplog.text
+
+
+def test_lookup_error_degrades_with_own_cause_logged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A candidate-lookup failure degrades to zeros, logs its own
+    cause at ERROR, and does not misreport 'no candidate row'."""
+    import logging
+    import sqlite3
+
+    db_path = tmp_path / "test.db"
+    _bare_db(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    async def _boom(_db, _ticker):  # type: ignore[no-untyped-def]
+        raise sqlite3.Error("lookup exploded")
+
+    monkeypatch.setattr(
+        "gimmes.store.queries.get_candidate_for_ticker", _boom,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="gimmes.cli"):
+        result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    assert "candidate lookup failed" in caplog.text
+    assert "found no candidate row" not in caplog.text
+
     s = _skip_row(db_path)
     assert s["model_probability"] == 0.0
     assert s["price"] == 0.0

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -335,20 +335,23 @@ def test_scout_shape_prob_zero_real_price_no_candidate(
 def test_non_entry_reason_skips_backfill(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Close-workflow skips (no_position, close_failed) carry no entry
-    decision — the candidate row must NOT be fabricated onto them,
-    else the missed-opportunity audit counts a failed close as a
-    missed entry (#657 review)."""
+    """Non-entry skips (no_position, close_failed, plus #670's
+    infra_failed and already_traded) carry no entry decision — the
+    candidate row must NOT be fabricated onto them, else the
+    missed-opportunity audit counts a failed close, a tooling
+    casualty, or a held position as a missed entry."""
     db_path = tmp_path / "test.db"
     _seed_candidate(db_path)
     _patch_config(monkeypatch, db_path)
 
-    for reason in ("no_position", "close_failed"):
+    from gimmes.strategy.advisor import NON_ENTRY_SKIP_REASONS
+
+    for reason in sorted(NON_ENTRY_SKIP_REASONS):
         result = _invoke_skip("--reason", reason)
         assert result.exit_code == 0, result.output
 
     rows = _trade_rows(db_path)
-    assert len(rows) == 2
+    assert len(rows) == len(NON_ENTRY_SKIP_REASONS)
     for s in rows:
         assert s["model_probability"] == 0.0
         assert s["price"] == 0.0
@@ -437,3 +440,72 @@ def test_bound_price_close_with_explicit_prob_records_zero_edge(
     [c] = _trade_rows(db_path, "close")
     assert c["model_probability"] == 0.9
     assert c["edge"] == 0.0
+
+
+def _age_candidate(db_path: Path, sql_age: str) -> None:
+    async def _age(db: Database) -> None:
+        await db.conn.execute(
+            "UPDATE candidates SET scanned_at = " + sql_age,
+        )
+        await db.conn.commit()
+
+    _db_run(db_path, _age)
+
+
+def test_stale_candidate_not_backfilled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#670: a candidate scanned >48h ago is a different market — the
+    skip keeps honest zeros instead of inheriting stale analytics
+    (mirrors caddie-master's 48h research-void rule)."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _age_candidate(db_path, "datetime('now', '-49 hours')")
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    s = _skip_row(db_path)
+    assert s["model_probability"] == 0.0
+    assert s["price"] == 0.0
+    assert s["edge"] == 0.0
+
+
+def test_candidate_just_inside_bound_backfills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """47h old is within the bound — full backfill (pins the
+    comparison direction)."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _age_candidate(db_path, "datetime('now', '-47 hours')")
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    s = _skip_row(db_path)
+    assert s["model_probability"] == CAND_PROB
+    assert s["price"] == CAND_PRICE
+
+
+def test_unparseable_scanned_at_not_backfilled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A corrupt scanned_at is unknown-age data — treated as stale
+    (zeros) rather than trusted, and WARNED about (data integrity —
+    Groundskeeper triages logs post-cycle)."""
+    import logging
+
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _age_candidate(db_path, "'garbage'")
+    _patch_config(monkeypatch, db_path)
+
+    with caplog.at_level(logging.WARNING, logger="gimmes.cli"):
+        result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    assert "unparseable" in caplog.text
+    s = _skip_row(db_path)
+    assert s["model_probability"] == 0.0
+    assert s["price"] == 0.0


### PR DESCRIPTION
## Summary

Resolves the five #670 hardening items deferred from #657:

**1. Staleness bound on the skip backfill.** `log-trade` inherited skip analytics from the latest candidate row regardless of age. It now rejects rows scanned more than 48 hours ago — mirroring caddie-master's research-void rule — using the canonical `parse_scanned_at` parser (review finding: an inline `fromisoformat` had a latent timezone-corruption path for offset-bearing strings). Stale rows log at info; unparseable timestamps warn (data-integrity signal for Groundskeeper) and degrade to honest zeros. `prune_candidates` deliberately stays unwired: old candidate rows are still legitimately consumed by the cooldown display and the flip/STALE-CLOSE checks, and the reader-side bound makes them harmless for the backfill.

**2/3. Vocabulary: `infra_failed` and `already_traded`.** A decision-note write failure was logged as `review_reject` — a proceed that died to tooling, not a review verdict — and now uses `infra_failed`. "Already traded" skips (criterion 4) get their own value. Both are non-entry reasons: they keep honest zeros (the open trade row carries the real analytics) and stay out of the missed-opportunity audit. The non-entry set is now a single source of truth (`advisor.NON_ENTRY_SKIP_REASONS`) aliased by the CLI, with an identity drift-guard test — three review agents independently flagged the comment-only sync as armed-but-not-fired.

**4. Prose skip sites.** caddie-master criterion 3 (price unchanged) now explicitly instructs `--reason cooldown` via the criterion-2 template; criterion 4 gets a full `already_traded` log-trade template (no analytics flags, per the zero-flag pin).

**5. Audit denominator.** `analyze_missed_opportunities` now excludes skips missing **either** probability or price: log-trade's edge normalization zeroes edge unless both are positive, so such rows can never classify as missed wins and only dilute the false-negative rate — and legacy prob-only rows carried a fabricated constructor edge (probability minus a never-recorded price) that inflated the numerator. Both exclusions land in the auditable `excluded_degenerate` count.

`--reason` on non-skip actions (#670 item 2) was verified already rejected and pinned — no change.

Closes #670

## Test plan

- `test_cli_skip_analytics.py`: 3 staleness tests (>48h stale, 47h backfills — pins the comparison direction and the constant to ±1h, unparseable warns via caplog), non-entry loop derived from the shared constant.
- `test_advisor.py`: both half-degenerate shapes excluded with the fabricated-edge case pinned (`false_negative_rate` unchanged by legacy prob-only rows), price-only dilution mirror, non-entry loop derived from the constant, single-source-of-truth identity test.
- `test_agent_prompts.py`: fragments pin the `already_traded` template and the `infra_failed` instruction.
- Full suite: **1839 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB