### PR TITLE
Fix #682: --taker-fill conservative mode, stale-candle and zero-sizing visibility

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -11,7 +11,7 @@ from gimmes.config import GimmesConfig
 from gimmes.kalshi.client import KalshiClient
 from gimmes.kalshi.historical import Candle, get_candlesticks
 from gimmes.kalshi.markets import list_all_markets
-from gimmes.models.market import Market, MarketStatus, Orderbook, OrderbookLevel
+from gimmes.models.market import Market, MarketStatus
 from gimmes.risk.limits import (
     check_event_exposure,
     check_series_exposure,
@@ -48,6 +48,15 @@ class BacktestConfig:
     starting_balance: float
     gimmes_config: GimmesConfig
     assumed_edge: float = 0.10  # Edge premium over market price for Kelly sizing
+    # #682: conservative fill model — entries cross the spread and pay
+    # the ask with taker fees, instead of filling at the midpoint as a
+    # maker. Selection (filter/score) AND the model belief (true_prob
+    # = midpoint + assumed_edge) stay anchored to the midpoint — the
+    # flag models fill COST only, so it can never pass MORE markets
+    # through the prob gate or size them larger than maker mode
+    # (review: deriving true_prob from the fill price loosened the
+    # gate). Edge and Kelly then shrink naturally when paying the ask.
+    taker_fill: bool = False
 
 
 @dataclass
@@ -86,6 +95,11 @@ class BacktestResult:
     skipped_one_sided: int = 0
     fetch_failures: int = 0
     skipped_entry_gates: int = 0
+    # #682: markets PRICED (not skipped) from a candle >1 day older
+    # than entry — visibility before policy; and pass-1 drops where
+    # kelly sizing yielded zero contracts.
+    stale_candles: int = 0
+    skipped_zero_sizing: int = 0
     truncated_chunks: list[str] = field(default_factory=list)
 
 
@@ -202,35 +216,6 @@ class BacktestLedger:
     def snapshot(self, timestamp: str) -> None:
         """Record an equity snapshot (balance only — all positions settle)."""
         self.equity_curve.append((timestamp, self.balance))
-
-
-# ---------------------------------------------------------------------------
-# Orderbook synthesis
-# ---------------------------------------------------------------------------
-
-
-def synthesize_orderbook(ticker: str, candle: Candle, depth: int = 100) -> Orderbook:
-    """Build a minimal Orderbook from candlestick bid/ask close prices.
-
-    Uses the candle's yes_bid_close as a YES bid level and derives a NO bid
-    level from yes_ask_close (NO bid = 1 - YES ask). Assigns synthetic depth.
-    """
-    yes_bid_price = candle.yes_bid_close
-    yes_ask_price = candle.yes_ask_close
-
-    yes_bids = []
-    no_bids = []
-
-    if yes_bid_price > 0:
-        yes_bids.append(OrderbookLevel(price=yes_bid_price, quantity=depth))
-
-    if yes_ask_price > 0:
-        # NO bid = 1 - YES ask
-        no_bid_price = round(1.0 - yes_ask_price, 2)
-        if no_bid_price > 0:
-            no_bids.append(OrderbookLevel(price=no_bid_price, quantity=depth))
-
-    return Orderbook(ticker=ticker, yes_bids=yes_bids, no_bids=no_bids)
 
 
 # ---------------------------------------------------------------------------
@@ -504,6 +489,7 @@ async def run_backtest(
     entry_candles: dict[str, Candle] = {}
     entry_times: dict[str, datetime] = {}
     skipped_no_candle = 0
+    stale_candles = 0
     skipped_one_sided = 0
     fetch_failures = 0
     failed_fetches: set[str] = set()
@@ -555,8 +541,16 @@ async def run_backtest(
                 m.ticker,
             )
             continue
-        if candle_midpoint(candle) <= 0:
-            # One-sided OR empty quote (either/both closes zero): no
+        if (
+            candle_midpoint(candle) <= 0
+            or candle.yes_bid_close >= 1.0
+            or candle.yes_ask_close >= 1.0
+        ):
+            # One-sided OR empty quote (either/both closes zero), or
+            # an at/over-bound close (#682: as unpriceable as an
+            # empty one — without the upper bound a 1.0 close passes
+            # and pollutes the sizing/gate counters; taker mode reads
+            # the raw close directly): no
             # priceable midpoint; trade-price OHLC stays deliberately
             # rejected as a fallback (stale on thin days, #655).
             # Counted separately because these skips can bias the
@@ -569,6 +563,7 @@ async def run_backtest(
             )
             continue
         if entry_ts - candle.end_period_ts > 86400:
+            stale_candles += 1
             logger.debug(
                 "entry candle for %s is %.1f days older than"
                 " entry_ts — stale-quote pricing (#666 residual)",
@@ -595,6 +590,7 @@ async def run_backtest(
     # --- 3-4. Filter, Score, Identify trades — per side ---
     pending: list[_PendingTrade] = []
     skipped_entry_gates = 0
+    zero_sized_tickers: set[str] = set()
     seen_tickers: set[str] = set()
     total_passed = 0
     total_scored = 0
@@ -648,8 +644,21 @@ async def run_backtest(
             ticker = orig_m.ticker
             entry_time = entry_times[ticker]
             mid = view.midpoint
-            entry_eff = effective_price(mid, scan_side)
-            true_prob = min(entry_eff + config.assumed_edge, 0.99)
+            mid_eff = effective_price(mid, scan_side)
+            is_taker = config.taker_fill
+            if is_taker:
+                # Conservative fill (#682): entry crosses the spread
+                # and pays the ask. NO ask = 1 - YES bid.
+                entry_eff = (
+                    view.yes_ask if scan_side == "yes"
+                    else effective_price(view.yes_bid, "no")
+                )
+            else:
+                entry_eff = mid_eff
+            # The model belief is anchored to the MIDPOINT, not the
+            # fill price — otherwise taker mode would float true_prob
+            # up with the ask and pass markets maker mode rejects.
+            true_prob = min(mid_eff + config.assumed_edge, 0.99)
             true_prob = apply_base_rate_floor(
                 true_prob, ticker, side=scan_side,
             )
@@ -657,7 +666,7 @@ async def run_backtest(
                 skipped_entry_gates += 1
                 continue
             if edge_after_fees(
-                entry_eff, true_prob, is_taker=False, fees=fees,
+                entry_eff, true_prob, is_taker=is_taker, fees=fees,
             ) < min_edge:
                 skipped_entry_gates += 1
                 continue
@@ -670,12 +679,17 @@ async def run_backtest(
                 max_position_pct=side_cfg.sizing.max_position_pct,
                 fees=fees,
                 mode=side_cfg.sizing.mode,
+                is_taker=is_taker,
             )
             if count <= 0:
+                # Set, not counter (#682 review): under side='both' a
+                # ticker can zero-size on both sides (one market, not
+                # two), or zero-size on one and trade the other.
+                zero_sized_tickers.add(ticker)
                 continue
 
             trade_fees = fee_for_order(
-                count, entry_eff, is_taker=False, fees=fees,
+                count, entry_eff, is_taker=is_taker, fees=fees,
             )
 
             seen_tickers.add(ticker)
@@ -783,6 +797,8 @@ async def run_backtest(
         skipped_one_sided=skipped_one_sided,
         fetch_failures=fetch_failures,
         skipped_entry_gates=skipped_entry_gates,
+        stale_candles=stale_candles,
+        skipped_zero_sizing=len(zero_sized_tickers - seen_tickers),
         skipped_balance=skipped_balance,
         truncated_chunks=truncated_chunks,
     )

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -81,6 +81,8 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         f" – {cfg.gimmes_config.strategy.max_market_price:.2f}",
         f"Gimme threshold: {cfg.gimmes_config.strategy.gimme_threshold:.0f}",
         f"Assumed edge: {cfg.assumed_edge:.0%}",
+        "Fill model: "
+        + ("taker (pays the ask)" if cfg.taker_fill else "maker (midpoint)"),
     ]
     console.print(Panel(
         "\n".join(header_lines), title="Backtest Config", border_style="blue",
@@ -123,6 +125,19 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         funnel.add_row(
             "Candle fetch FAILURES (API problem)",
             str(result.fetch_failures),
+        )
+    if result.stale_candles > 0:
+        # PRICED, not skipped — these views carry a quote up to 3
+        # days old (they may still be filtered out downstream; #682
+        # visibility, policy deferred).
+        funnel.add_row(
+            "Priced from stale candle (>1 day old)",
+            str(result.stale_candles),
+        )
+    if result.skipped_zero_sizing > 0:
+        funnel.add_row(
+            "Skipped (zero position size)",
+            str(result.skipped_zero_sizing),
         )
     if result.skipped_entry_gates > 0:
         funnel.add_row(
@@ -255,6 +270,7 @@ def backtest_result_to_json(result: BacktestResult) -> dict:  # type: ignore[typ
             "end_date": str(result.config.end_date),
             "starting_balance": result.config.starting_balance,
             "assumed_edge": result.config.assumed_edge,
+            "taker_fill": result.config.taker_fill,
         },
         "funnel": {
             "markets_scanned": result.markets_scanned,
@@ -265,6 +281,8 @@ def backtest_result_to_json(result: BacktestResult) -> dict:  # type: ignore[typ
             "skipped_one_sided": result.skipped_one_sided,
             "fetch_failures": result.fetch_failures,
             "skipped_entry_gates": result.skipped_entry_gates,
+            "stale_candles": result.stale_candles,
+            "skipped_zero_sizing": result.skipped_zero_sizing,
             "truncated_chunks": result.truncated_chunks,
         },
         "summary": {

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4140,6 +4140,11 @@ def backtest(
     json_output: bool = typer.Option(
         False, "--json", help="Output results as JSON",
     ),
+    taker_fill: bool = typer.Option(
+        False, "--taker-fill",
+        help="Conservative fill model: entries pay the ask (taker)"
+             " instead of the midpoint, with taker fees (#682)",
+    ),
 ) -> None:
     """Backtest the gimme strategy on historical settled markets."""
     config = load_config()
@@ -4169,6 +4174,7 @@ def backtest(
             starting_balance=balance,
             gimmes_config=config,
             assumed_edge=edge,
+            taker_fill=taker_fill,
         )
         console.print(
             f"[dim]Running backtest: {start} to {end}, "

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -14,7 +14,6 @@ from gimmes.backtest.engine import (
     entry_candle_at,
     monthly_chunks,
     run_backtest,
-    synthesize_orderbook,
     weekly_chunks,
 )
 from gimmes.kalshi.historical import Candle
@@ -117,38 +116,6 @@ class TestBacktestLedger:
         assert len(ledger.trades) == 2
         assert ledger.trades[0].pnl > 0
         assert ledger.trades[1].pnl < 0
-
-
-class TestSynthesizeOrderbook:
-    def test_basic_orderbook(self) -> None:
-        candle = _make_candle(yes_bid_close=0.65, yes_ask_close=0.70)
-        ob = synthesize_orderbook("T1", candle)
-
-        assert ob.ticker == "T1"
-        assert len(ob.yes_bids) == 1
-        assert ob.yes_bids[0].price == 0.65
-        assert ob.yes_bids[0].quantity == 100
-
-        assert len(ob.no_bids) == 1
-        assert ob.no_bids[0].price == 0.30  # 1 - 0.70
-        assert ob.no_bids[0].quantity == 100
-
-    def test_custom_depth(self) -> None:
-        candle = _make_candle()
-        ob = synthesize_orderbook("T1", candle, depth=50)
-        assert ob.yes_bids[0].quantity == 50
-
-    def test_zero_bid_produces_empty(self) -> None:
-        candle = _make_candle(yes_bid_close=0.0, yes_ask_close=0.0)
-        ob = synthesize_orderbook("T1", candle)
-        assert ob.yes_bids == []
-        assert ob.no_bids == []
-
-    def test_best_yes_ask_derived(self) -> None:
-        candle = _make_candle(yes_ask_close=0.72)
-        ob = synthesize_orderbook("T1", candle)
-        # NO bid = 1 - 0.72 = 0.28, so best YES ask = 1 - 0.28 = 0.72
-        assert ob.best_yes_ask == 0.72
 
 
 
@@ -590,9 +557,9 @@ class TestStrategyFilters:
         assert len(live_defaults.trades) == len(permissive.trades)
 
 
-class TestEntryDayPricing:
-    """#655 regression suite: entries are priced, gated, and sized on
-    the ENTRY-DAY candle — settlement data reaches only the payout."""
+class _EntryDayHarness:
+    """Shared pricing-path harness (no test methods — subclassing a
+    Test class re-collects its tests, review #682)."""
 
     def _markets(self):
         # Settlement quotes 0.25/0.35 → NO eff at settlement = 0.70.
@@ -635,10 +602,35 @@ class TestEntryDayPricing:
             min_true_probability=0.0, min_edge_after_fees=-1.0,
         )
 
+    def _taker_config(self):
+        """Permissive config with the #682 taker fill model on."""
+        cfg = self._permissive_config()
+        cfg.taker_fill = True
+        return cfg
+
+    def _stub_entry_candle(
+        self, monkeypatch, *, yes_bid, yes_ask, ts_offset=0,
+    ):
+        """Stub the single settled market with one entry-day candle
+        (ts_offset shifts the candle timestamp, e.g. negative for a
+        stale quote)."""
+        markets = self._markets()
+        m = markets[0]
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m) + ts_offset,
+            yes_bid_close=yes_bid, yes_ask_close=yes_ask,
+        )]}
+        return self._stub(monkeypatch, markets, candles)
+
     async def _run(self, config=None):
         return await run_backtest(
             client=None, config=config or self._permissive_config(),
         )
+
+
+class TestEntryDayPricing(_EntryDayHarness):
+    """#655 regression suite: entries are priced, gated, and sized on
+    the ENTRY-DAY candle — settlement data reaches only the payout."""
 
     @pytest.mark.asyncio
     async def test_entry_priced_from_candle_not_settlement(
@@ -1003,3 +995,342 @@ class TestEntryDayView:
         assert view.status.value == "active"
         # the settled original is untouched
         assert m.yes_bid == 0.10
+
+
+class TestTakerFill(_EntryDayHarness):
+    """#682: --taker-fill prices entries at the ask with taker fees;
+    selection still runs on the midpoint. Inherits the pricing
+    harness; overrides nothing that changes the base tests."""
+
+    @pytest.mark.asyncio
+    async def test_no_side_entry_pays_the_ask(self, monkeypatch) -> None:
+        """Candle 0.30/0.40: NO mid-fill = 0.65 (pinned by the base
+        suite); NO taker ask = 1 − yes_bid = 0.70. Kills a bid/ask
+        inversion mutant (0.70 ≠ 0.65 ≠ 0.60)."""
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        result = await self._run(config=self._taker_config())
+        assert len(result.trades) == 1
+        t = result.trades[0]
+        assert t.entry_price == pytest.approx(0.70)
+
+    @pytest.mark.asyncio
+    async def test_taker_fees_charged(self, monkeypatch) -> None:
+        from gimmes.strategy.fees import fee_for_order
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        result = await self._run(config=self._taker_config())
+        [t] = result.trades
+        assert t.fees == pytest.approx(
+            fee_for_order(t.count, 0.70, is_taker=True),
+        )
+        # Sanity: taker fees exceed the maker fee at the same size.
+        assert t.fees > fee_for_order(t.count, 0.70, is_taker=False)
+
+    @pytest.mark.asyncio
+    async def test_json_config_reports_fill_model(self, monkeypatch) -> None:
+        from gimmes.backtest.report import backtest_result_to_json
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+        result = await self._run(config=self._taker_config())
+        assert backtest_result_to_json(result)["config"]["taker_fill"] is True
+
+
+class TestStaleCandleCounter(_EntryDayHarness):
+    """#682: a candle >1 day older than entry_ts prices the view — the
+    counter makes it visible; the market still trades (count-only,
+    policy deferred)."""
+
+    @pytest.mark.asyncio
+    async def test_stale_candle_counted_and_still_traded(
+        self, monkeypatch,
+    ) -> None:
+        self._stub_entry_candle(
+            monkeypatch, yes_bid=0.30, yes_ask=0.40,
+            ts_offset=-2 * 86400,  # 2 days stale
+        )
+
+        result = await self._run()
+        assert result.stale_candles == 1
+        # Count-only: a future tightening must consciously break this.
+        assert len(result.trades) == 1
+
+    @pytest.mark.asyncio
+    async def test_fresh_candle_not_counted(self, monkeypatch) -> None:
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        result = await self._run()
+        assert result.stale_candles == 0
+
+    @pytest.mark.asyncio
+    async def test_exactly_one_day_old_not_stale(self, monkeypatch) -> None:
+        """Strict >: an exactly-one-day-old daily candle is the normal
+        case, not stale."""
+        self._stub_entry_candle(
+            monkeypatch, yes_bid=0.30, yes_ask=0.40, ts_offset=-86400,
+        )
+
+        result = await self._run()
+        assert result.stale_candles == 0
+
+
+class TestZeroSizingCounter(_EntryDayHarness):
+    """#682: pass-1 kelly drops (count <= 0) are counted, not silent."""
+
+    @pytest.mark.asyncio
+    async def test_tiny_bankroll_counts_zero_sizing(
+        self, monkeypatch,
+    ) -> None:
+        from gimmes.backtest.engine import BacktestConfig
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        base = self._permissive_config()
+        config = BacktestConfig(
+            start_date=base.start_date,
+            end_date=base.end_date,
+            starting_balance=1.0,  # $1 buys zero contracts at ~$0.65
+            gimmes_config=base.gimmes_config,
+            assumed_edge=base.assumed_edge,
+        )
+        result = await self._run(config=config)
+        assert result.skipped_zero_sizing == 1
+        assert result.trades == []
+        # Counted at the SIZING gate, not upstream.
+        assert result.skipped_entry_gates == 0
+
+
+class TestBothSidesDedup(_EntryDayHarness):
+    """#682: pass 1's seen_tickers guard must yield exactly one trade
+    when a ticker qualifies on BOTH sides under side='both'."""
+
+    @pytest.mark.asyncio
+    async def test_ticker_traded_once_across_sides(
+        self, monkeypatch,
+    ) -> None:
+        # Candle 0.45/0.55 → mid 0.50: yes eff 0.50, no eff 0.50 —
+        # both sides in an explicit wide band.
+        self._stub_entry_candle(monkeypatch, yes_bid=0.45, yes_ask=0.55)
+
+        # effective_config_for_side RE-VALIDATES StrategyConfig, so
+        # the overrides must be constructible (min edge > 0).
+        config = _backtest_config_with_overrides(
+            min_true_probability=0.01, min_edge_after_fees=0.0001,
+            min_market_price=0.10, max_market_price=0.90,
+        )
+        config.gimmes_config.strategy.side = "both"
+        # The operator's live config carries per-side overrides that
+        # would clobber the flat test values — reset them to empty
+        # (all-None fields inherit the flat values above).
+        from gimmes.config import SideOverrides
+
+        config.gimmes_config.strategy.yes_overrides = SideOverrides()
+        config.gimmes_config.strategy.no_overrides = SideOverrides()
+
+        result = await self._run(config=config)
+        # Both sides genuinely qualified — without this the test can
+        # pass vacuously.
+        assert result.markets_scored == 2
+        # The guard: exactly one trade for the ticker. markets_traded
+        # is the killing assertion (without the guard, pass 2 buys
+        # twice); the risk-limit asserts prove the dedup path — not a
+        # concentration/balance backstop — produced the single trade.
+        assert result.markets_traded == 1
+        assert len(result.trades) == 1
+        assert result.skipped_concentration == 0
+        assert result.skipped_balance == 0
+
+
+class TestTakerFillReviewPins(_EntryDayHarness):
+    """#682 review: yes-side branch, is_taker threading at every call
+    site, edge-gate interaction, guard bound, and the CLI wiring."""
+
+    @pytest.mark.asyncio
+    async def test_yes_side_entry_pays_the_ask(self, monkeypatch) -> None:
+        """Candle 0.45/0.55, side='yes': taker entry = ask 0.55
+        (mid-fill would be 0.50, bid 0.45 — three-way
+        discrimination)."""
+        from gimmes.config import SideOverrides
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.45, yes_ask=0.55)
+
+        config = _backtest_config_with_overrides(
+            min_true_probability=0.01, min_edge_after_fees=0.0001,
+            min_market_price=0.10, max_market_price=0.90,
+        )
+        config.gimmes_config.strategy.side = "yes"
+        config.gimmes_config.strategy.yes_overrides = SideOverrides()
+        config.taker_fill = True
+
+        result = await self._run(config=config)
+        assert len(result.trades) == 1
+        assert result.trades[0].entry_price == pytest.approx(0.55)
+
+    @pytest.mark.asyncio
+    async def test_sizing_uses_taker_price_and_fees(
+        self, monkeypatch,
+    ) -> None:
+        """Pins is_taker at the position_size call site — the fees
+        test alone is self-consistent with any count."""
+        from gimmes.strategy.fee_cache import DEFAULT_FEE_MULTIPLIERS
+        from gimmes.strategy.kelly import position_size
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        config = self._taker_config()
+        result = await self._run(config=config)
+        [t] = result.trades
+        side_cfg = config.gimmes_config.effective_config_for_side("no")
+        # true_prob anchored to the MIDPOINT (0.65 + 0.10), entry at
+        # the taker ask (0.70).
+        expected = position_size(
+            10_000.0, 0.70, 0.75,
+            is_taker=True,
+            fraction=side_cfg.sizing.kelly_fraction,
+            max_position_pct=side_cfg.sizing.max_position_pct,
+            fees=DEFAULT_FEE_MULTIPLIERS,
+            mode=side_cfg.sizing.mode,
+        )
+        assert t.count == expected
+        # And the maker-sized mutant is genuinely different.
+        assert expected != position_size(
+            10_000.0, 0.70, 0.75,
+            is_taker=False,
+            fraction=side_cfg.sizing.kelly_fraction,
+            max_position_pct=side_cfg.sizing.max_position_pct,
+            fees=DEFAULT_FEE_MULTIPLIERS,
+            mode=side_cfg.sizing.mode,
+        )
+
+    @pytest.mark.asyncio
+    async def test_taker_mode_cannot_pass_more_markets(
+        self, monkeypatch,
+    ) -> None:
+        """The review fix: true_prob stays midpoint-anchored, so a
+        prob gate that rejects the maker fill also rejects the taker
+        fill (pre-fix taker floated true_prob up and PASSED)."""
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        # mid_eff = 0.65 → true_prob 0.75; taker entry 0.70 would give
+        # 0.80 under the pre-fix float-up.
+        config = _backtest_config_with_overrides(
+            min_true_probability=0.78, min_edge_after_fees=0.0001,
+        )
+        config.taker_fill = True
+        result = await self._run(config=config)
+        assert result.trades == []
+        assert result.skipped_entry_gates == 1
+
+    @pytest.mark.asyncio
+    async def test_taker_edge_gate_tighter_than_maker(
+        self, monkeypatch,
+    ) -> None:
+        """Pins is_taker at the edge_after_fees gate: a threshold
+        inside the (taker_edge, maker_edge) window rejects under
+        taker and would pass under the is_taker=False mutant."""
+        from gimmes.strategy.fees import edge_after_fees
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.30, yes_ask=0.40)
+
+        taker_edge = edge_after_fees(0.70, 0.75, is_taker=True)
+        maker_edge = edge_after_fees(0.70, 0.75, is_taker=False)
+        assert taker_edge < maker_edge  # window exists
+        threshold = (taker_edge + maker_edge) / 2
+
+        config = _backtest_config_with_overrides(
+            min_true_probability=0.0,
+            min_edge_after_fees=threshold,
+        )
+        config.taker_fill = True
+        result = await self._run(config=config)
+        assert result.trades == []
+        assert result.skipped_entry_gates == 1
+
+    @pytest.mark.asyncio
+    async def test_at_bound_close_counted_one_sided(
+        self, monkeypatch,
+    ) -> None:
+        """#682 review: an at/over-bound close (ask 1.0) is as
+        unpriceable as an empty one — it must land in the one-sided
+        counter, not pollute the sizing/gate counters."""
+        self._stub_entry_candle(monkeypatch, yes_bid=0.40, yes_ask=1.0)
+
+        result = await self._run(config=self._taker_config())
+        assert result.skipped_one_sided == 1
+        assert result.skipped_zero_sizing == 0
+        assert result.trades == []
+
+    @pytest.mark.asyncio
+    async def test_zero_sizing_counts_markets_not_side_attempts(
+        self, monkeypatch,
+    ) -> None:
+        """#682 review: under side='both' a ticker zero-sizing on both
+        sides is ONE market, not two."""
+        from gimmes.backtest.engine import BacktestConfig
+        from gimmes.config import SideOverrides
+
+        self._stub_entry_candle(monkeypatch, yes_bid=0.45, yes_ask=0.55)
+
+        base = _backtest_config_with_overrides(
+            min_true_probability=0.01, min_edge_after_fees=0.0001,
+            min_market_price=0.10, max_market_price=0.90,
+        )
+        base.gimmes_config.strategy.side = "both"
+        base.gimmes_config.strategy.yes_overrides = SideOverrides()
+        base.gimmes_config.strategy.no_overrides = SideOverrides()
+        config = BacktestConfig(
+            start_date=base.start_date,
+            end_date=base.end_date,
+            starting_balance=1.0,  # zero-sizes on BOTH sides
+            gimmes_config=base.gimmes_config,
+            assumed_edge=base.assumed_edge,
+        )
+        result = await self._run(config=config)
+        assert result.markets_scored == 2  # both sides qualified
+        assert result.skipped_zero_sizing == 1  # one market
+
+
+def test_cli_taker_fill_flag_wired() -> None:
+    """#682: --taker-fill reaches BacktestConfig through the CLI."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from typer.testing import CliRunner
+
+    from gimmes.backtest.engine import BacktestResult
+    from gimmes.cli import app
+
+    captured: dict = {}
+
+    async def _fake_run(client, config):
+        captured["config"] = config
+        return BacktestResult(
+            config=config, trades=[], final_balance=10_000.0,
+            equity_curve=[], markets_scanned=0,
+            markets_passed_filter=0, markets_scored=0, markets_traded=0,
+        )
+
+    class _FakeClient:
+        def __init__(self, _config):
+            pass
+
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    cfg = MagicMock()
+    with (
+        patch("gimmes.cli.load_config", return_value=cfg),
+        patch("gimmes.backtest.engine.run_backtest", _fake_run),
+        # the backtest command opens its own KalshiClient
+        patch("gimmes.kalshi.client.KalshiClient", _FakeClient),
+    ):
+        result = CliRunner().invoke(app, [
+            "backtest", "--from", "2026-05-01", "--to", "2026-05-10",
+            "--taker-fill", "--json",
+        ])
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].taker_fill is True

--- a/tests/unit/test_backtest_report.py
+++ b/tests/unit/test_backtest_report.py
@@ -281,3 +281,59 @@ class TestSkipCountersInReport:
         buf = StringIO()
         format_backtest_report(result, Console(file=buf, width=120))
         assert "Caution" not in buf.getvalue()
+
+
+class TestNewCountersInReport:
+    """#682: stale_candles and skipped_zero_sizing reach the JSON and
+    the funnel; the header names the fill model."""
+
+    def test_json_carries_new_counters(self) -> None:
+        result = _make_result()
+        result.stale_candles = 4
+        result.skipped_zero_sizing = 2
+        data = backtest_result_to_json(result)
+        assert data["funnel"]["stale_candles"] == 4
+        assert data["funnel"]["skipped_zero_sizing"] == 2
+
+    def test_json_config_carries_fill_model(self) -> None:
+        data = backtest_result_to_json(_make_result())
+        assert data["config"]["taker_fill"] is False
+
+    def test_stale_row_says_priced_not_skipped(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.stale_candles = 3
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        out = buf.getvalue()
+        assert "Priced from stale candle" in out
+        assert "3" in out
+
+    def test_zero_sizing_row_renders(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.skipped_zero_sizing = 5
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "zero position size" in buf.getvalue()
+
+    def test_header_names_fill_model(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "maker (midpoint)" in buf.getvalue()
+
+        result.config.taker_fill = True
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "taker (pays the ask)" in buf.getvalue()


### PR DESCRIPTION
## Summary

Resolves four of the five #682 residuals from #666; the disk candle cache — the one item introducing persistent operational state, with its own design surface — is deferred to #696 carrying the full design sketch (SQLite at GIMMES_HOME, immutable-history keys, negative caching of empty windows, never-cache-failures preserving #655 visibility).

**1. `--taker-fill` conservative fill mode.** The machinery turned out far smaller than #666 assumed: entry-day candles already carry bid/ask closes, so no fill model or `synthesize_orderbook` is needed — entries pay the ask (`yes_ask` for YES; `1 − yes_bid` for NO) with taker fees threaded through the edge gate, Kelly sizing, and the fee calc. **Review-caught semantics bug:** deriving `true_prob` from the fill price floated the model belief up with the ask, *passing markets and up-sizing positions maker mode rejects* — the opposite of conservative. Fixed by anchoring `true_prob` to the midpoint (identical in maker mode); a pre-fix-failing test pins that a prob gate rejecting the maker fill also rejects the taker fill. The candle guard also gains an upper bound: an at/over-bound close (≥ \$1.00) now lands in `skipped_one_sided` instead of polluting the sizing/gate counters taker mode would otherwise misattribute it to. `synthesize_orderbook` is removed — the flag landing without it falsified its reason to exist.

**2. Stale-candle visibility.** Views priced from a candle more than one day older than entry (the thin-market case where Kalshi omits zero-activity periods) get a `stale_candles` counter, funnel row ("Priced from stale candle" — deliberately not "Skipped": these markets trade), and JSON key. Count-only by design: tightening the lookback before seeing the population size would silently shrink the traded sample.

**3. Zero-sizing visibility.** Pass-1 Kelly drops (`count <= 0`) get `skipped_zero_sizing` — counted per *market* via a set (review caught the per-side-attempt double-count under `side='both'`), excluding tickers that traded on the other side.

**4. `side='both'` dedup pinned.** One ticker qualifying on both sides trades exactly once; `markets_traded == 1` is the killing assertion (the trades-list length alone survives the mutant), with concentration/balance guards proving the dedup path — not a risk backstop — produced the single trade.

## Test plan

- 15 new tests: taker pricing on both sides (three-way price discrimination), midpoint-anchored prob gate (fails pre-fix), `is_taker` pinned at the sizing call (694 ≠ 704 contracts) and the edge gate (threshold inside the taker/maker window), taker fees, at-bound close routing, stale counter (2-day / fresh / exactly-1-day boundary), zero-sizing single-side and both-sides-one-market, both-sides dedup, CLI flag wiring, report rows/JSON/header.
- Harness extracted to a non-collected mixin — removed 28 duplicate test collections.
- Full suite: **1927 passed** on frozen code.

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB