### PR TITLE
Fix #680: dashboard window truncation, orphan render noise, shared daily-P&L SQL, schema check

### DIFF
--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -372,8 +372,12 @@ async def get_metrics(db_path: Path) -> MetricsResponse:
                 # DESC so an overflow discards the OLDEST rows — a
                 # dashboard must stay fresh; consumers re-sort.
                 cursor = await conn.execute(
+                    # space->T normalization + id tie-break: mixed
+                    # legacy/ISO timestamp formats mis-order raw
+                    # string comparison (the #661 lesson).
                     "SELECT * FROM trades WHERE action = ?"
-                    " ORDER BY timestamp DESC LIMIT ?",
+                    " ORDER BY replace(timestamp, ' ', 'T') DESC,"
+                    " id DESC LIMIT ?",
                     (action, cap),
                 )
                 rows = await cursor.fetchall()
@@ -392,7 +396,9 @@ async def get_metrics(db_path: Path) -> MetricsResponse:
             # SSE uptime at the 5-minute writer cadence): the same
             # staleness class as the trades window (#680 review).
             cursor = await conn.execute(
-                "SELECT * FROM snapshots ORDER BY timestamp DESC LIMIT 500"
+                "SELECT * FROM snapshots"
+                " ORDER BY replace(timestamp, ' ', 'T') DESC,"
+                " id DESC LIMIT 500"
             )
             snapshots = [dict(row) for row in await cursor.fetchall()]
             snapshots.reverse()

--- a/src/gimmes/clubhouse/data.py
+++ b/src/gimmes/clubhouse/data.py
@@ -25,6 +25,7 @@ from gimmes.clubhouse.models import (
 )
 from gimmes.config import GimmesConfig, load_config
 from gimmes.reporting.metrics import calculate_metrics
+from gimmes.store.queries import DAILY_PNL_SQL
 
 logger = logging.getLogger("gimmes.clubhouse")
 
@@ -358,20 +359,51 @@ async def get_metrics(db_path: Path) -> MetricsResponse:
 
     try:
         async with _connect(db_path) as conn:
-            # Get trades
-            cursor = await conn.execute(
-                "SELECT * FROM trades ORDER BY timestamp ASC LIMIT 1000"
-            )
-            trades = [dict(row) for row in await cursor.fetchall()]
+            # Get trades per-action (#680, the #542 pattern): a
+            # single window across all actions let skip volume push
+            # the newest closes out and win_rate/equity silently went
+            # stale past 1000 rows. calculate_metrics reads only
+            # open/size_up/close (skips dropped); no consumer needs a
+            # global order — calculate_pnl re-sorts per group and the
+            # equity fallback sorts the whole list itself.
+            trades: list[dict] = []  # type: ignore[type-arg]
+            cap = 100_000
+            for action in ("open", "close", "size_up"):
+                # DESC so an overflow discards the OLDEST rows — a
+                # dashboard must stay fresh; consumers re-sort.
+                cursor = await conn.execute(
+                    "SELECT * FROM trades WHERE action = ?"
+                    " ORDER BY timestamp DESC LIMIT ?",
+                    (action, cap),
+                )
+                rows = await cursor.fetchall()
+                if len(rows) == cap:
+                    # No silent caps (#686 lesson).
+                    logger.warning(
+                        "trades fetch for action=%s hit the"
+                        " %d-row cap; oldest rows dropped",
+                        action, cap,
+                    )
+                trades += [dict(row) for row in rows]
 
-            # Get snapshots
+            # Get the NEWEST 500 snapshots, re-sorted ascending —
+            # the old ASC window froze equity/Sharpe/total_return at
+            # the oldest 500 once the table overflowed (~2 days of
+            # SSE uptime at the 5-minute writer cadence): the same
+            # staleness class as the trades window (#680 review).
             cursor = await conn.execute(
-                "SELECT * FROM snapshots ORDER BY timestamp ASC LIMIT 500"
+                "SELECT * FROM snapshots ORDER BY timestamp DESC LIMIT 500"
             )
             snapshots = [dict(row) for row in await cursor.fetchall()]
+            snapshots.reverse()
 
             initial = config.paper.starting_balance if not config.is_championship else 0
-            metrics = calculate_metrics(trades, snapshots, initial)
+            # log_orphans=False (#680): this runs per SSE client per
+            # fingerprint change — a historical orphan close would
+            # warn forever here. The CLI report keeps the warning.
+            metrics = calculate_metrics(
+                trades, snapshots, initial, log_orphans=False,
+            )
 
             resp.win_rate = metrics.win_rate
             resp.sharpe_ratio = metrics.sharpe_ratio
@@ -399,22 +431,12 @@ async def get_risk(db_path: Path) -> RiskResponse:
 
     try:
         async with _connect(db_path) as conn:
-            # Realized P&L — match canonical get_daily_pnl query
-            cursor = await conn.execute(
-                """SELECT COALESCE(SUM(
-                    (c.price - COALESCE(
-                        (SELECT price FROM trades o
-                         WHERE o.ticker = c.ticker
-                           AND o.action = 'open'
-                           AND o.timestamp <= c.timestamp
-                         ORDER BY o.timestamp DESC
-                         LIMIT 1),
-                    0)) * c.count
-                ), 0) as daily_pnl
-                FROM trades c
-                WHERE c.action = 'close'
-                  AND date(c.timestamp) = date('now')"""
-            )
+            # Canonical daily-P&L SQL shared with get_daily_pnl
+            # (#680): the dashboard's risk panel must match the
+            # daily-loss trigger the loop reads — #622 excludes
+            # reconcile drift, #653 includes settlement closes. The
+            # inlined copy here was missing the drift exclusion.
+            cursor = await conn.execute(DAILY_PNL_SQL, ("now",))
             row = await cursor.fetchone()
             realized_pnl = row["daily_pnl"] if row else 0.0
 

--- a/src/gimmes/clubhouse/server.py
+++ b/src/gimmes/clubhouse/server.py
@@ -326,6 +326,49 @@ def _find_port(start: int = DEFAULT_PORT, max_tries: int = 11) -> int | None:
     return None
 
 
+def _check_schema_version(db_path: Path) -> str | None:
+    """Warn when the DB schema is behind (#680).
+
+    The dashboard reads mode=ro and never migrates — on an old DB the
+    #653 repricing silently skips (resolved_outcome absent) and newer
+    semantics are missing. Warn-don't-refuse: an old DB still renders,
+    and the writer migrates it on its next open. Returns the warning
+    text (also logged) or None when current/missing.
+    """
+    import sqlite3
+
+    from gimmes.store.migrations import LATEST_SCHEMA_VERSION
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except Exception:
+        # Fresh install / missing DB — the writer will create+migrate.
+        return None
+    try:
+        row = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()
+        version = int(row[0]) if row and row[0] is not None else 0
+    except Exception as exc:
+        # The file OPENED but isn't a migrated GIMMES DB (foreign/
+        # corrupt file, garbage version) — one clear startup line
+        # beats the per-panel warning noise downstream (#680 review).
+        logger.warning("schema check failed on %s: %s", db_path, exc)
+        return None
+    finally:
+        conn.close()
+    if version >= LATEST_SCHEMA_VERSION:
+        return None
+    msg = (
+        f"Database schema v{version} < v{LATEST_SCHEMA_VERSION} — the"
+        " dashboard is read-only and cannot migrate; newer columns"
+        " (e.g. resolved_outcome, #653 repricing) are missing. Run"
+        " the trading loop or any write command to migrate."
+    )
+    logger.warning(msg)
+    return msg
+
+
 def run_standalone(
     port: int = DEFAULT_PORT,
     db_path: Path | None = None,
@@ -339,6 +382,9 @@ def run_standalone(
 
     if db_path:
         set_db_path(db_path)
+    schema_msg = _check_schema_version(_db_path)
+    if schema_msg:
+        print(f"\n  WARNING: {schema_msg}")
 
     actual_port = _find_port(port)
     if actual_port is None:
@@ -383,6 +429,7 @@ def start_background(
 
     if db_path:
         set_db_path(db_path)
+    _check_schema_version(_db_path)
     set_pause_seconds(pause_seconds)
 
     actual_port = _find_port(port)

--- a/src/gimmes/reporting/metrics.py
+++ b/src/gimmes/reporting/metrics.py
@@ -170,8 +170,14 @@ def calculate_metrics(
     trades: list[dict],  # type: ignore[type-arg]
     snapshots: list[dict],  # type: ignore[type-arg]
     initial_bankroll: float = 0.0,
+    *,
+    log_orphans: bool = True,
 ) -> PerformanceMetrics:
-    """Calculate performance metrics from trades and snapshots."""
+    """Calculate performance metrics from trades and snapshots.
+
+    ``log_orphans=False`` (#680) demotes calculate_pnl's orphan-close
+    warnings to debug — for render-loop callers like the clubhouse.
+    """
     metrics = PerformanceMetrics()
 
     # Win rate — delegated to calculate_pnl (#662): (ticker, side)
@@ -182,7 +188,9 @@ def calculate_metrics(
     # win on the $0.60 basis; the weighted $0.75 basis says loss).
     # Scratch trades (pnl == 0) stay excluded from numerator and
     # denominator, matching the previous semantics.
-    metrics.win_rate = calculate_pnl(trades).win_rate
+    metrics.win_rate = calculate_pnl(
+        trades, log_orphans=log_orphans,
+    ).win_rate
 
     # Edge accuracy
     predicted_edges = [t.get("edge", 0) for t in trades if t.get("action") == "open"]

--- a/src/gimmes/reporting/metrics.py
+++ b/src/gimmes/reporting/metrics.py
@@ -131,7 +131,11 @@ def _equity_curve_from_trades(
     """Build a cash-balance equity curve from trade history."""
     cash = initial_bankroll
     curve: list[dict] = []  # type: ignore[type-arg]
-    for t in sorted(trades, key=lambda x: x.get("timestamp", "")):
+    # space->T normalization (#680) — see calculate_pnl's sort.
+    for t in sorted(
+        trades,
+        key=lambda x: str(x.get("timestamp", "")).replace(" ", "T"),
+    ):
         action = t.get("action", "")
         cost = t.get("count", 0) * t.get("price", 0.0)
         if action in ("open", "size_up"):

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -65,7 +65,12 @@ def calculate_pnl(
         groups.setdefault(key, []).append(t)
 
     for (ticker, side), events in groups.items():
-        events.sort(key=lambda e: str(e.get("timestamp", "")))
+        # space->T normalization (#680): mixed legacy/ISO formats
+        # mis-order raw string comparison (' ' < 'T'), which could
+        # walk a close before its open on the boundary day.
+        events.sort(
+            key=lambda e: str(e.get("timestamp", "")).replace(" ", "T"),
+        )
         remaining = 0
         avg_cost = 0.0
 

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -33,7 +33,11 @@ class PnLSummary:
         return self.winning_trades / completed
 
 
-def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  # accepts TradeRecord dicts
+def calculate_pnl(
+    trades: list[dict],  # type: ignore[type-arg]  # accepts TradeRecord dicts
+    *,
+    log_orphans: bool = True,
+) -> PnLSummary:
     """Calculate P&L from a list of trade records.
 
     Groups by ``(ticker, side)`` and walks each group in timestamp-ascending
@@ -124,7 +128,12 @@ def calculate_pnl(trades: list[dict]) -> PnLSummary:  # type: ignore[type-arg]  
             orphan = count - matched
             pnl = (price - avg_cost) * matched if matched else 0.0
             if orphan:
-                _log.warning(
+                # #680: the clubhouse calls this per SSE client per
+                # fingerprint change — a historical orphan would warn
+                # forever there. log_orphans=False demotes to debug
+                # (forensic trail kept); CLI report keeps the warning.
+                _log.log(
+                    logging.WARNING if log_orphans else logging.DEBUG,
                     "orphan close: ticker=%s side=%s count=%d remaining=%d",
                     ticker, side, count, remaining,
                 )

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from gimmes.store.database import Database
 
+# The version a fully-migrated DB reports (#680): read-only consumers
+# (the clubhouse) compare against this at startup. Drift-guarded by
+# test_latest_schema_version_constant_matches_migrations.
+LATEST_SCHEMA_VERSION = 18
+
 # Migrations are applied sequentially. Each is a tuple of (version, sql).
 MIGRATIONS: list[tuple[int, str]] = [
     # Version 1 is the initial schema (handled by database.py SCHEMA_SQL).

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -835,6 +835,26 @@ async def clear_all_candidates(db: Database) -> int:
 # ---------------------------------------------------------------------------
 
 
+# Canonical daily-P&L SQL (#622: reconcile drift excluded; #653:
+# settlement closes included). Shared with the read-only clubhouse
+# (clubhouse/data.py get_risk) so the dashboard's risk panel can never
+# drift from the daily-loss-limit trigger the loop reads (#680).
+DAILY_PNL_SQL = """SELECT COALESCE(SUM(
+            (c.price - COALESCE(
+                (SELECT price FROM trades o
+                 WHERE o.ticker = c.ticker
+                   AND o.action = 'open'
+                   AND o.timestamp <= c.timestamp
+                 ORDER BY o.timestamp DESC
+                 LIMIT 1),
+            0)) * c.count
+        ), 0) as daily_pnl
+        FROM trades c
+        WHERE c.action = 'close'
+          AND c.agent != 'reconcile'
+          AND date(c.timestamp) = date(?)"""
+
+
 async def get_daily_pnl(db: Database, *, today: str | None = None) -> float:
     """Calculate realized P&L from close trades for a given date (defaults to today).
 
@@ -858,20 +878,7 @@ async def get_daily_pnl(db: Database, *, today: str | None = None) -> float:
         today: Optional date string (YYYY-MM-DD) to use instead of 'now'.
     """
     cursor = await db.conn.execute(
-        """SELECT COALESCE(SUM(
-            (c.price - COALESCE(
-                (SELECT price FROM trades o
-                 WHERE o.ticker = c.ticker
-                   AND o.action = 'open'
-                   AND o.timestamp <= c.timestamp
-                 ORDER BY o.timestamp DESC
-                 LIMIT 1),
-            0)) * c.count
-        ), 0) as daily_pnl
-        FROM trades c
-        WHERE c.action = 'close'
-          AND c.agent != 'reconcile'
-          AND date(c.timestamp) = date(?)""",
+        DAILY_PNL_SQL,
         ("now" if today is None else today,),
     )
     row = await cursor.fetchone()

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -833,3 +833,290 @@ class TestGetMarketDetail:
 
         with pytest.raises(ValueError, match="API key not set"):
             await data_mod.get_market_detail("TEST-YES")
+
+
+class TestDashboardTradeWindow:
+    """#680: a single 1000-row window across all actions let skip
+    volume push the newest closes out — win_rate silently went stale.
+    Per-action fetching (the #542 pattern) is immune."""
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_survives_skip_flood(
+        self, db_path: Path,
+    ) -> None:
+        async with Database(db_path) as db:
+            await db.conn.executemany(
+                """INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES (?, 'skip', 'no', 0, 0, 0, 0, 0, 0, 's',
+                           'scout', ?)""",
+                [
+                    (f"SKIP-{i}", f"2026-01-01T{i % 24:02d}:00:00")
+                    for i in range(1001)
+                ],
+            )
+            await db.conn.execute(
+                """INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXWIN', 'open', 'no', 10, 0.50, 0.8, 70,
+                           0.1, 0.02, 'entry', 'closer',
+                           '2026-06-01T10:00:00')""",
+            )
+            await db.conn.execute(
+                """INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXWIN', 'close', 'no', 10, 0.90, 0, 0, 0,
+                           0, 'win', 'closer', '2026-06-02T10:00:00')""",
+            )
+            await db.conn.commit()
+
+        metrics = await get_metrics(db_path)
+        # Pre-fix the window held only skips → win_rate 0.
+        assert metrics.win_rate == 1.0
+
+
+class TestSnapshotWindow:
+    """#680 review: the snapshots fetch keeps the NEWEST 500 — the
+    old ASC window froze equity/total_return at the oldest 500 after
+    ~2 days of SSE uptime."""
+
+    @pytest.mark.asyncio
+    async def test_equity_reflects_newest_snapshot_past_window(
+        self, db_path: Path,
+    ) -> None:
+        async with Database(db_path) as db:
+            await db.conn.executemany(
+                """INSERT INTO snapshots (balance, portfolio_value,
+                   total_equity, timestamp)
+                   VALUES (?, 0, ?, ?)""",
+                [
+                    (10_000.0, 10_000.0, f"2026-01-01T{i // 60:02d}:{i % 60:02d}:00")
+                    for i in range(501)
+                ],
+            )
+            # The single NEWEST snapshot carries a distinct equity.
+            await db.conn.execute(
+                """INSERT INTO snapshots (balance, portfolio_value,
+                   total_equity, timestamp)
+                   VALUES (99999.0, 0, 99999.0,
+                           '2027-01-01T00:00:00')""",
+            )
+            await db.conn.commit()
+
+        metrics = await get_metrics(db_path)
+        # Pre-fix the ASC window dropped the newest row → stale curve.
+        assert metrics.equity_curve[-1]["equity"] == pytest.approx(
+            99999.0,
+        )
+
+
+class TestOrphanWarningQuiet:
+    """#680: get_metrics runs per SSE client per fingerprint change —
+    orphan-close warnings are demoted to debug on that path only."""
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_silences_orphan_warnings(
+        self, db_path: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        async with Database(db_path) as db:
+            await db.conn.execute(
+                """INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXORPHAN', 'close', 'no', 10, 0.90, 0, 0,
+                           0, 0, 'orphan', 'closer',
+                           '2026-06-02T10:00:00')""",
+            )
+            await db.conn.commit()
+
+        with caplog.at_level(
+            logging.DEBUG, logger="gimmes.reporting.pnl",
+        ):
+            await get_metrics(db_path)
+        warnings = [
+            r for r in caplog.records
+            if r.levelno >= logging.WARNING
+            and "orphan close" in r.message
+        ]
+        assert warnings == []
+        # Forensic trail kept at debug.
+        assert any("orphan close" in r.message for r in caplog.records)
+
+
+class TestRiskExcludesReconcileDrift:
+    """#680: get_risk shares the canonical DAILY_PNL_SQL — reconcile
+    drift is excluded from the dashboard's daily P&L (#622), matching
+    the daily-loss trigger the loop reads."""
+
+    @pytest.mark.asyncio
+    async def test_get_risk_excludes_reconcile_drift(
+        self, db_path: Path,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        from gimmes.store.queries import get_daily_pnl
+
+        today = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        async with Database(db_path) as db:
+            await db.conn.execute(
+                f"""INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXDRIFT', 'open', 'no', 100, 0.50, 0.8,
+                           70, 0.1, 0.02, 'entry', 'closer',
+                           '{today}')""",
+            )
+            await db.conn.execute(
+                f"""INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXDRIFT', 'close', 'no', 100, 0.10, 0, 0,
+                           0, 0, 'drift', 'reconcile', '{today}')""",
+            )
+            # A real close with known P&L defeats the default-0
+            # escape: get_risk swallows exceptions into daily_pnl=0,
+            # which would vacuously equal an all-zero expectation.
+            await db.conn.execute(
+                f"""INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXREAL', 'open', 'no', 10, 0.50, 0.8, 70,
+                           0.1, 0.02, 'entry', 'closer', '{today}')""",
+            )
+            await db.conn.execute(
+                f"""INSERT INTO trades (ticker, action, side, count,
+                   price, model_probability, gimme_score, edge,
+                   kelly_fraction, rationale, agent, timestamp)
+                   VALUES ('KXREAL', 'close', 'no', 10, 0.90, 0, 0, 0,
+                           0, 'win', 'closer', '{today}')""",
+            )
+            await db.conn.commit()
+            canonical = await get_daily_pnl(db)
+            assert canonical == pytest.approx(4.0)  # (0.9-0.5)*10
+            cursor = await db.conn.execute(
+                # paper mode: get_risk reads paper_positions
+                "SELECT COALESCE(SUM(unrealized_pnl), 0) AS u"
+                " FROM paper_positions WHERE count > 0"
+            )
+            unrealized = float((await cursor.fetchone())["u"])
+
+        risk = await get_risk(db_path)
+        # Parity with the canonical query: realized component matches
+        # get_daily_pnl exactly (drift excluded on both paths); the
+        # dashboard adds unrealized on top.
+        assert risk.daily_pnl == pytest.approx(canonical + unrealized)
+        # Pre-fix the -$40 phantom drift loss landed here.
+        assert risk.daily_pnl > -1.0
+
+
+class TestSchemaVersionCheck:
+    """#680: the read-only dashboard warns (never refuses) on a DB
+    behind the writer's schema version."""
+
+    def test_warning_on_old_db(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+        import sqlite3
+
+        from gimmes.clubhouse.server import _check_schema_version
+
+        old_db = tmp_path / "old.db"
+        conn = sqlite3.connect(old_db)
+        conn.execute(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY)"
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (5)")
+        conn.commit()
+        conn.close()
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.clubhouse"):
+            msg = _check_schema_version(old_db)
+        assert msg is not None
+        assert "v5" in msg
+        assert "read-only" in msg
+        # start_background discards the return — the LOG line is the
+        # whole feature on that path.
+        assert any(
+            "read-only" in r.message and r.levelno >= logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_foreign_file_warns_not_silent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A file that OPENS but isn't a GIMMES DB gets one clear
+        startup line, not silence (#680 review)."""
+        import logging
+        import sqlite3
+
+        from gimmes.clubhouse.server import _check_schema_version
+
+        foreign = tmp_path / "foreign.db"
+        conn = sqlite3.connect(foreign)
+        conn.execute("CREATE TABLE unrelated (x INTEGER)")
+        conn.commit()
+        conn.close()
+
+        with caplog.at_level(logging.WARNING, logger="gimmes.clubhouse"):
+            assert _check_schema_version(foreign) is None
+        assert any(
+            "schema check failed" in r.message for r in caplog.records
+        )
+
+    def test_check_wired_into_both_entry_points(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Deleting the call sites must fail a test — the helper runs
+        before _find_port in both entry points, so stubbing the port
+        lookup short-circuits before uvicorn."""
+        from gimmes.clubhouse import server as server_mod
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            server_mod, "_check_schema_version",
+            lambda p: calls.append(str(p)) or None,
+        )
+        monkeypatch.setattr(server_mod, "_find_port", lambda p: None)
+
+        assert server_mod.start_background() is None
+        assert len(calls) == 1
+
+        with pytest.raises(RuntimeError):
+            server_mod.run_standalone(open_browser=False)
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_silent_on_current_db(self, db_path: Path) -> None:
+        from gimmes.clubhouse.server import _check_schema_version
+
+        assert _check_schema_version(db_path) is None
+
+    def test_silent_on_missing_db(self, tmp_path: Path) -> None:
+        from gimmes.clubhouse.server import _check_schema_version
+
+        assert _check_schema_version(tmp_path / "nope.db") is None
+
+
+def test_latest_schema_version_constant_matches_migrations(
+    tmp_path: Path,
+) -> None:
+    """Drift guard for the #680 constant: a new migration must bump
+    LATEST_SCHEMA_VERSION."""
+    import asyncio
+
+    from gimmes.store.migrations import (
+        LATEST_SCHEMA_VERSION,
+        run_migrations,
+    )
+
+    async def _version() -> int:
+        async with Database(tmp_path / "fresh.db") as db:
+            return await run_migrations(db)
+
+    assert asyncio.run(_version()) == LATEST_SCHEMA_VERSION

--- a/tests/unit/test_clubhouse.py
+++ b/tests/unit/test_clubhouse.py
@@ -913,6 +913,31 @@ class TestSnapshotWindow:
         )
 
 
+class TestMixedTimestampFormats:
+    """#680 review: legacy space-format rows must not outrank newer
+    ISO rows (or vice versa) in the newest-N windows."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_row_ordered_by_time_not_separator(
+        self, db_path: Path,
+    ) -> None:
+        async with Database(db_path) as db:
+            # Legacy-format snapshot NEWER than every ISO row: the
+            # raw DESC sort would rank it LAST (' ' < 'T'); the
+            # normalized sort keeps it as the curve's newest point.
+            await db.conn.execute(
+                """INSERT INTO snapshots (balance, portfolio_value,
+                   total_equity, timestamp)
+                   VALUES (77777.0, 0, 77777.0, '2027-06-01 00:00:00')""",
+            )
+            await db.conn.commit()
+
+        metrics = await get_metrics(db_path)
+        assert metrics.equity_curve[-1]["equity"] == pytest.approx(
+            77777.0,
+        )
+
+
 class TestOrphanWarningQuiet:
     """#680: get_metrics runs per SSE client per fingerprint change —
     orphan-close warnings are demoted to debug on that path only."""

--- a/tests/unit/test_pnl.py
+++ b/tests/unit/test_pnl.py
@@ -157,6 +157,26 @@ class TestCalculatePnlWeightedAverage:
         assert summary.gross_pnl == pytest.approx(10.0)
         assert "orphan close" in caplog.text
 
+    def test_orphan_quiet_flag_demotes_to_debug(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """#680: log_orphans=False demotes the warning to debug (same
+        numeric result) — for render-loop callers like the clubhouse."""
+        import logging
+
+        trades = [self._t("close", "X", 0.80, 50, "2026-05-01T10:00:00")]
+        with caplog.at_level(
+            logging.DEBUG, logger="gimmes.reporting.pnl",
+        ):
+            loud = calculate_pnl(trades)
+            caplog.clear()
+            quiet = calculate_pnl(trades, log_orphans=False)
+        assert quiet.gross_pnl == loud.gross_pnl
+        assert not [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any("orphan close" in r.message for r in caplog.records)
+
     def test_yes_and_no_sides_isolated(self) -> None:
         trades = [
             self._t("open", "X", 0.40, 10, "t1", side="yes"),

--- a/tests/unit/test_pnl.py
+++ b/tests/unit/test_pnl.py
@@ -177,6 +177,28 @@ class TestCalculatePnlWeightedAverage:
         ]
         assert any("orphan close" in r.message for r in caplog.records)
 
+    def test_mixed_timestamp_formats_order_chronologically(
+        self,
+    ) -> None:
+        """#680: a legacy space-format row must sort by TIME, not by
+        separator byte (' ' < 'T' would walk the close before its
+        open on the boundary day, fabricating an orphan)."""
+        trades = [
+            # ISO close at 09:00, legacy open at 08:00 SAME DAY:
+            # raw string order puts the space row FIRST correctly
+            # here, so invert: legacy close after ISO open.
+            self._t("open", "X", 0.50, 10, "2026-05-01T08:00:00"),
+            {
+                "ticker": "X", "side": "yes", "action": "close",
+                "count": 10, "price": 0.70,
+                "timestamp": "2026-05-01 09:00:00",  # legacy format
+            },
+        ]
+        summary = calculate_pnl(trades)
+        # Raw-string sort: ' 09:00' < 'T08:00' → close walks first →
+        # orphan + $0. Normalized: (0.70-0.50)*10 = 2.0.
+        assert summary.gross_pnl == pytest.approx(2.0)
+
     def test_yes_and_no_sides_isolated(self) -> None:
         trades = [
             self._t("open", "X", 0.40, 10, "t1", side="yes"),


### PR DESCRIPTION
## Summary

Resolves the four #680 residuals from #662, plus one review-caught sibling:

**1. Trade-window truncation.** `get_metrics` fetched the *oldest* 1000 trade rows across all actions — skip volume pushed the newest closes out of the window and win_rate/equity went silently stale. Now per-action fetches (open/close/size_up at 100k each, the #542 pattern), with skips dropped entirely (verified: `calculate_pnl` filters them, edge accuracy reads opens only, the equity fallback skips them). DESC ordering means any future overflow discards the *oldest* rows — the right failure mode for a dashboard — and a cap-hit warning fires when a fetch returns exactly the limit (no silent caps). **Review extension:** the snapshots query had the identical oldest-window bug — equity curve, Sharpe, and total_return froze at the oldest 500 snapshots after ~2 days of SSE uptime (288 snapshots/day). Now newest-500 re-sorted ascending, with a regression test.

**2. Orphan-warning render noise.** `calculate_pnl` gains a keyword-only `log_orphans=True`; the clubhouse metrics path passes `False` (it runs per SSE client per 2-second fingerprint change — a historical orphan would warn forever), demoting to debug so the forensic trail survives. The CLI report and all other callers keep the warning by default.

**3. Shared daily-P&L SQL.** `get_risk`'s inlined query was missing the `agent != 'reconcile'` exclusion (#622) — reconcile drift leaked into the dashboard's daily P&L, diverging from the daily-loss trigger the loop reads. The canonical query is now a `DAILY_PNL_SQL` module constant executed by both `get_daily_pnl` and the read-only clubhouse (zero drift by construction; extraction verified byte-equal), with a behavior-parity test hardened against `get_risk`'s exception-swallowing default-0 escape.

**4. Schema version check.** The read-only dashboard (mode=ro, never migrates) warns at startup when the DB is behind `LATEST_SCHEMA_VERSION` — previously an unmigrated DB silently skipped #653 repricing. Warn-don't-refuse (an old DB still renders; the writer migrates on its next open). A file that opens but isn't a GIMMES DB gets one clear line instead of per-panel noise. The constant is drift-guarded against `run_migrations`, and the wiring into both server entry points is pinned.

Closes #680

## Test plan

- `test_clubhouse.py` (+8): skip-flood survival (1001 skips + one winning pair → win_rate 1.0; fails pre-fix), newest-snapshot-past-window equity, orphan-quiet with debug-trail assertion, drift-parity with nonzero canonical value, old-DB warning (return + log record), foreign-file warning, wiring into both entry points, `LATEST_SCHEMA_VERSION == run_migrations()` drift guard.
- `test_pnl.py` (+1): quiet flag demotes to debug with identical numerics.
- Full suite: **1909 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB