### PR TITLE
Fix #676: flip-baseline robustness against bookkeeping rows, memo panel for CM review

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1689,9 +1689,13 @@ def candidates(
             )
             if memo_row is not None:
                 scanned = str(memo_row.get("scanned_at") or "?")
+                # Header claims only what was searched: the fetched
+                # window is bounded by --limit, so the scanned-at
+                # timestamp — not a "newest on record" claim — anchors
+                # recency (PR #692 review).
                 console.print(
-                    f"\n[bold]--- RESEARCH MEMO (newest on record,"
-                    f" scanned {rich_escape(scanned)}) ---[/bold]"
+                    f"\n[bold]--- RESEARCH MEMO (scanned"
+                    f" {rich_escape(scanned)}) ---[/bold]"
                 )
                 console.print(
                     str(memo_row.get("research_memo") or ""),

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1668,6 +1668,41 @@ def candidates(
                 f" contain; re-research before approving (#661)[/red]"
             )
 
+        # #676: single-ticker mode prints the newest row's research
+        # memo — caddie-master's 4c derivation rule reads the memo
+        # through this command, and the table has no memo column.
+        # markup=False renders bracketed memo text literally (the
+        # #644 markup class); plain print wraps but never ellipsizes
+        # (the #659 width lesson).
+        if ticker:
+            # Newest NON-EMPTY memo (#676 review): a bookkeeping row
+            # with an empty memo must not hide the real research the
+            # 4c derivation rule reads. soft_wrap keeps unbroken
+            # tokens (source URLs) intact instead of hard-wrapping
+            # them into dead links at width 80.
+            memo_row = next(
+                (
+                    r for r in records
+                    if str(r.get("research_memo") or "").strip()
+                ),
+                None,
+            )
+            if memo_row is not None:
+                scanned = str(memo_row.get("scanned_at") or "?")
+                console.print(
+                    f"\n[bold]--- RESEARCH MEMO (newest on record,"
+                    f" scanned {rich_escape(scanned)}) ---[/bold]"
+                )
+                console.print(
+                    str(memo_row.get("research_memo") or ""),
+                    markup=False, soft_wrap=True,
+                )
+            else:
+                console.print(
+                    "\n[bold]--- RESEARCH MEMO ---[/bold]"
+                )
+                console.print("[dim][No memo stored][/dim]")
+
     _run(_candidates())
 
 
@@ -2660,8 +2695,18 @@ def log_candidate(
             # its own fetch failing must degrade to "no check", never
             # block the insert (log-candidate is the Caddie's primary
             # logging path; the #657 logger-of-last-resort rule).
+            # #676: fetch the newest SCORED prior — the market-info-
+            # failure rows caddie.md/scout.md mandate (--price 0
+            # --prob 0) are bookkeeping, not scorings, and at a plain
+            # limit=1 a single one hid the real baseline (a multi-
+            # cycle outage would stack several). The SQL filter finds
+            # the true baseline no matter how many failure rows sit
+            # above it; the detector's own staleness/degenerate
+            # guards stay the policy backstop.
             try:
-                prior_rows = await get_candidate_for_ticker(db, ticker)
+                prior_rows = await get_candidate_for_ticker(
+                    db, ticker, scored_only=True,
+                )
             except sqlite3.Error:
                 logging.getLogger(__name__).error(
                     "prior-candidate lookup failed for %s; flip check"
@@ -2669,10 +2714,11 @@ def log_candidate(
                 )
                 prior_rows = []
             if prior_rows:
+                prior = prior_rows[0]
                 warnings = detect_candidate_flip(
-                    prior_prob=prior_rows[0]["model_probability"] or 0.0,
-                    prior_price=prior_rows[0]["market_price"] or 0.0,
-                    prior_scanned_at=str(prior_rows[0]["scanned_at"] or ""),
+                    prior_prob=prior["model_probability"] or 0.0,
+                    prior_price=prior["market_price"] or 0.0,
+                    prior_scanned_at=str(prior["scanned_at"] or ""),
                     new_prob=prob,
                     new_price=price_val,
                 )

--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -771,6 +771,17 @@ def validate_observation(
 FLIP_PROB_DELTA = 0.50
 FLIP_PRICE_DELTA = 0.10
 INVERSION_TOLERANCE = 0.05
+# 48h is deliberate and load-bearing (#676 decision): (1) it matches
+# Caddie Master's research-expiry rule — research older than 48h IS
+# "no prior research" to the workflow, so warning against it would be
+# stricter about the past than the process that produces the past;
+# (2) the flip warning feeds caddie.md's mandatory acknowledgment and
+# CM's 4c REJECT criterion, so it must stay high-precision — a
+# 0.98->0.02 move across the observed 139-168h gaps is exactly what a
+# near-binary market does when the event resolves against the prior
+# view, and complements are where genuine multi-day repricings LAND,
+# so even the inversion signature loses evidentiary force at that
+# horizon. Keep this equal to the caddie-master 48h expiry (pinned).
 FLIP_STALENESS_HOURS = 48
 # The marker MUST stay uppercase: Rich only parses tags starting
 # [a-z#/@], so [FLIP-WARNING] renders literally while a lowercase

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -968,13 +968,21 @@ async def get_thesis_for_ticker(db: Database, ticker: str) -> str:
 
 async def get_candidate_for_ticker(
     db: Database, ticker: str, *, limit: int = 1,
+    scored_only: bool = False,
 ) -> list[dict]:
-    """Return the most recent candidate row(s) for a specific ticker."""
-    cursor = await db.conn.execute(
-        "SELECT * FROM candidates WHERE ticker = ?"
-        " ORDER BY scanned_at DESC, id DESC LIMIT ?",
-        (ticker, limit),
-    )
+    """Return the most recent candidate row(s) for a specific ticker.
+
+    ``scored_only`` (#676) skips bookkeeping rows (prob/price 0 — the
+    market-info-failure rows caddie.md/scout.md mandate) so the true
+    newest SCORING is found no matter how many failure rows stack
+    above it. The predicate mirrors detect_candidate_flip's degenerate
+    guard, which remains the policy backstop.
+    """
+    query = "SELECT * FROM candidates WHERE ticker = ?"
+    if scored_only:
+        query += " AND model_probability > 0 AND market_price > 0"
+    query += " ORDER BY scanned_at DESC, id DESC LIMIT ?"
+    cursor = await db.conn.execute(query, (ticker, limit))
     rows = await cursor.fetchall()
     return [dict(row) for row in rows]
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -2238,3 +2238,16 @@ def test_data_error_literal_shared_across_code_and_prompts(
     assert "StopGate: DATA-ERROR" in buf.getvalue()
     assert "DATA-ERROR" in caddie_master_text
     assert "DATA-ERROR" in monitor_text
+
+
+def test_flip_staleness_matches_cm_research_expiry(
+    caddie_master_text: str,
+) -> None:
+    """#676: the flip detector's 48h window is deliberately equal to
+    Caddie Master's research-expiry rule — research older than 48h IS
+    "no prior research" to the workflow. Whoever changes either 48
+    must reconsider the other."""
+    from gimmes.store.observation_validator import FLIP_STALENESS_HOURS
+
+    assert FLIP_STALENESS_HOURS == 48
+    assert "more than 48 hours" in caddie_master_text

--- a/tests/unit/test_cli_markup_escape.py
+++ b/tests/unit/test_cli_markup_escape.py
@@ -94,6 +94,27 @@ def test_candidates_title_brackets(tmp_path: Path) -> None:
     assert "[draft]" in result.output, result.output
 
 
+def test_candidates_memo_panel_renders_markup_literally(tmp_path) -> None:
+    """#676: the memo panel prints with markup=False — bracketed memo
+    text must render literally, not vanish as Rich markup (#644)."""
+    row = {
+        "ticker": "KXCPI-26APR-T0.5", "gimme_score": 70.0,
+        "market_price": 0.5, "model_probability": 0.6, "edge": 0.1,
+        "cap_blocked": 0, "recommendation": "proceed",
+        "scanned_at": "2026-07-01 12:00:00",
+        "research_memo": "sources say [red]hot[/red] print likely",
+    }
+    with patch("gimmes.store.database.Database", MagicMock()), \
+         patch(
+             "gimmes.store.queries.get_candidate_for_ticker",
+             AsyncMock(return_value=[row]),
+         ), patch("gimmes.cli.load_config", return_value=_config(tmp_path)):
+        result = runner.invoke(
+            app, ["candidates", "--ticker", "KXCPI-26APR-T0.5"],
+        )
+    assert "[red]hot[/red]" in result.output, result.output
+
+
 def test_discover_category_brackets(tmp_path: Path) -> None:
     series = [{"ticker": "KXCPI", "title": "CPI [preliminary] index"}]
     with patch("gimmes.cli.load_config", return_value=_config(tmp_path)), \

--- a/tests/unit/test_data_collection.py
+++ b/tests/unit/test_data_collection.py
@@ -872,6 +872,82 @@ class TestLogCandidateFlipGuard:
         assert r2.exit_code == 0, r2.output
         assert "FLIP-WARNING" not in r2.output
 
+    def test_degenerate_row_does_not_reset_flip_baseline(
+        self, tmp_path,
+    ) -> None:
+        """#676: caddie.md's mandated market-info-failure row
+        (--price 0 --prob 0) is bookkeeping, not a scoring — it must
+        not consume the flip baseline (at limit=1 it hid the real
+        prior and the inversion sailed through)."""
+        db_path = tmp_path / "test.db"
+        self._invoke(db_path, "0.41", "0.98")
+        r_deg = self._invoke(db_path, "0", "0")
+        assert r_deg.exit_code == 0, r_deg.output
+        r3 = self._invoke(db_path, "0.40", "0.02")
+        assert r3.exit_code == 0, r3.output
+        assert "[FLIP-WARNING]" in r3.output
+        assert "INVERSION SIGNATURE" in r3.output
+
+    def test_degenerate_row_then_stable_rescore_stays_clean(
+        self, tmp_path,
+    ) -> None:
+        """The selection must not manufacture a false positive."""
+        db_path = tmp_path / "test.db"
+        self._invoke(db_path, "0.41", "0.98")
+        self._invoke(db_path, "0", "0")
+        r3 = self._invoke(db_path, "0.40", "0.95")
+        assert r3.exit_code == 0, r3.output
+        assert "FLIP-WARNING" not in r3.output
+
+    def test_all_priors_degenerate_fails_open(self, tmp_path) -> None:
+        """All-degenerate window → no usable baseline → warn-only
+        path fails open (exit 0, no warning)."""
+        db_path = tmp_path / "test.db"
+        for _ in range(3):
+            self._invoke(db_path, "0", "0")
+        r = self._invoke(db_path, "0.40", "0.02")
+        assert r.exit_code == 0, r.output
+        assert "FLIP-WARNING" not in r.output
+
+    def test_half_degenerate_row_does_not_reset_baseline(
+        self, tmp_path,
+    ) -> None:
+        """A row with a real price but failed prob (or vice versa) is
+        still bookkeeping — the scored filter requires BOTH."""
+        db_path = tmp_path / "test.db"
+        self._invoke(db_path, "0.41", "0.98")
+        self._invoke(db_path, "0.41", "0")  # prob failed, price known
+        r3 = self._invoke(db_path, "0.40", "0.02")
+        assert r3.exit_code == 0, r3.output
+        assert "[FLIP-WARNING]" in r3.output
+
+    def test_two_consecutive_failure_rows_do_not_reset_baseline(
+        self, tmp_path,
+    ) -> None:
+        """A multi-cycle market-info outage stacks several mandated
+        failure rows — the SQL filter finds the real baseline no
+        matter how many sit above it."""
+        db_path = tmp_path / "test.db"
+        self._invoke(db_path, "0.41", "0.98")
+        self._invoke(db_path, "0", "0")
+        self._invoke(db_path, "0", "0")
+        r4 = self._invoke(db_path, "0.40", "0.02")
+        assert r4.exit_code == 0, r4.output
+        assert "[FLIP-WARNING]" in r4.output
+
+    def test_newest_scored_prior_is_the_baseline(
+        self, tmp_path,
+    ) -> None:
+        """Two usable priors that disagree: the NEWEST one is the
+        baseline (an oldest-first mutant would fire a false flip
+        against the ancient row)."""
+        db_path = tmp_path / "test.db"
+        self._invoke(db_path, "0.41", "0.02")   # ancient view
+        self._invoke(db_path, "0.41", "0.98")   # newest scoring (warns; ignore)
+        r3 = self._invoke(db_path, "0.40", "0.95")
+        assert r3.exit_code == 0, r3.output
+        assert "FLIP-WARNING" not in r3.output
+
     def test_candidates_status_shows_flip_warn(self, tmp_path) -> None:
         from unittest.mock import patch
 
@@ -895,3 +971,115 @@ class TestLogCandidateFlipGuard:
         # The banner below the table carries the load-bearing string —
         # cells ellipsize at the width-80 non-TTY default (#659 lesson)
         assert "KXCPI-26JUN-T-0.2 FLIP-WARN:" in result.output
+
+
+class TestCandidatesMemoPanel:
+    """#676: single-ticker mode prints the newest row's research memo
+    below the banners — caddie-master's 4c derivation rule reads the
+    memo through this command, and the table has no memo column."""
+
+    @staticmethod
+    def _log(db_path, memo: str, prob: str = "0.9"):
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        with patch("gimmes.cli.load_config") as mock_cfg:
+            mock_cfg.return_value.db_path = db_path
+            mock_cfg.return_value.strategy.side = "no"
+            return CliRunner().invoke(app, [
+                "log-candidate", "KXCPI-26JUN-T-0.2",
+                "--price", "0.41", "--prob", prob, "--score", "80",
+                "--memo", memo,
+            ])
+
+    @staticmethod
+    def _candidates(tmp_path, *args):
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from gimmes.cli import app
+
+        with patch("gimmes.config.GIMMES_HOME", tmp_path):
+            return CliRunner().invoke(app, ["candidates", *args])
+
+    def test_ticker_mode_prints_newest_memo_in_full(
+        self, tmp_path,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        self._log(db_path, "old memo with OLDSENTINEL word")
+        self._log(
+            db_path,
+            "Fresh research: CPI prints at 8:30 ET; consensus 0.2;"
+            " sources reviewed; conclusion holds NEWSENTINEL",
+            prob="0.88",
+        )
+        result = self._candidates(
+            tmp_path, "--ticker", "KXCPI-26JUN-T-0.2", "--limit", "5",
+        )
+        assert result.exit_code == 0, result.output
+        assert "RESEARCH MEMO" in result.output
+        # Wrap-safe single-word sentinels (#659 width lesson).
+        assert "NEWSENTINEL" in result.output
+        assert "OLDSENTINEL" not in result.output
+
+    def test_list_mode_prints_no_memo(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        self._log(db_path, "memo text")
+        result = self._candidates(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert "RESEARCH MEMO" not in result.output
+
+    def test_empty_memo_placeholder(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        self._log(db_path, "")
+        result = self._candidates(
+            tmp_path, "--ticker", "KXCPI-26JUN-T-0.2",
+        )
+        assert result.exit_code == 0, result.output
+        assert "No memo stored" in result.output
+
+    def test_bookkeeping_row_does_not_hide_real_memo(
+        self, tmp_path,
+    ) -> None:
+        """#676 review: a newest bookkeeping row with an empty memo
+        must not hide the real research memo underneath it."""
+        db_path = tmp_path / "gimmes.db"
+        self._log(db_path, "real research REALSENTINEL here")
+        self._log(db_path, "", prob="0")  # market-info-failure row
+        result = self._candidates(
+            tmp_path, "--ticker", "KXCPI-26JUN-T-0.2", "--limit", "5",
+        )
+        assert result.exit_code == 0, result.output
+        assert "REALSENTINEL" in result.output
+        assert "No memo stored" not in result.output
+
+    def test_long_url_token_survives_unbroken(self, tmp_path) -> None:
+        """soft_wrap: a source URL longer than width 80 must not be
+        hard-wrapped into a dead link."""
+        url = "https://www.bls.gov/news.release/archives/cpi_" + "x" * 60
+        db_path = tmp_path / "gimmes.db"
+        self._log(db_path, f"source: {url}")
+        result = self._candidates(
+            tmp_path, "--ticker", "KXCPI-26JUN-T-0.2",
+        )
+        assert result.exit_code == 0, result.output
+        assert url in result.output
+
+    def test_flip_annotated_memo_marker_renders_literally(
+        self, tmp_path,
+    ) -> None:
+        """markup=False proof: the [FLIP-WARNING] annotation prints
+        intact in the memo section."""
+        db_path = tmp_path / "gimmes.db"
+        self._log(db_path, "scoring memo", prob="0.98")
+        self._log(db_path, "rescore memo", prob="0.02")
+        result = self._candidates(
+            tmp_path, "--ticker", "KXCPI-26JUN-T-0.2", "--limit", "5",
+        )
+        assert result.exit_code == 0, result.output
+        assert "RESEARCH MEMO" in result.output
+        assert "[FLIP-WARNING]" in result.output


### PR DESCRIPTION
## Summary

Resolves the four #676 residuals from #660:

**1. Flip baseline vs bookkeeping rows.** The probability-flip detector compared against the single newest candidate row — but caddie.md and scout.md *mandate* logging a `--price 0 --prob 0` row on every market-info failure, so one such row reset the baseline and the next inversion sailed through unwarned. `get_candidate_for_ticker` gains a `scored_only` kwarg (SQL filter `model_probability > 0 AND market_price > 0`): the flip check now fetches the true newest scoring no matter how many bookkeeping rows stack above it — a multi-cycle API outage stacks several, which is why the review upgraded the plan's limit=3 window to the structural fix. The detector's own degenerate/staleness guards remain the policy backstop.

**2. Memo visibility in CM review.** caddie-master.md's 4c derivation rule instructs reading Caddie's research memo via `gimmes candidates --ticker` — a command that rendered no memo at all. Single-ticker mode now prints the newest **non-empty** memo below the FLIP/STALE banners (review finding: a bookkeeping row's empty memo must not hide the research underneath), with the scanned-at timestamp in the header, `markup=False` (bracketed memo text renders literally — the #644 markup class), and `soft_wrap=True` (source URLs stay unbroken instead of hard-wrapping into dead links at width 80). The prompt claim becomes true with **zero prompt edits**, so every existing pin is untouched by construction.

**3. 48h staleness window: kept, now documented.** The cutoff deliberately equals Caddie Master's research-expiry rule — research older than 48h *is* "no prior research" to the workflow, so warning against it would be stricter about the past than the process that produces the past — and a 0.98→0.02 move across the observed 139–168h gaps is exactly what a near-binary market does when the event resolves against the prior view (complements are where genuine multi-day repricings land, so even the inversion signature loses evidentiary force at that horizon). A drift-guard test ties `FLIP_STALENESS_HOURS == 48` to the CM prompt's "more than 48 hours" text.

**4. Side-config residual:** accepted as already documented (warning-only, theoretical, detector never blocks; a side column is a migration serving one spurious warning after a rare operator action).

Closes #676

## Test plan

- `test_data_collection.py`: 6 flip-baseline tests (degenerate / half-degenerate / two-consecutive-failures don't reset; stable rescore stays clean; all-degenerate fails open; newest-scored-prior property kills the oldest-first mutant) + `TestCandidatesMemoPanel` (6: newest memo in full, list-mode silent, empty placeholder, bookkeeping row doesn't hide the real memo, long URL unbroken, FLIP annotation renders literally).
- `test_cli_markup_escape.py`: memo with Rich-markup-like text renders literally.
- `test_agent_prompts.py`: 48h drift guard.
- Full suite: **1886 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB