### PR TITLE
Fix #672: scorer/size stop fabricating edge at bounds, validator bound check unconditional

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -27,7 +27,7 @@ You are the Caddie — the research agent in the GIMMES trading pipeline. You ta
 
    **Side awareness:** When `trading_side` is `no`, you are evaluating the NO outcome. Your true probability estimate (`--prob`) should reflect the probability of the NO outcome (i.e., 1 - P(YES)). The `--price` argument should still be the YES price as shown by `market-info` — the CLI converts it internally.
 
-   **Untradeable at the bound:** If `market-info` shows the tradeable side priced within one tick of a bound (effective price <= $0.01 or >= $0.99), the market is untradeable at the bound — there is no realizable edge, whatever the arithmetic says. Still log the candidate (the record feeds cooldown), but set `--recommendation pass` and note untradeable-at-bound in the memo. A bound-priced sibling is also excluded from the sibling-strike lowest-price comparison — an untradeable strike does not dominate its event.
+   **Untradeable at the bound:** If `market-info` shows the tradeable side priced within one tick of a bound (effective price <= $0.01 or >= $0.99), the market is untradeable at the bound — there is no realizable edge, whatever the arithmetic says. Still log the candidate (the record feeds cooldown), but set `--recommendation pass` and note untradeable-at-bound in the memo. Score the edge-size component 0 at a bound — the edge after fees is 0, whatever the arithmetic says — and compute GimmeScore accordingly (a high stored score would re-trigger research every cycle). A bound-priced sibling is also excluded from the sibling-strike lowest-price comparison — an untradeable strike does not dominate its event.
 
 1. For each candidate (or event group) from the Scout's shortlist:
    - Run `gimmes market-info TICKER` for detailed market data
@@ -186,7 +186,7 @@ When researching a candidate, find its category below and check these sources BE
 ## GimmeScore Calculation
 
 The GimmeScore is a weighted composite (0-100) computed from five components:
-- **Edge size** (30% weight): Based on edge after fees. >=25pp → 100, >=15pp → 80, >=10pp → 60, >=5pp → 40, <5pp → 20
+- **Edge size** (30% weight): Based on edge after fees. >=25pp → 100, >=15pp → 80, >=10pp → 60, >=5pp → 40, <5pp → 20. At/within one tick of a bound: 0 (no realizable edge).
 - **Signal strength** (25% weight): Based on number and average strength. >=4 signals → 90, >=3 → 70, >=2 → 50, 1 → 25
 - **Liquidity depth** (15% weight): Based on volume. >=500 → 100, >=200 → 80, >=50 → 60, <50 → 20
 - **Settlement clarity** (15% weight): Clear → 100, Medium risk → 50, High risk → 0

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -567,36 +567,53 @@ def size(
                 from gimmes.kalshi.portfolio import get_balance
                 balance = await get_balance(client)
 
-            from gimmes.strategy.scanner import effective_price
+            from gimmes.strategy.scanner import effective_price, price_at_bound
 
             raw_price = market.midpoint or market.last_price
             price = effective_price(raw_price, config.strategy.side)
             fees = get_multipliers(market.series_ticker)
 
+            # #672: a bound-priced market is unfillable — kelly's
+            # 0 < price < 1 guard misses the one-tick-inside case
+            # (eff $0.01), so without this the table fabricates
+            # Edge/Contracts/Cost for an order that cannot exist.
+            at_bound = price_at_bound(price)
+            if at_bound:
+                import logging
+
+                logging.getLogger(__name__).debug(
+                    "size %s: price at bound (eff $%.2f) — table"
+                    " zeroed (#672)", ticker, price,
+                )
+
             bankroll = config.bankroll
             true_prob = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
-            kf = kelly_fraction(
+            kf = 0.0 if at_bound else kelly_fraction(
                 price, true_prob,
                 fraction=config.sizing.kelly_fraction, fees=fees,
             )
-            contracts = position_size(
+            contracts = 0 if at_bound else position_size(
                 bankroll, price, true_prob,
                 fraction=config.sizing.kelly_fraction,
                 max_position_pct=config.sizing.max_position_pct, fees=fees,
                 mode=config.sizing.mode,
             )
             fee = fee_for_order(contracts, price, is_taker=False, fees=fees)
-            edge = edge_after_fees(price, true_prob, fees=fees)
+            edge = 0.0 if at_bound else edge_after_fees(price, true_prob, fees=fees)
             cost = contracts * price + fee
 
             table = format_kv_table(f"Position Sizing: {ticker}", [
                 ("Market Price", f"${price:.2f}"),
                 ("True Probability", f"{true_prob:.1%}"),
-                ("Edge After Fees", f"{edge:.1%}"),
+                ("Edge After Fees",
+                 f"{edge:.1%} (price at bound — untradeable, #658)"
+                 if at_bound else f"{edge:.1%}"),
                 ("Kelly Fraction", f"{kf:.4f}"),
                 ("Bankroll", f"${bankroll:,.2f}"),
                 ("Balance", f"${balance:,.2f}"),
-                ("Contracts", f"[bold]{contracts}[/bold]"),
+                ("Contracts",
+                 f"[bold]{contracts}[/bold] (at bound)"
+                 if at_bound else f"[bold]{contracts}[/bold]"),
                 ("Est. Cost", f"${cost:,.2f}"),
                 ("Est. Fee", f"${fee:,.2f}"),
             ])

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -161,27 +161,29 @@ def validate_trade(
     else:
         checks.append("True probability check skipped (no probability provided)")
 
-    # 6. Edge after fees (skipped when probability is unknown)
-    if true_probability is not None:
-        raw_price = market.midpoint if market.midpoint > 0 else market.last_price
-        price = effective_price(raw_price, config.strategy.side)
-        # #658: within one tick of a bound the edge formula collapses
-        # to `prob - 0` — a fabricated "Edge OK (88%)" would wave an
-        # unfillable order through the last pre-capital gate. The
-        # price can drift to the bound between Caddie research and
-        # Closer execution, so the live check must catch it.
-        if price_at_bound(price):
-            failures.append(
-                f"Price at bound: effective price ${price:.2f} is"
-                f" untradeable — no realizable edge (#658)"
-            )
+    # 6. Price at bound + edge after fees. The bound rejection is
+    # NOT probability-gated (#672 review): the price is known
+    # regardless, and a count-only manual order at eff $0.01 is just
+    # as unfillable as a probability-carrying one.
+    raw_price = market.midpoint if market.midpoint > 0 else market.last_price
+    price = effective_price(raw_price, config.strategy.side)
+    # #658: within one tick of a bound the edge formula collapses
+    # to `prob - 0` — a fabricated "Edge OK (88%)" would wave an
+    # unfillable order through the last pre-capital gate. The
+    # price can drift to the bound between Caddie research and
+    # Closer execution, so the live check must catch it.
+    if price_at_bound(price):
+        failures.append(
+            f"Price at bound: effective price ${price:.2f} is"
+            f" untradeable — no realizable edge (#658)"
+        )
+    elif true_probability is not None:
+        edge = edge_after_fees(price, true_probability, is_taker=is_taker, fees=fees)
+        min_edge = config.strategy.min_edge_after_fees
+        if edge >= min_edge:
+            checks.append(f"Edge OK ({edge:.1%} >= {min_edge:.1%})")
         else:
-            edge = edge_after_fees(price, true_probability, is_taker=is_taker, fees=fees)
-            min_edge = config.strategy.min_edge_after_fees
-            if edge >= min_edge:
-                checks.append(f"Edge OK ({edge:.1%} >= {min_edge:.1%})")
-            else:
-                failures.append(f"Insufficient edge: {edge:.1%} < {min_edge:.1%} minimum")
+            failures.append(f"Insufficient edge: {edge:.1%} < {min_edge:.1%} minimum")
     else:
         checks.append("Edge check skipped (no probability provided)")
 

--- a/src/gimmes/strategy/scanner.py
+++ b/src/gimmes/strategy/scanner.py
@@ -22,6 +22,11 @@ def effective_price(yes_price: float, side: str) -> float:
 
 # Kalshi's cent tick. A side priced within one tick of a bound is
 # untradeable in practice (at $0.00 an order isn't even placeable).
+# Near-bound-but-placeable prices (eff $0.02-$0.05) are deliberately
+# NOT clamped: the arithmetic stands, and execution is gated by the
+# validator's price-at-bound rejection and the scan price band
+# (#672 decision, deferred from #658). Historical degenerate candidate
+# rows are not repaired — resurfacing tickers self-heal.
 BOUND_TICK = 0.01
 
 

--- a/src/gimmes/strategy/scorer.py
+++ b/src/gimmes/strategy/scorer.py
@@ -6,7 +6,7 @@ from gimmes.config import GimmesConfig
 from gimmes.models.gimme import GimmeCandidate, GimmeScore
 from gimmes.models.market import Market, Orderbook
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, edge_after_fees
-from gimmes.strategy.scanner import days_until, effective_price
+from gimmes.strategy.scanner import days_until, effective_price, price_at_bound
 
 
 def quick_score(market: Market, config: GimmesConfig) -> float:
@@ -90,19 +90,28 @@ def full_score(
     side_price = effective_price(candidate.market_price, config.strategy.side)
 
     # Edge size score (0-100)
-    edge = edge_after_fees(side_price, candidate.model_probability, fees=fees)
-    if edge >= 0.25:
-        edge_score = 100.0
-    elif edge >= 0.15:
-        edge_score = 80.0
-    elif edge >= 0.10:
-        edge_score = 60.0
-    elif edge >= 0.05:
-        edge_score = 40.0
-    elif edge > 0:
-        edge_score = 20.0
-    else:
+    # #658/#672: at/within one tick of a bound, edge_after_fees
+    # collapses to ~prob on an UNFILLABLE order — no realizable edge,
+    # score 0 (same guard-then-compute pattern as the validator).
+    at_bound = price_at_bound(side_price)
+    if at_bound:
         edge_score = 0.0
+    else:
+        edge = edge_after_fees(
+            side_price, candidate.model_probability, fees=fees,
+        )
+        if edge >= 0.25:
+            edge_score = 100.0
+        elif edge >= 0.15:
+            edge_score = 80.0
+        elif edge >= 0.10:
+            edge_score = 60.0
+        elif edge >= 0.05:
+            edge_score = 40.0
+        elif edge > 0:
+            edge_score = 20.0
+        else:
+            edge_score = 0.0
 
     # Signal strength score (0-100)
     signals = candidate.signals
@@ -183,5 +192,11 @@ def full_score(
         liquidity_depth_score=liq_score,
         settlement_clarity_score=settlement_score,
         time_to_resolution_score=time_score,
-        memo=candidate.research_memo,
+        # #672: the memo carries the bound determination — a zeroed
+        # edge from an unfillable price must stay distinguishable from
+        # a genuinely dead thesis (GimmeScore has no flags field).
+        memo=(
+            f"[at-bound: edge component zeroed #658] {candidate.research_memo}"
+            if at_bound else candidate.research_memo
+        ),
     )

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -1910,6 +1910,8 @@ def test_caddie_untradeable_at_bound_rule(caddie_text: str) -> None:
     assert "within one tick of a bound" in caddie_text
     assert "--recommendation pass" in caddie_text
     assert "sibling-strike" in caddie_text  # bound strikes don't dominate
+    # #672: the numeric score must not undo the pass recommendation.
+    assert "edge-size component 0" in caddie_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_buy_no.py
+++ b/tests/unit/test_buy_no.py
@@ -76,6 +76,15 @@ class TestTradeableEdge:
         # stands (documented residual: the $0.97 case is 3 ticks in)
         assert tradeable_edge(0.88, 0.98, "no") == pytest.approx(0.86)
 
+    def test_garbage_yes_price_clamps_both_sides(self) -> None:
+        """#672 pin: out-of-range yes_price lands at/beyond a bound on
+        one side or the other — always clamped to 0, never a
+        fabricated edge."""
+        assert tradeable_edge(0.88, -0.5, "yes") == 0.0
+        assert tradeable_edge(0.88, -0.5, "no") == 0.0
+        assert tradeable_edge(0.88, 1.5, "yes") == 0.0
+        assert tradeable_edge(0.88, 1.5, "no") == 0.0
+
     def test_mid_range_unchanged(self) -> None:
         # NO at YES 0.70 → eff 0.30
         assert tradeable_edge(0.85, 0.70, "no") == pytest.approx(0.55)

--- a/tests/unit/test_cli_size.py
+++ b/tests/unit/test_cli_size.py
@@ -1,0 +1,111 @@
+"""`gimmes size` must not fabricate sizing rows for bound-priced
+markets (#672, deferred from #658).
+
+kelly_fraction's `0 < price < 1` guard misses the one-tick-inside case
+(effective $0.01), so pre-fix the table showed a fabricated Edge After
+Fees AND nonzero Contracts/Cost for an order that cannot exist. The
+command is pure display (no DB writes, no orders) — the fix zeroes the
+whole row set behind the same `price_at_bound` gate the validator and
+the stored-edge writers use.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from io import StringIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rich.console import Console
+from typer.testing import CliRunner
+
+from gimmes.cli import app
+from gimmes.config import GimmesConfig, Mode, StrategyConfig
+
+runner = CliRunner()
+
+
+def _fake_trading_context(broker):  # type: ignore[no-untyped-def]
+    @asynccontextmanager
+    async def _ctx(config):  # type: ignore[no-untyped-def]
+        yield AsyncMock(), broker, AsyncMock()
+
+    return _ctx
+
+
+def _stub_market(yes_price: float):  # type: ignore[no-untyped-def]
+    m = MagicMock()
+    m.midpoint = yes_price
+    m.last_price = yes_price
+    m.series_ticker = "TEST"
+    return m
+
+
+def _run_size(yes_price: float, side: str = "no") -> str:
+    config = GimmesConfig(
+        mode=Mode.DRIVING_RANGE,
+        strategy=StrategyConfig(side=side),
+    )
+    broker = MagicMock()
+    broker.get_balance = AsyncMock(return_value=10_000.0)
+    buf = StringIO()
+    # Wide console: cell content must not ellipsize (the #618 lesson).
+    real_console = Console(file=buf, width=200)
+    from gimmes.strategy.fee_cache import DEFAULT_FEE_MULTIPLIERS
+    mock_fees = DEFAULT_FEE_MULTIPLIERS
+
+    with (
+        patch("gimmes.cli.load_config", return_value=config),
+        patch("gimmes.cli.trading_context", _fake_trading_context(broker)),
+        patch("gimmes.cli.console", real_console),
+        patch(
+            "gimmes.kalshi.markets.get_market",
+            AsyncMock(return_value=_stub_market(yes_price)),
+        ),
+        patch(
+            "gimmes.strategy.fee_cache.get_multipliers",
+            MagicMock(return_value=mock_fees),
+        ),
+    ):
+        result = runner.invoke(app, ["size", "KXTEST", "--prob", "0.88"])
+    assert result.exit_code == 0, result.output
+    return buf.getvalue()
+
+
+def test_exact_bound_shows_untradeable_and_zero_contracts() -> None:
+    # YES $1.00 → NO effective $0.00
+    out = _run_size(1.00, side="no")
+    assert "price at bound" in out
+    contracts_line = next(
+        line for line in out.splitlines() if "Contracts" in line
+    )
+    assert " 0 " in contracts_line
+    assert "(at bound)" in contracts_line
+
+
+def test_one_tick_inside_bound_zeroes_the_table() -> None:
+    """YES $0.99 → NO effective $0.01 — the case kelly does NOT guard;
+    pre-fix this fabricated nonzero contracts."""
+    out = _run_size(0.99, side="no")
+    assert "price at bound" in out
+    contracts_line = next(
+        line for line in out.splitlines() if "Contracts" in line
+    )
+    assert " 0 " in contracts_line
+    kelly_line = next(
+        line for line in out.splitlines() if "Kelly Fraction" in line
+    )
+    assert "0.0000" in kelly_line
+
+
+def test_mid_range_market_unchanged() -> None:
+    """Control: a normally-priced market keeps real sizing output."""
+    import re
+
+    out = _run_size(0.70, side="no")  # NO effective $0.30
+    assert "price at bound" not in out
+    contracts_line = next(
+        line for line in out.splitlines() if "Contracts" in line
+    )
+    # 0.88 prob at $0.30 effective sizes a real position.
+    contracts = int(re.search(r"(\d+)", contracts_line.split("Contracts")[1]).group(1))
+    assert contracts > 0

--- a/tests/unit/test_scorer.py
+++ b/tests/unit/test_scorer.py
@@ -73,6 +73,65 @@ class TestFullScore:
         # Settlement penalty should lower the score
         assert score.settlement_clarity_score <= 30
 
+    def test_bound_priced_no_side_scores_edge_zero(self) -> None:
+        """#672: YES $1.00 → NO effective $0.00 — an unfillable order.
+        edge_after_fees would say +88pp; the edge component must be 0
+        (this exact shape scored 100 pre-fix, re-triggering Caddie
+        research every cycle)."""
+        no_config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="no"),
+        )
+        candidate = GimmeCandidate(
+            ticker="KXCPIYOY", market_price=1.00,
+            model_probability=0.88,
+        )
+        score = full_score(candidate, None, no_config)
+        assert score.edge_size_score == 0.0
+
+    def test_one_tick_inside_bound_scores_edge_zero(self) -> None:
+        """YES $0.99 → NO effective $0.01 — within one tick, still
+        untradeable (matches tradeable_edge and the validator)."""
+        no_config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="no"),
+        )
+        candidate = GimmeCandidate(
+            ticker="X", market_price=0.99, model_probability=0.88,
+        )
+        score = full_score(candidate, None, no_config)
+        assert score.edge_size_score == 0.0
+
+    def test_bound_determination_carried_in_memo(self) -> None:
+        """#672: a zeroed-at-bound edge must stay distinguishable from
+        a genuinely dead thesis — the memo carries the marker."""
+        no_config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="no"),
+        )
+        bound = GimmeCandidate(
+            ticker="X", market_price=1.00, model_probability=0.88,
+            research_memo="thesis text",
+        )
+        score = full_score(bound, None, no_config)
+        assert score.memo.startswith("[at-bound:")
+        assert "thesis text" in score.memo
+
+        normal = GimmeCandidate(
+            ticker="X", market_price=0.30, model_probability=0.88,
+            research_memo="thesis text",
+        )
+        score = full_score(normal, None, no_config)
+        assert score.memo == "thesis text"
+
+    def test_yes_side_floor_bound_scores_edge_zero(self) -> None:
+        candidate = GimmeCandidate(
+            ticker="X", market_price=0.01, model_probability=0.90,
+        )
+        config = GimmesConfig(mode=Mode.DRIVING_RANGE)
+        score = full_score(candidate, None, config)
+        assert score.edge_size_score == 0.0
+
     def test_no_side_uses_effective_price(self) -> None:
         """full_score should convert YES-denominated market_price for NO side."""
         no_config = GimmesConfig(

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -398,6 +398,27 @@ class TestPriceBoundGate:
         assert result.approved is False
         assert any("Price at bound" in f for f in result.failures)
 
+    def test_count_only_order_still_rejected_at_bound(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#672: the bound rejection is not probability-gated — a
+        manual `order --count N` without --prob is just as unfillable
+        at the bound (pre-fix the whole check was skipped)."""
+        config.strategy.side = "no"
+        market = _make_market(yes_bid=1.0, yes_ask=1.0, last_price=1.0)
+        result = validate_trade(
+            market=market,
+            trade_dollars=200,
+            true_probability=None,
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+        assert result.approved is False
+        assert any("Price at bound" in f for f in result.failures)
+
     def test_mid_range_edge_check_unchanged(
         self, config: GimmesConfig,
     ) -> None:


### PR DESCRIPTION
## Summary

Resolves the five #672 residuals from #658:

**1. `full_score` bound guard.** The edge-size component scored 100 for bound-priced markets — `edge_after_fees(0.0, 0.88)` returns ~0.88 for an unfillable NO at YES $1.00 (the KXCPIYOY shape), and a stored score ≥ threshold re-triggers Caddie research every cycle. The component is now guarded by `price_at_bound` (the validator's guard-then-compute pattern), and the bound determination is carried in the returned memo so a zeroed edge stays distinguishable from a genuinely dead thesis (`GimmeScore` has no flags field; the marker survives serialization).

**2. `gimmes size` fabricated table.** Worse than the issue's "cosmetic": kelly's `0 < price < 1` guard misses the one-tick-inside case (effective $0.01), so pre-fix the table showed real-looking Edge/Kelly/Contracts/Cost for an unplaceable order (`kelly_fraction(0.01, 0.88)` = 0.2194, 25,000 contracts). The whole row set is now zeroed behind `price_at_bound`, with "(price at bound — untradeable, #658)" on the Edge row, "(at bound)" on the Contracts row (survives column truncation), and a debug log for grep-parity with `tradeable_edge`. Display-only command — no capital path.

**3. Validator bound check made unconditional (review finding).** The #658 price-at-bound rejection lived inside `if true_probability is not None:` — a manual `order --count N` without `--prob` bypassed it entirely and could reach the exchange with an unfillable one-tick-inside order. Hoisted out of the probability gate; the price is known regardless.

**4. Near-bound policy: stays as-is, now documented.** The $0.97/3-ticks case is deliberately not clamped (thin-but-placeable real edge); execution is gated by the validator rejection and the scan price band. Documented at `BOUND_TICK` alongside the no-repair decision for historical degenerate rows.

**5. caddie.md scoring rule.** The untradeable-at-bound rule now also instructs scoring the edge-size component 0 (rubric updated) — with edge 0 the max composite is 67.5 < default threshold 75, landing bound candidates in the borderline cooldown tier where re-research only fires on a real price move.

Plus: `tradeable_edge` garbage-input clamping pinned (negative/>1 yes_price → 0.0 both sides).

Closes #672

## Test plan

- `test_scorer.py`: 3 bound tests (exact bound / one-tick / YES floor — all verified to score 100 pre-fix) + memo-marker pin.
- `test_cli_size.py` (new): exact-bound and one-tick tables fully zeroed (Contracts, Kelly, Edge rows asserted), mid-range control extracts the contract count numerically.
- `test_validator.py`: count-only order at a bound rejects (pre-fix the whole check was skipped).
- `test_buy_no.py`: garbage-input pin. `test_agent_prompts.py`: edge-size-component-0 fragment pin.
- Full suite: **1850 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB