### PR TITLE
Fix #684: settled-count clamping, now-stamping, settlements consumption at every championship sync

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1250,8 +1250,14 @@ def order(
                 f" (status: {result.status})"
             )
 
-            # Sync positions + log trade atomically so a crash can't
-            # leave positions stale while a trade is recorded (or vice versa)
+            # Sync positions + log THIS ORDER's trade atomically so a
+            # crash can't leave positions stale while the trade is
+            # recorded (or vice versa). The #684 settlements
+            # consumption (below, before the atomic write) commits
+            # per-ticker by design — those closes are for OTHER,
+            # already-settled tickers, and the consumption is
+            # crash-idempotent (has_settlement_close guard), so they
+            # don't belong in this order's atomic unit.
             try:
                 if broker:
                     positions_for_sync = await broker.get_positions()
@@ -2235,15 +2241,25 @@ async def _settle_removed_positions(
                     " ledger (#684)",
                     ticker, record_count, residual,
                 )
-            else:
+            elif record_count < residual:
                 logging.getLogger("gimmes").warning(
                     "settlement record count mismatch for %s: record"
                     " %d vs ledger residual %d — %d contract(s)"
                     " exited off-ledger (#684)",
                     ticker, record_count, residual,
-                    abs(residual - record_count),
+                    residual - record_count,
                 )
-                count = min(residual, record_count)
+                count = record_count
+            else:
+                # record > residual: phantom/extra ledger closes, not
+                # an off-ledger exit — the ledger residual stands
+                # (min-clamp is a no-op in this direction).
+                logging.getLogger("gimmes").warning(
+                    "settlement record count mismatch for %s: record"
+                    " %d vs ledger residual %d — using the ledger"
+                    " (#684)",
+                    ticker, record_count, residual,
+                )
         if count <= 0:
             continue
         await log_settlement_close(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -655,6 +655,14 @@ def validate(
                 from gimmes.kalshi.portfolio import get_all_positions
                 from gimmes.store.queries import sync_positions
                 positions = await get_all_positions(client)
+                # #684: consume settlements before this sync writes
+                # drift closes — the daily-loss read downstream must
+                # see settlement losses, and a drift close here would
+                # permanently block the later settlement write
+                # (residual exhausted).
+                await _consume_settlements_before_sync(
+                    client, db, positions,
+                )
                 await sync_positions(db, positions)
 
             fees = get_multipliers(market.series_ticker)
@@ -837,6 +845,14 @@ def order(
                 from gimmes.kalshi.portfolio import get_all_positions
                 from gimmes.store.queries import sync_positions
                 positions = await get_all_positions(client)
+                # #684: consume settlements before this sync writes
+                # drift closes — the daily-loss read downstream must
+                # see settlement losses, and a drift close here would
+                # permanently block the later settlement write
+                # (residual exhausted).
+                await _consume_settlements_before_sync(
+                    client, db, positions,
+                )
                 await sync_positions(db, positions)
 
             order_action = OrderAction(action.lower())
@@ -1245,6 +1261,11 @@ def order(
                     )
 
                     positions_for_sync = await refresh_pos(client)
+                    # #684: same settlements-before-sync rule as the
+                    # other championship sync sites.
+                    await _consume_settlements_before_sync(
+                        client, db, positions_for_sync,
+                    )
 
                 if result.status in ("executed", "resting"):
                     from gimmes.models.trade import TradeDecision
@@ -1952,6 +1973,11 @@ def positions() -> None:
                 from gimmes.kalshi.portfolio import get_all_positions
                 from gimmes.store.queries import sync_positions
                 pos_list = await get_all_positions(client)
+                # #684: consume settlements before the sync writes
+                # drift closes — same semantics as reconcile.
+                await _consume_settlements_before_sync(
+                    client, db, pos_list,
+                )
                 await sync_positions(db, pos_list)
                 # #674: an OPEN live position with realized P&L means
                 # prior sells/settlements on this market — Kalshi's
@@ -2000,6 +2026,12 @@ def risk_check() -> None:
                 from gimmes.store.queries import sync_positions
                 balance = await get_balance(client)
                 pos = await get_all_positions(client)
+                # #684: consume settlements before the sync writes
+                # drift closes — the daily-loss check below must see
+                # settlement losses, not mark-priced drift.
+                await _consume_settlements_before_sync(
+                    client, db, pos,
+                )
                 await sync_positions(db, pos)
 
             try:
@@ -2064,6 +2096,43 @@ def risk_check() -> None:
     _run(_check())
 
 
+def _parse_settled_count(rec: dict, side: str) -> int | None:  # type: ignore[type-arg]
+    """Parse the settlement record's settled count for a side (#684).
+
+    Kalshi fp scaling is inconsistent across endpoints: the live-
+    probed settlements shape carries integer centi-contract strings
+    ("10000" = 100), while orders carry decimal strings ("60.00" =
+    60). Tolerate both; None means "no usable info" and callers keep
+    the ledger-only behavior. Defensive by design (review #684): the
+    scaling is unverified pre-championship, and a misparse here can
+    reroute a settlement loss into drift the daily-loss trigger
+    excludes — so anything ambiguous returns None rather than a
+    guess. Integer forms must be whole centi-contracts (%100 == 0:
+    a plain-contracts "60" would otherwise misparse to 0.6), and
+    fractional results are rejected, never truncated. CAUTION:
+    re-verify the scaling against a live probe before championship
+    deploy.
+    """
+    import math
+
+    raw = str(rec.get(f"{side}_count_fp", "")).strip()
+    if not raw:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+    if not math.isfinite(value) or value < 0:
+        return None
+    if "." not in raw:
+        if value % 100 != 0:
+            return None
+        value = value / 100
+    if value != int(value):
+        return None
+    return int(value)
+
+
 async def _settle_removed_positions(
     client, db, old_tickers, removed: set[str],
 ) -> int:
@@ -2072,12 +2141,29 @@ async def _settle_removed_positions(
     positions settled. Commit-per-ticker; residual <= 0 tickers are
     skipped (the drift close is then also suppressed by the #653
     dup-guard, and a history-less ticker must NOT be pre-written or
-    it would produce BOTH rows)."""
-    from datetime import datetime
+    it would produce BOTH rows).
+
+    #684: the close count is min(ledger residual, record's settled
+    count) — an off-ledger exit (operator sold on the Kalshi UI)
+    settles fewer contracts than the ledger residual, and the
+    remainder falls to a reconcile drift close at the last mark
+    (excluded from daily P&L per #622 — correct accounting for an
+    exit whose price we never saw). The close is stamped NOW, not
+    settled_time: reconcile is a live loop where the loss is NEW
+    information the daily-loss trigger must see (a backdated stamp
+    can land on a prior UTC date the trigger never re-reads); the
+    #653 backfill deliberately backdates and is unaffected. The raw
+    settled_time is preserved in the rationale. Known asymmetry
+    (#684 review): after a multi-day outage a stale settlement WIN
+    consumed today nets against today's genuine losses in
+    get_daily_pnl — accepted; the breaker is loss-conservative and
+    the window only exists when no command ran for days."""
+    import logging
 
     from gimmes.kalshi.portfolio import get_settlements_for_tickers
     from gimmes.store.queries import (
         count_opened_closed,
+        has_settlement_close,
         log_settlement_close,
     )
 
@@ -2094,37 +2180,144 @@ async def _settle_removed_positions(
         residual = opened - closed
         if opened <= 0 or residual <= 0:
             continue
+        # #684 review: a market settles ONCE — an existing settlement
+        # close for this ticker/side means a prior (possibly clamped)
+        # consumption already ran; writing again would book the
+        # off-ledger drift remainder at settlement value. The count
+        # clamp broke the old residual-based idempotency, so this
+        # check restores it.
+        if await has_settlement_close(db, ticker, pos.side):
+            continue
         if residual != pos.count:
-            import logging
-
             logging.getLogger("gimmes").warning(
                 "settlement residual mismatch for %s: ledger %d vs"
                 " broker %d — using the ledger (#663)",
                 ticker, residual, pos.count,
             )
+        count = residual
+        record_count = _parse_settled_count(rec, pos.side)
         raw_time = str(rec.get("settled_time", ""))
-        try:
-            settled_time: datetime | None = datetime.fromisoformat(
-                raw_time.replace("Z", "+00:00"),
+        if record_count == 0:
+            # Full off-ledger exit: zero contracts settled. Write a
+            # 0-count settlement EVIDENCE row — it books nothing,
+            # sets resolved_outcome, and makes group_has_settlement
+            # true so the drift close (full residual, written by the
+            # sync) keeps its mark instead of being repriced to a
+            # settlement the position never rode to (#684 review).
+            await log_settlement_close(
+                db, ticker=ticker, side=pos.side, count=0,
+                won=pos.side == result,
+                rationale=(
+                    "settlement record shows ZERO contracts settled —"
+                    " position fully exited off-ledger before"
+                    " resolution; evidence row only, the drift close"
+                    " carries the exit at the last mark (#684);"
+                    f" settled_time={raw_time or 'unknown'}"
+                ),
             )
-        except ValueError:
-            settled_time = None
+            await db.conn.commit()
+            settled += 1
+            continue
+        if record_count is not None and record_count != residual:
+            # Distrust wildly-off records: the fp scaling is
+            # unverified, and a 100x under-parse would reroute a
+            # settlement loss into drift the daily-loss trigger
+            # excludes. Outside [residual/2, residual*2] → treat as
+            # unparseable (ledger behavior) and say so at ERROR.
+            if (
+                record_count < max(1, residual // 2)
+                or record_count > residual * 2
+            ):
+                logging.getLogger("gimmes").error(
+                    "settlement record count for %s is wildly off"
+                    " the ledger residual (record %d vs residual %d)"
+                    " — possible fp-scaling misparse; using the"
+                    " ledger (#684)",
+                    ticker, record_count, residual,
+                )
+            else:
+                logging.getLogger("gimmes").warning(
+                    "settlement record count mismatch for %s: record"
+                    " %d vs ledger residual %d — %d contract(s)"
+                    " exited off-ledger (#684)",
+                    ticker, record_count, residual,
+                    abs(residual - record_count),
+                )
+                count = min(residual, record_count)
+        if count <= 0:
+            continue
         await log_settlement_close(
             db,
             ticker=ticker,
             side=pos.side,
-            count=residual,
+            count=count,
             won=pos.side == result,
-            timestamp=settled_time,
             rationale=(
                 "market settled — outcome consumed from the"
                 " authoritative portfolio settlements endpoint"
-                " during reconcile (#663)"
+                " during reconcile (#663);"
+                f" settled_time={raw_time or 'unknown'} (#684)"
             ),
         )
         await db.conn.commit()
         settled += 1
     return settled
+
+
+async def _consume_settlements_before_sync(
+    client, db, fresh, old_tickers=None,
+) -> None:
+    """Championship-mode settlements consumption (#663/#684): before a
+    sync writes drift closes, removed positions are matched against
+    the authoritative settlements endpoint and pre-written as
+    agent='settlement' closes; the #653 dup-guard then suppresses (or
+    count-clamps, #684) the drift close. Crash-idempotent; any failure
+    degrades to drift — the calling command is never blocked.
+
+    ``old_tickers`` (ticker -> ledger position) is read from the DB
+    when not supplied; reconcile passes its precomputed dict. A ledger
+    read failure propagates to the caller, same as at the old call
+    sites — only the settlements lookup/write degrades to drift."""
+    if old_tickers is None:
+        from gimmes.store.queries import get_positions
+
+        old_tickers = {p.ticker: p for p in await get_positions(db)}
+    prospective_removed = (
+        old_tickers.keys() - {p.ticker for p in fresh}
+    )
+    if not prospective_removed:
+        return
+    try:
+        settled_count = await _settle_removed_positions(
+            client, db, old_tickers, prospective_removed,
+        )
+        if settled_count:
+            console.print(
+                f"  [green]{settled_count} removed"
+                f" position(s) matched settlement"
+                f" records — closed at settlement"
+                f" value (#663)[/green]"
+            )
+    except Exception as exc:
+        import logging
+
+        # A mid-write failure leaves the per-ticker
+        # implicit transaction open — without a
+        # rollback, sync_positions' BEGIN IMMEDIATE
+        # below would die on "cannot start a
+        # transaction within a transaction" and the
+        # promised drift fallback would never run.
+        await db.conn.rollback()
+        logging.getLogger("gimmes").warning(
+            "settlements lookup failed — falling back"
+            " to reconcile drift (#663): %s", exc,
+            exc_info=True,
+        )
+        console.print(
+            f"  [yellow]Warning: settlements lookup"
+            f" failed ({exc}) — removed positions"
+            f" fall back to drift closes[/yellow]"
+        )
 
 
 @app.command(rich_help_panel="Portfolio")
@@ -2208,42 +2401,9 @@ def reconcile() -> None:
             # <= 0 and skips). Any settlements-API failure degrades
             # to today's drift behavior — reconcile is never blocked.
             if not broker:
-                prospective_removed = (
-                    old_tickers.keys() - {p.ticker for p in fresh}
+                await _consume_settlements_before_sync(
+                    client, db, fresh, old_tickers=old_tickers,
                 )
-                if prospective_removed:
-                    try:
-                        settled_count = await _settle_removed_positions(
-                            client, db, old_tickers,
-                            prospective_removed,
-                        )
-                        if settled_count:
-                            console.print(
-                                f"  [green]{settled_count} removed"
-                                f" position(s) matched settlement"
-                                f" records — closed at settlement"
-                                f" value (#663)[/green]"
-                            )
-                    except Exception as exc:
-                        import logging
-
-                        # A mid-write failure leaves the per-ticker
-                        # implicit transaction open — without a
-                        # rollback, sync_positions' BEGIN IMMEDIATE
-                        # below would die on "cannot start a
-                        # transaction within a transaction" and the
-                        # promised drift fallback would never run.
-                        await db.conn.rollback()
-                        logging.getLogger("gimmes").warning(
-                            "settlements lookup failed — falling back"
-                            " to reconcile drift (#663): %s", exc,
-                            exc_info=True,
-                        )
-                        console.print(
-                            f"  [yellow]Warning: settlements lookup"
-                            f" failed ({exc}) — removed positions"
-                            f" fall back to drift closes[/yellow]"
-                        )
 
             await sync_positions(db, fresh)
 
@@ -2853,7 +3013,9 @@ def backfill_settlements(
             # updates only touch count > 0 rows). Do NOT also require
             # realized_pnl < 0 for 0.0 marks: realized_pnl is
             # cumulative, so a settled loss after profitable partial
-            # sells can end lifetime-positive.
+            # sells can end lifetime-positive. Hand-imported/manually
+            # repaired rows sit outside this invariant — accepted
+            # (#684): this is a one-time #653 correction tool.
             cursor = await db.conn.execute(
                 "SELECT ticker, side, avg_price, cost_basis,"
                 " market_price, updated_at"

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -90,6 +90,14 @@ def calculate_pnl(
         # properly recorded for this position — any reconcile drift
         # row alongside it is genuinely NON-settlement drift (e.g. a
         # manual exit) and must keep its mark, not be repriced.
+        # Known approximation (#684): a UI full exit BEFORE resolution
+        # leaves the drift row as the only record; once the outcome
+        # lands it is repriced to settlement value, an error bounded
+        # by (mark − true exit). When the settlement RECORD proved
+        # zero contracts settled, the consumption writes a 0-count
+        # settlement evidence row that makes this flag true and
+        # protects the drift mark; the ambiguity note applies only
+        # when no record was ever consumed.
         group_has_settlement = any(
             e.get("agent") == "settlement" and e.get("action") == "close"
             for e in events

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -296,6 +296,12 @@ async def _log_reconcile_closes(
             # position with NO trade history (opened == 0) still gets
             # its drift close (pre-#609 DBs, seeded positions).
             continue
+        # #684: the drift close covers the LEDGER residual, not
+        # pos.count — a clamped settlement close (record count <
+        # residual, an off-ledger exit) leaves a remainder that must
+        # not be over-closed, and a stale pos.count must not inflate
+        # the group either. opened == 0 keeps the pos.count behavior.
+        drift_count = (opened - closed) if opened > 0 else pos.count
         # Use last-known mark (market_price or avg_price) as the close
         # price rather than 0.0 — keeps `get_daily_pnl`'s realized-P&L
         # math honest. Documented in the rationale so audit can see
@@ -310,7 +316,7 @@ async def _log_reconcile_closes(
                 ticker=pos.ticker,
                 action=TradeDecision.Action.CLOSE,
                 side=pos.side,
-                count=pos.count,
+                count=drift_count,
                 price=close_price,
                 model_probability=analytics.get("model_probability", 0.0),
                 gimme_score=analytics.get("gimme_score", 0.0),
@@ -354,7 +360,7 @@ async def _log_reconcile_closes(
             f"Decision: CLOSE\n"
             f"Trigger: Reconcile-divergence\n"
             f"Side: {pos.side}\n"
-            f"Count: {pos.count}\n"
+            f"Count: {drift_count}\n"
             f"Last-known mark: {close_price}\n"
             f"Rationale: broker reported position absent during reconcile;"
             f" local DB had it open. This is broker-divergence drift,"
@@ -387,6 +393,25 @@ def settlement_outcome(side: str, won: bool) -> str:
     if won:
         return side
     return "no" if side == "yes" else "yes"
+
+
+async def has_settlement_close(
+    db: Database, ticker: str, side: str
+) -> bool:
+    """True when an agent='settlement' close exists for ticker/side.
+
+    A market settles once — used by the #684 consumption idempotency
+    guard (the count clamp broke the old residual-based idempotency:
+    a retry after a clamped write would book the off-ledger drift
+    remainder at settlement value).
+    """
+    cursor = await db.conn.execute(
+        """SELECT 1 FROM trades
+           WHERE ticker = ? AND side = ? AND action = 'close'
+             AND agent = 'settlement' LIMIT 1""",
+        (ticker, side),
+    )
+    return await cursor.fetchone() is not None
 
 
 async def count_opened_closed(

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -65,6 +65,8 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
         )
         # #663: mirror calculate_pnl — drift rows in groups that carry
         # a real settlement close keep their mark (manual exits).
+        # Same #684 approximation note as calculate_pnl: a UI full
+        # exit before resolution is repriced once the outcome lands.
         group_has_settlement = any(
             e.get("agent") == "settlement" and e.get("action") == "close"
             for e in events

--- a/tests/unit/test_cli_positions.py
+++ b/tests/unit/test_cli_positions.py
@@ -411,6 +411,12 @@ class TestPositionsStaleAndSuspect:
                     "gimmes.store.queries.sync_positions",
                     AsyncMock(),
                 ),
+                # #684: the settlements pre-consumption reads the old
+                # positions; empty → no removed tickers → no-op.
+                patch(
+                    "gimmes.store.queries.get_positions",
+                    AsyncMock(return_value=[]),
+                ),
             ])
 
         with ExitStack() as stack:

--- a/tests/unit/test_cli_reconcile_settlements.py
+++ b/tests/unit/test_cli_reconcile_settlements.py
@@ -169,7 +169,14 @@ def test_removed_position_closed_at_settlement_value(
     assert closes[0]["price"] == 1.0  # NO side, market_result 'no'
     assert closes[0]["count"] == 100
     assert closes[0]["resolved_outcome"] == "no"
-    assert str(closes[0]["timestamp"]).startswith("2026-06-20")
+    # #684: stamped NOW so the daily-loss trigger sees the loss on the
+    # date it reads; the record's settled_time lives in the rationale.
+    from datetime import UTC, datetime
+
+    assert str(closes[0]["timestamp"]).startswith(
+        datetime.now(UTC).date().isoformat(),
+    )
+    assert SETTLED_TIME in str(closes[0]["rationale"])
 
 
 def test_losing_side_closed_at_zero(
@@ -322,6 +329,549 @@ def test_unparseable_settled_time_still_settles(
     assert len(closes) == 1
     assert closes[0]["agent"] == "settlement"
     assert closes[0]["price"] == 1.0
+
+
+def test_off_ledger_exit_splits_settlement_and_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#684: the record says only 60 contracts settled (operator sold
+    40 on the Kalshi UI) — the settlement close is clamped to 60 and
+    the 40-contract remainder falls to a drift close at the mark
+    (excluded from daily P&L, correct for an exit we never saw)."""
+    import logging
+
+    db_path = tmp_path / "test.db"
+    _seed(db_path)  # open 100, position count 100
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record() | {"no_count_fp": "6000"}},
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gimmes"):
+        result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "settlement record count mismatch" in caplog.text
+
+    closes = _closes(db_path)
+    settlement = [c for c in closes if c["agent"] == "settlement"]
+    drift = [c for c in closes if c["agent"] == "reconcile"]
+    assert len(settlement) == 1 and settlement[0]["count"] == 60
+    assert settlement[0]["price"] == 1.0
+    assert len(drift) == 1 and drift[0]["count"] == 40
+    assert drift[0]["price"] == pytest.approx(0.705)  # last mark
+
+
+def test_decimal_count_fp_form_parsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Orders-style decimal fp ("60.00" = 60) parses too."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record() | {"no_count_fp": "60.00"}},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    settlement = [
+        c for c in _closes(db_path) if c["agent"] == "settlement"
+    ]
+    assert settlement[0]["count"] == 60
+
+
+def test_garbage_count_fp_keeps_ledger_residual(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unusable record count → ledger-only behavior (pre-#684)."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record() | {"no_count_fp": "garbage"}},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    settlement = [
+        c for c in _closes(db_path) if c["agent"] == "settlement"
+    ]
+    assert settlement[0]["count"] == 100
+
+
+def test_settlement_loss_lands_in_todays_daily_pnl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 item 2: a record settled_time on a PRIOR UTC date must not
+    hide the loss from the daily-loss trigger — the close is stamped
+    now."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record(
+            market_result="yes",  # NO side LOSES → close at 0.0
+            settled_time="2026-06-20T23:59:59.000000Z",
+        )},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    async def _pnl() -> float:
+        from gimmes.store.queries import get_daily_pnl
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await get_daily_pnl(db)
+        finally:
+            await db.close()
+
+    daily = asyncio.run(_pnl())
+    assert daily == pytest.approx((0.0 - 0.63) * 100)
+
+
+def test_crash_on_second_ticker_preserves_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 item 8: commit-per-ticker — a failure on the second ticker
+    keeps the first ticker's settlement close, degrades the rest to
+    drift, and never blocks reconcile."""
+    db_path = tmp_path / "test.db"
+
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            for tk in (TICKER, "KXSECOND-26JUL-T1"):
+                await insert_trade(db, TradeDecision(
+                    ticker=tk, action=TradeDecision.Action.OPEN,
+                    side="no", count=100, price=0.63,
+                ))
+                await upsert_position(db, Position(
+                    ticker=tk, title=tk, side="no", count=100,
+                    avg_price=0.63, market_price=0.705,
+                    cost_basis=63.0, market_value=70.5,
+                    unrealized_pnl=7.5, realized_pnl=0.0,
+                ))
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {
+        TICKER: _settlement_record(),
+        "KXSECOND-26JUL-T1": _settlement_record(
+            ticker="KXSECOND-26JUL-T1",
+        ),
+    })
+
+    from gimmes.store import queries as queries_module
+
+    real = queries_module.log_settlement_close
+    calls = {"n": 0}
+
+    async def _fail_second(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("write exploded")
+        return await real(*args, **kwargs)
+
+    monkeypatch.setattr(
+        queries_module, "log_settlement_close", _fail_second,
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "settlements lookup failed" in result.output
+
+    all_closes = _closes(db_path) + [
+        c for c in asyncio.run(_all_trades(db_path))
+        if c["ticker"] == "KXSECOND-26JUL-T1" and c["action"] == "close"
+    ]
+    first = [
+        c for c in all_closes
+        if c["ticker"] == TICKER and c["agent"] == "settlement"
+    ]
+    second_drift = [
+        c for c in all_closes
+        if c["ticker"] == "KXSECOND-26JUL-T1"
+        and c["agent"] == "reconcile"
+    ]
+    assert len(first) == 1  # commit-per-ticker held
+    assert len(second_drift) == 1  # degraded to drift
+
+
+def _all_trades(db_path: Path):  # type: ignore[no-untyped-def]
+    async def _r():
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await get_trades(db, limit=1000)
+        finally:
+            await db.close()
+
+    return _r()
+
+
+def test_positions_command_consumes_settlements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 item 6: the positions command's championship branch also
+    consumes settlements before its sync — a settled position gets a
+    settlement close, not a drift row (previously reconcile-only)."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {TICKER: _settlement_record()})
+
+    result = runner.invoke(app, ["positions"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "settlement"
+    assert closes[0]["price"] == 1.0
+
+
+def test_risk_check_consumes_settlements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 item 6: risk-check's daily-loss reading must see the
+    settlement loss, not a mark-priced drift row it excludes."""
+    from unittest.mock import AsyncMock
+
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record(market_result="yes")},  # NO loses
+    )
+    monkeypatch.setattr(
+        portfolio_module, "get_balance", AsyncMock(return_value=1000.0),
+    )
+
+    result = runner.invoke(app, ["risk-check"])
+    # risk-check may exit nonzero on breached limits — the settlement
+    # write is what we pin, not the verdict.
+    closes = _closes(db_path)
+    settlement = [c for c in closes if c["agent"] == "settlement"]
+    assert len(settlement) == 1, result.output
+    assert settlement[0]["price"] == 0.0
+
+
+def test_zero_settled_record_writes_evidence_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 review: record says ZERO settled (full off-ledger exit) —
+    a 0-count settlement evidence row protects the drift mark from
+    later repricing while booking nothing."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record(market_result="yes")
+         | {"no_count_fp": "0"}},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    closes = _closes(db_path)
+    evidence = [
+        c for c in closes
+        if c["agent"] == "settlement" and c["count"] == 0
+    ]
+    drift = [c for c in closes if c["agent"] == "reconcile"]
+    assert len(evidence) == 1
+    assert len(drift) == 1 and drift[0]["count"] == 100
+    # Repricing protection: the group has a settlement close, so the
+    # drift row keeps its mark even with the outcome known.
+    from gimmes.reporting.pnl import calculate_pnl
+
+    async def _trades():
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await get_trades(db, ticker=TICKER, limit=100)
+        finally:
+            await db.close()
+
+    summary = calculate_pnl(asyncio.run(_trades()))
+    # Drift mark kept: (0.705-0.63)*100, NOT (0.0-0.63)*100.
+    assert summary.gross_pnl == pytest.approx((0.705 - 0.63) * 100)
+
+
+def test_wildly_off_record_distrusted_to_ledger(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#684 review: a plain-contracts "100" misparses to 1 under the
+    centi heuristic — wildly off the residual → distrust, ledger
+    behavior, ERROR naming the possible scaling misparse."""
+    import logging
+
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record() | {"no_count_fp": "100"}},
+    )
+
+    with caplog.at_level(logging.ERROR, logger="gimmes"):
+        result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "possible fp-scaling misparse" in caplog.text
+
+    settlement = [
+        c for c in _closes(db_path) if c["agent"] == "settlement"
+    ]
+    assert settlement[0]["count"] == 100  # full ledger residual
+
+
+def test_unusable_fp_forms_fall_back_to_ledger(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nan/inf/fractional/negative/non-centi-integer forms all parse
+    to None → ledger-only behavior."""
+    for bad in ("nan", "inf", "100.5", "-6000", "60"):
+        db_path = tmp_path / f"test-{bad}.db"
+        _seed(db_path)
+        _wire_championship(monkeypatch, db_path)
+        _mock_settlements(
+            monkeypatch,
+            {TICKER: _settlement_record() | {"no_count_fp": bad}},
+        )
+        result = runner.invoke(app, ["reconcile"])
+        assert result.exit_code == 0, (bad, result.output)
+        settlement = [
+            c for c in _closes(db_path) if c["agent"] == "settlement"
+        ]
+        assert settlement[0]["count"] == 100, bad
+
+
+def test_second_run_does_not_double_settle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 review: the count clamp broke residual-based idempotency —
+    a retry after a clamped write must NOT book the off-ledger drift
+    remainder at settlement value."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record() | {"no_count_fp": "6000"}},
+    )
+
+    # Run 1: clamped settlement close (60) — then simulate the crash
+    # BEFORE sync by... running reconcile fully, then deleting the
+    # drift row and re-inserting the position (the retry world).
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+
+    async def _retry_world() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await db.conn.execute(
+                "DELETE FROM trades WHERE agent = 'reconcile'",
+            )
+            await db.conn.commit()
+            await upsert_position(db, Position(
+                ticker=TICKER, title="CPI April NO", side="no",
+                count=100, avg_price=0.63, market_price=0.705,
+                cost_basis=63.0, market_value=70.5,
+                unrealized_pnl=7.5, realized_pnl=0.0,
+            ))
+        finally:
+            await db.close()
+
+    asyncio.run(_retry_world())
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    settlement = [
+        c for c in _closes(db_path) if c["agent"] == "settlement"
+    ]
+    assert len(settlement) == 1  # no second settlement write
+    assert settlement[0]["count"] == 60
+
+
+def test_yes_side_record_keyed_by_side(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 review: the whole suite was NO-side — pin the side-keyed
+    count_fp lookup and win math for a YES position."""
+    db_path = tmp_path / "test.db"
+
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.OPEN,
+                side="yes", count=100, price=0.37,
+            ))
+            await upsert_position(db, Position(
+                ticker=TICKER, title="CPI April YES", side="yes",
+                count=100, avg_price=0.37, market_price=0.295,
+                cost_basis=37.0, market_value=29.5,
+                unrealized_pnl=-7.5, realized_pnl=0.0,
+            ))
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record(market_result="yes")
+         | {"yes_count_fp": "6000", "no_count_fp": "0"}},
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = _closes(db_path)
+    settlement = [
+        c for c in closes
+        if c["agent"] == "settlement" and c["count"] > 0
+    ]
+    assert len(settlement) == 1
+    assert settlement[0]["count"] == 60  # yes_count_fp, not no_
+    assert settlement[0]["price"] == 1.0  # YES won
+
+
+def test_open_position_never_consumed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 review: the fresh-exclusion — a position STILL OPEN on the
+    API must not be force-closed even when a (stale/re-listed)
+    settlement record exists for it."""
+    db_path = tmp_path / "test.db"
+    _seed(db_path)
+    _wire_championship(monkeypatch, db_path)
+    # The API still reports the position open.
+    still_open = Position(
+        ticker=TICKER, title="CPI April NO", side="no", count=100,
+        avg_price=0.63, market_price=0.71, cost_basis=63.0,
+        market_value=71.0, unrealized_pnl=8.0, realized_pnl=0.0,
+    )
+
+    async def _fresh(_client):  # type: ignore[no-untyped-def]
+        return [still_open]
+
+    monkeypatch.setattr(
+        portfolio_module, "get_all_positions", _fresh,
+    )
+    requested: list[set] = []
+
+    async def _spy(_client, tickers, **_kw):  # type: ignore[no-untyped-def]
+        requested.append(set(tickers))
+        return {TICKER: _settlement_record()}
+
+    monkeypatch.setattr(
+        portfolio_module, "get_settlements_for_tickers", _spy,
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert requested == []  # nothing removed → endpoint not asked
+    assert _closes(db_path) == []  # no close rows of any kind
+
+
+def test_mid_write_crash_rolls_back_open_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#684 review: the rollback is load-bearing — a failure AFTER a
+    partial commit-less write leaves an open implicit transaction
+    that would kill sync_positions' BEGIN IMMEDIATE."""
+    db_path = tmp_path / "test.db"
+
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            for tk in (TICKER, "KXSECOND-26JUL-T1"):
+                await insert_trade(db, TradeDecision(
+                    ticker=tk, action=TradeDecision.Action.OPEN,
+                    side="no", count=100, price=0.63,
+                ))
+                await upsert_position(db, Position(
+                    ticker=tk, title=tk, side="no", count=100,
+                    avg_price=0.63, market_price=0.705,
+                    cost_basis=63.0, market_value=70.5,
+                    unrealized_pnl=7.5, realized_pnl=0.0,
+                ))
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(monkeypatch, {
+        TICKER: _settlement_record(),
+        "KXSECOND-26JUL-T1": _settlement_record(
+            ticker="KXSECOND-26JUL-T1",
+        ),
+    })
+
+    from gimmes.store import queries as queries_module
+
+    real = queries_module.log_settlement_close
+    calls = {"n": 0}
+
+    async def _write_then_fail(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        row_id = await real(*args, **kwargs)
+        if calls["n"] >= 2:
+            # The write happened, uncommitted — the exception leaves
+            # an open implicit transaction.
+            raise RuntimeError("post-write explosion")
+        return row_id
+
+    monkeypatch.setattr(
+        queries_module, "log_settlement_close", _write_then_fail,
+    )
+
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "settlements lookup failed" in result.output
+
+    async def _rows():
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await get_trades(db, limit=1000)
+        finally:
+            await db.close()
+
+    rows = asyncio.run(_rows())
+    first_settlement = [
+        r for r in rows
+        if r["ticker"] == TICKER and r["agent"] == "settlement"
+    ]
+    second_settlement = [
+        r for r in rows
+        if r["ticker"] == "KXSECOND-26JUL-T1"
+        and r["agent"] == "settlement"
+    ]
+    second_drift = [
+        r for r in rows
+        if r["ticker"] == "KXSECOND-26JUL-T1"
+        and r["agent"] == "reconcile"
+    ]
+    assert len(first_settlement) == 1  # commit-per-ticker held
+    assert second_settlement == []  # uncommitted write rolled back
+    assert len(second_drift) == 1  # degraded to drift
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_reconcile_settlements.py
+++ b/tests/unit/test_cli_reconcile_settlements.py
@@ -638,6 +638,35 @@ def test_wildly_off_record_distrusted_to_ledger(
     assert settlement[0]["count"] == 100  # full ledger residual
 
 
+def test_record_above_residual_uses_ledger_generic_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """In-band record > residual (phantom/extra ledger closes, not an
+    off-ledger exit): the ledger residual stands, one settlement close
+    for the full residual, no drift row, generic warning."""
+    import logging
+
+    db_path = tmp_path / "test.db"
+    _seed(db_path)  # residual 100
+    _wire_championship(monkeypatch, db_path)
+    _mock_settlements(
+        monkeypatch,
+        {TICKER: _settlement_record() | {"no_count_fp": "15000"}},
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gimmes"):
+        result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "using the ledger (#684)" in caplog.text
+    assert "exited off-ledger" not in caplog.text
+
+    closes = _closes(db_path)
+    assert len(closes) == 1
+    assert closes[0]["agent"] == "settlement"
+    assert closes[0]["count"] == 100
+
+
 def test_unusable_fp_forms_fall_back_to_ledger(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -166,6 +166,12 @@ def _run_order_cli(
                 AsyncMock(return_value=[]),
             ),
             patch("gimmes.store.queries.sync_positions", AsyncMock()),
+            # #684: the settlements pre-consumption reads the old
+            # positions; empty -> no removed tickers -> no-op.
+            patch(
+                "gimmes.store.queries.get_positions",
+                AsyncMock(return_value=[]),
+            ),
         ])
         if championship_create_order is not None:
             patches.append(

--- a/tests/unit/test_paper_reconcile_drift.py
+++ b/tests/unit/test_paper_reconcile_drift.py
@@ -290,3 +290,72 @@ def test_cli_reconcile_paper_mode_writes_synthetic_close(  # type: ignore[no-unt
             await db.close()
 
     asyncio.run(_check())
+
+
+def test_paper_reconcile_never_touches_settlements_endpoint(  # type: ignore[no-untyped-def]
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """#684 item 8: settlements consumption is championship-only — a
+    paper-mode reconcile with a removed position must never call the
+    settlements endpoint (the paper broker maintains its own truth)."""
+    import asyncio
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+
+    from typer.testing import CliRunner
+
+    from gimmes import cli as cli_module
+    from gimmes.cli import app
+    from gimmes.kalshi import portfolio as portfolio_module
+
+    db_path = tmp_path / "test.db"
+
+    async def _setup() -> None:
+        db = Database(db_path)
+        await db.connect()
+        broker = PaperBroker(db, _paper_config().paper)
+        await broker.initialize()
+        await _seed_position(db, broker, ticker="KXCPI-26APR-T0.5")
+        # Remove from the broker WITHOUT settling — the reconcile
+        # will see it as removed and write a drift close.
+        await db.conn.execute(
+            "DELETE FROM paper_positions WHERE ticker = ?",
+            ("KXCPI-26APR-T0.5",),
+        )
+        await db.conn.commit()
+        await db.close()
+
+    asyncio.run(_setup())
+
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.is_championship = False
+    cfg.paper = _paper_config().paper
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    @asynccontextmanager
+    async def _ctx(_config):  # type: ignore[no-untyped-def]
+        db = Database(db_path)
+        await db.connect()
+        try:
+            broker = PaperBroker(db, _paper_config().paper)
+            await broker.initialize()
+            yield None, broker, db
+        finally:
+            await db.close()
+
+    monkeypatch.setattr(cli_module, "trading_context", _ctx)
+
+    calls: list[set] = []
+
+    async def _spy(_client, tickers, **_kw):  # type: ignore[no-untyped-def]
+        calls.append(set(tickers))
+        return {}
+
+    monkeypatch.setattr(
+        portfolio_module, "get_settlements_for_tickers", _spy,
+    )
+
+    result = CliRunner().invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert calls == []  # endpoint never touched in paper mode

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -687,3 +687,42 @@ class TestCorruptAnalyticsGuard:
             with pytest.raises(ValidationError):
                 await sync_positions(db, [])
         assert "recorded with zeroed analytics" not in caplog.text
+
+
+class TestDriftCountClamp:
+    """#684: the drift close covers the LEDGER residual, not
+    pos.count — a clamped settlement close (off-ledger exit) leaves a
+    remainder that must not be over-closed."""
+
+    async def test_drift_close_uses_residual_after_partial_settlement(
+        self, db,
+    ):
+        from gimmes.store.queries import log_settlement_close
+
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        # A clamped settlement close covered 6 of the 10 opens.
+        async with db.transaction():
+            await log_settlement_close(
+                db, ticker="KXCPI-26APR-T0.5", side="yes",
+                count=6, won=True,
+            )
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=0.42),
+        )
+
+        await sync_positions(db, [])
+
+        closes = [
+            t for t in await get_trades(db) if t["action"] == "close"
+        ]
+        drift = [c for c in closes if c["agent"] == "reconcile"]
+        assert len(drift) == 1
+        # 10 opened − 6 settled = 4, NOT pos.count 10.
+        assert drift[0]["count"] == 4
+
+    async def test_no_history_position_keeps_pos_count(self, db):
+        await upsert_position(db, _pos("NO-HISTORY", count=10, price=0.42))
+        await sync_positions(db, [])
+        [c] = await get_trades(db)
+        assert c["action"] == "close"
+        assert c["count"] == 10


### PR DESCRIPTION
## Summary

Resolves the #684 settlement-accounting follow-ups (deferred from #663). Items 1, 2, 6, 8 land; 3 and 5 are doc-accepted; item 4 folds into #690 (comment posted); item 7 filed as #698.

**1. Settled-count clamping with defensive parsing.** `_settle_removed_positions` now reads the settlement record's `{side}_count_fp` and clamps the settlement close to `min(ledger residual, record count)` — an off-ledger UI exit splits into a settlement close for what actually settled plus a drift close at the last mark for the untracked remainder (excluded from daily P&L per #622: correct accounting for an exit whose price we never saw). A companion residual clamp in `_log_reconcile_closes` makes the split sum instead of over-closing. Review hardening, given the fp scaling is live-unverified: the parser accepts only finite, whole, centi-aligned values (a plain-contracts `"60"` would otherwise misparse to 0.6 → 0); records wildly off the residual (outside ½–2×) are distrusted back to pure-ledger behavior with an **ERROR naming the possible fp-scaling misparse** rather than a warning that misdiagnoses itself; and a record proving **zero** contracts settled writes a 0-count settlement *evidence row* — it books nothing, sets `resolved_outcome`, and flips `group_has_settlement` so the full-residual drift close keeps its mark instead of being repriced to a settlement the position never rode to. `has_settlement_close` restores the crash-idempotency the clamp broke (a retry would otherwise book the drift remainder at settlement value).

**2. Now-stamping.** Reconcile settlement closes are stamped at consumption time, with the record's `settled_time` preserved in the rationale — a backdated stamp can land on a prior UTC date `get_daily_pnl` never re-reads, hiding the loss from the daily-loss trigger (proven by a test with a prior-date record). The #653 backfill deliberately keeps backdating. The win-netting asymmetry after a multi-day outage is documented.

**6. Consumption at every championship sync.** Review caught that wiring only reconcile/positions/risk-check left `validate` and both `order` syncs writing drift closes first — which permanently blocks the settlement write (residual exhausted) and hides the loss from the daily-loss reads those very commands gate on. `_consume_settlements_before_sync` now owns the read-ledger-then-consume invariant and runs before all five championship sync sites.

**8. Test hardening** including the review-caught gap: the rollback in the fallback handler was never exercised with an open transaction — a new mid-write crash test (write-then-raise on ticker 2) proves the first ticker's commit survives, the uncommitted write rolls back, and the remainder degrades to drift.

Closes #684

## Test plan

- `test_cli_reconcile_settlements.py` (+14): off-ledger 60/40 split with mark-kept drift, zero-settled evidence row with `calculate_pnl` repricing-protection proof, distrust bound, fp-form matrix (`nan`/`inf`/fractional/negative/non-centi), idempotent retry, YES-side keying, fresh-exclusion (open positions never consumed), mid-write rollback, commit-per-ticker crash isolation, positions/risk-check consumption, daily-P&L trigger proof.
- `test_sync_positions.py` (+2 drift-clamp), `test_paper_reconcile_drift.py` (+1 endpoint spy); harnesses updated for the new ledger read.
- Full suite: **1944 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB