### PR TITLE
Fix #686: lifecycle-aware outcomes, bounded analysis window, corrupt-position skip-and-escalate

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4079,12 +4079,30 @@ def lesson(
     config = load_config()
 
     async def _lesson() -> None:
+        from datetime import UTC, datetime, timedelta
+
         from rich.table import Table
 
         from gimmes.reporting.formatter import format_local_timestamp
         from gimmes.store.database import Database
         from gimmes.store.queries import get_recommendations, get_trades, insert_recommendation
         from gimmes.strategy.advisor import run_all_analyses
+
+        # #686: bound the analysis window so recommendations reflect
+        # trading under CURRENT configs (0 = all-time). The cutoff is
+        # applied post-pairing for open/close/size_up (the walk needs
+        # full history — an in-window close whose open predates the
+        # window must still price correctly) and at the DB for skips,
+        # which is where the row volume lives.
+        window_days = config.strategy.lesson_window_days
+        # Naive-UTC, second-truncated cutoff (#686 review): the SQL
+        # path (datetime()) and the advisor's string compares must
+        # window IDENTICALLY, and stored rows mix naive/aware forms.
+        cutoff = (
+            (datetime.now(UTC) - timedelta(days=window_days))
+            .replace(microsecond=0, tzinfo=None).isoformat()
+            if window_days > 0 else None
+        )
 
         async with Database(config.db_path) as db:
             # Fetch per-action so skip volume can't truncate older
@@ -4094,11 +4112,25 @@ def lesson(
             # analyze_missed_opportunities consumes them.
             all_trades: list[dict] = []  # type: ignore[type-arg]
             for action in ("open", "close", "size_up", "skip"):
-                all_trades += await get_trades(db, action=action, limit=100_000)
+                rows = await get_trades(
+                    db, action=action, limit=100_000,
+                    since=cutoff if action == "skip" else None,
+                )
+                if len(rows) == 100_000:
+                    # No silent caps (#686/#686 lesson).
+                    console.print(
+                        f"[yellow]Warning: fetch for action"
+                        f" {action!r} hit the 100000-row limit —"
+                        f" oldest rows dropped; analyses may be"
+                        f" incomplete[/yellow]"
+                    )
+                all_trades += rows
             # Candidates not yet used (scoring correlation needs #20)
             candidates: list[dict] = []  # type: ignore[type-arg]
 
-            recs = run_all_analyses(all_trades, candidates, config)
+            recs = run_all_analyses(
+                all_trades, candidates, config, since=cutoff,
+            )
 
             if not recs:
                 console.print(

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -205,6 +205,23 @@ class StrategyConfig(BaseModel):
             "max_val": 100,
         },
     )
+    lesson_window_days: int = Field(
+        default=90,
+        ge=0,
+        json_schema_extra={
+            "display_name": "Lesson Analysis Window (days)",
+            "description": (
+                "How far back `gimmes lesson` looks when computing"
+                " parameter recommendations. Bounds the analyses to"
+                " trading under CURRENT configs instead of all-time"
+                " history (#686). 0 = all-time. CAUTION: the analyses"
+                " have minimum-sample gates (20-30 closed trades) —"
+                " a window tighter than your recent trade volume"
+                " silently disables them, which is worse than"
+                " all-time."
+            ),
+        },
+    )
     side: Literal["yes", "no", "both"] = Field(
         default="no",
         json_schema_extra={

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from datetime import datetime
@@ -9,7 +10,11 @@ from typing import TypedDict
 
 from pydantic import ValidationError
 
-from gimmes.models.error import ErrorLogEntry
+from gimmes.models.error import (
+    ErrorCategory,
+    ErrorLogEntry,
+    ErrorSeverity,
+)
 from gimmes.models.portfolio import PortfolioSnapshot, Position
 from gimmes.models.recommendation import Recommendation
 from gimmes.models.trade import TradeDecision
@@ -84,6 +89,7 @@ async def get_trades(
     action: str | None = None,
     limit: int = 50,
     ticker_prefix: bool = False,
+    since: str | None = None,
 ) -> list[TradeRecord]:
     """Query trade decisions with optional filters.
 
@@ -91,7 +97,9 @@ async def get_trades(
     to prefix match (``ticker LIKE <bound_ticker> || '%'``) for the
     CLI's ``gimmes trades --ticker`` command — programmatic callers
     (P&L reports, etc.) default to exact match to preserve their
-    semantics.
+    semantics. ``since`` (#686) bounds rows to ``timestamp >=`` the
+    given ISO instant, normalized via ``datetime()`` so legacy
+    space-format rows compare correctly (the #680 lesson).
     """
     query = "SELECT * FROM trades WHERE 1=1"
     params: list[object] = []
@@ -105,6 +113,9 @@ async def get_trades(
     if action:
         query += " AND action = ?"
         params.append(action)
+    if since:
+        query += " AND datetime(timestamp) >= datetime(?)"
+        params.append(since)
 
     query += " ORDER BY timestamp DESC LIMIT ?"
     params.append(limit)
@@ -259,7 +270,7 @@ async def _log_reconcile_closes(
     removed: list[Position],
     *,
     exclude_ticker: str | None = None,
-) -> None:
+) -> list[ErrorLogEntry]:
     """Write a synthetic close trade + decision note for each removed
     position (#609 — reconcile-driven drift).
 
@@ -279,6 +290,7 @@ async def _log_reconcile_closes(
     transaction.
     """
     cycle = _cycle_from_env()
+    corrupt: list[ErrorLogEntry] = []
 
     for pos in removed:
         if exclude_ticker and pos.ticker == exclude_ticker:
@@ -335,12 +347,49 @@ async def _log_reconcile_closes(
         except ValidationError as exc:
             # #668: same guard as log_settlement_close — corrupt
             # analytics must not abort the sync_positions transaction
-            # every reconcile cycle. Retry before warning: count and
-            # close_price come from the positions row (unconstrained
-            # in the Position model), so a corrupt caller value
-            # re-raises out of the zeroed retry — fail-loud, with no
-            # lying "recorded" log line.
-            synth = _build({})
+            # every reconcile cycle. Retry before warning; if the
+            # zeroed retry ALSO raises, the culprit is a caller value
+            # (count/close_price from the positions row — the
+            # Position model is unconstrained, and bounding it is
+            # wrong: fee-inclusive avg_price legitimately exceeds
+            # 1.0). #686: skip-and-escalate that single position
+            # instead of aborting the whole sync — no lying row is
+            # written, the healthy positions still get their closes,
+            # and the error_log row is the triage breadcrumb
+            # (insert_error commits, so callers write it AFTER the
+            # transaction).
+            try:
+                synth = _build({})
+            except ValidationError as caller_exc:
+                fields = ", ".join(
+                    str(e.get("loc", ("?",))[0])
+                    for e in caller_exc.errors()
+                )
+                logging.getLogger(__name__).error(
+                    "corrupt position values for %s/%s (%s) — drift"
+                    " close SKIPPED for this position (#686)",
+                    pos.ticker, pos.side, fields,
+                )
+                corrupt.append(ErrorLogEntry(
+                    severity=ErrorSeverity.ERROR,
+                    category=ErrorCategory.DATA_INTEGRITY,
+                    error_code="corrupt_position_skipped",
+                    component="store.queries",
+                    agent="reconcile",
+                    cycle=cycle,
+                    message=(
+                        f"Corrupt position values for {pos.ticker}/"
+                        f"{pos.side} ({fields}) — reconcile drift"
+                        f" close skipped (#686)"
+                    ),
+                    context=json.dumps({
+                        "ticker": pos.ticker, "side": pos.side,
+                        "count": pos.count,
+                        "market_price": pos.market_price,
+                        "fields": fields,
+                    }),
+                ))
+                continue
             logging.getLogger(__name__).warning(
                 "entry analytics for %s/%s failed validation (%s) —"
                 " reconcile close recorded with zeroed analytics"
@@ -374,6 +423,7 @@ async def _log_reconcile_closes(
             " VALUES (?, ?, ?, ?, ?)",
             (pos.ticker, cycle, "reconcile", "decision", body),
         )
+    return corrupt
 
 
 def _cycle_from_env() -> int:
@@ -582,7 +632,13 @@ async def sync_positions(db: Database, positions: list[Position]) -> None:
     """
     async with db.transaction():
         removed = await _sync_positions_rows(db, positions)
-        await _log_reconcile_closes(db, removed)
+        corrupt = await _log_reconcile_closes(db, removed)
+    # #686: insert_error commits, so corrupt-position escalations are
+    # written AFTER the transaction — if the sync rolled back, the
+    # exception propagates first and no orphan error rows describe a
+    # sync that never committed.
+    for entry in corrupt:
+        await insert_error(db, entry)
 
 
 async def sync_positions_with_trade(
@@ -600,10 +656,14 @@ async def sync_positions_with_trade(
     """
     async with db.transaction():
         removed = await _sync_positions_rows(db, positions)
-        await _log_reconcile_closes(
+        corrupt = await _log_reconcile_closes(
             db, removed, exclude_ticker=trade.ticker,
         )
-        return await _insert_trade_row(db, trade)
+        row_id = await _insert_trade_row(db, trade)
+    # #686: see sync_positions — error escalations post-transaction.
+    for entry in corrupt:
+        await insert_error(db, entry)
+    return row_id
 
 
 async def _check_position_staleness(db: Database, table: str) -> None:

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -117,7 +117,10 @@ async def get_trades(
         query += " AND datetime(timestamp) >= datetime(?)"
         params.append(since)
 
-    query += " ORDER BY timestamp DESC LIMIT ?"
+    # space->T normalization + id tie-break (#661/#680 pattern):
+    # mixed legacy/ISO formats mis-order raw string comparison, and a
+    # wrong order here silently drops the NEWEST rows at the LIMIT.
+    query += " ORDER BY replace(timestamp, ' ', 'T') DESC, id DESC LIMIT ?"
     params.append(limit)
 
     cursor = await db.conn.execute(query, params)

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -59,7 +59,11 @@ def _pair_closes(
 
     paired: list[dict] = []  # type: ignore[type-arg]
     for (ticker, side), events in groups.items():
-        events.sort(key=lambda e: str(e.get("timestamp", "")))
+        # space->T normalization (#680 lesson): mixed formats within
+        # a group would walk closes before their opens.
+        events.sort(
+            key=lambda e: str(e.get("timestamp", "")).replace(" ", "T"),
+        )
         group_outcome = next(
             (
                 e.get("resolved_outcome")

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -12,12 +12,11 @@ from gimmes.models.recommendation import (
 )
 
 
-def _open_trades(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
-    """Filter to open trades only."""
-    return [t for t in trades if t.get("action") == "open"]
-
-
-def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
+def _pair_closes(
+    trades: list[dict],  # type: ignore[type-arg]
+    *,
+    since: str | None = None,
+) -> list[dict]:
     """Pair each close row to its opens and classify it won/lost.
 
     Close rows carry no reliable outcome signal of their own (#656):
@@ -40,10 +39,16 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
     backfill repricing corrects them retroactively.
 
     Returns one record per matched close: ``{ticker, side, timestamp,
-    won, realized_return, entry_score, entry_price}`` where
+    won, realized_return, entry_score, entry_price, lifecycle}`` where
     ``realized_return`` is per-contract (close price − avg cost) and
     entry fields come from the most recent open/size_up before the
-    close.
+    close. ``lifecycle`` (#686) indexes flat-book re-entries: an entry
+    arriving with the book at zero after prior activity starts a new
+    lifecycle, so a later winning re-trade is never ratcheted to a
+    loss by an earlier lifecycle. ``since`` (ISO timestamp) drops
+    records whose CLOSE predates it AFTER the walk — the pairing
+    always sees full history so an in-window close whose open predates
+    the window still prices correctly.
     """
     groups: dict[tuple[str, str], list[dict]] = {}  # type: ignore[type-arg]
     for t in trades:
@@ -75,6 +80,14 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
         avg_cost = 0.0
         entry_score = 0.0
         entry_price = 0.0
+        lifecycle = 0
+        had_entry = False
+        # #686 review: the lifecycle's OPENING entry, snapshotted at
+        # the increment point — per-close entry_score/entry_price are
+        # "most recent entry" (edge-decay/Kelly semantics) and would
+        # misattribute sized-up positions to the size_up's bucket.
+        lc_entry_score = 0.0
+        lc_entry_price = 0.0
         for e in events:
             action = e.get("action")
             count = int(e.get("count", 0) or 0)
@@ -82,6 +95,15 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
             if count <= 0:
                 continue
             if action in ("open", "size_up"):
+                # #686: an entry onto a FLAT book after prior activity
+                # is a re-entry — a new lifecycle (a size_up onto a
+                # flat book is functionally an entry too).
+                if remaining == 0:
+                    if had_entry:
+                        lifecycle += 1
+                    lc_entry_score = float(e.get("gimme_score", 0) or 0)
+                    lc_entry_price = price
+                had_entry = True
                 total = remaining + count
                 avg_cost = (
                     (avg_cost * remaining + price * count) / total
@@ -117,25 +139,54 @@ def _pair_closes(trades: list[dict]) -> list[dict]:  # type: ignore[type-arg]
                 "realized_return": realized,
                 "entry_score": entry_score,
                 "entry_price": entry_price,
+                "lifecycle": lifecycle,
+                "lifecycle_entry_score": lc_entry_score,
+                "lifecycle_entry_price": lc_entry_price,
             })
+    if since is not None:
+        # #686 review: window whole LIFECYCLES by their last close —
+        # per-tranche filtering would strip a straddling lifecycle's
+        # early losing tranches from the any-loss AND, biasing win
+        # rates UP in exactly the loosening direction #668 guards.
+        # space->T normalization (#680 lesson) for legacy rows.
+        last_close: dict[tuple[str, str, int], str] = {}
+        for r in paired:
+            key = (r["ticker"], r["side"], r["lifecycle"])
+            ts = str(r["timestamp"]).replace(" ", "T")
+            if ts > last_close.get(key, ""):
+                last_close[key] = ts
+        paired = [
+            r for r in paired
+            if last_close[(r["ticker"], r["side"], r["lifecycle"])] >= since
+        ]
     return paired
 
 
-def _outcomes_by_position(
+def _lifecycle_outcomes(
     paired: list[dict],  # type: ignore[type-arg]
-) -> dict[tuple[str, str], bool]:
-    """Map ``(ticker, side)`` -> ``won`` from paired closes (#668).
+) -> dict[tuple[str, str, int], dict]:  # type: ignore[type-arg]
+    """Aggregate paired closes per ``(ticker, side, lifecycle)`` (#686).
 
-    Keyed by side so both sides of a ticker stay distinct, and
-    multiple partial closes aggregate any-loss = loss: a position that
-    realized a loss on any tranche was not a clean win — bias down.
-    When resolution is known every tranche carries the same ``won``,
-    so aggregation only bites on PnL-fallback partials.
+    ``won`` ANDs across the lifecycle's tranches (the #668 any-loss
+    rule, now scoped WITHIN a lifecycle so an old losing round trip
+    can never ratchet a later winning re-entry to a loss). Entry
+    fields come from the lifecycle's first paired close — records are
+    appended in timestamp order per group. Consuming these instead of
+    raw open rows also fixes the still-open inheritance bug: a
+    currently-open re-entry has no paired close and simply isn't
+    scored yet.
     """
-    outcomes: dict[tuple[str, str], bool] = {}
+    outcomes: dict[tuple[str, str, int], dict] = {}  # type: ignore[type-arg]
     for r in paired:
-        key = (r["ticker"], r["side"])
-        outcomes[key] = outcomes.get(key, True) and r["won"]
+        key = (r["ticker"], r["side"], r["lifecycle"])
+        if key in outcomes:
+            outcomes[key]["won"] = outcomes[key]["won"] and r["won"]
+        else:
+            outcomes[key] = {
+                "won": r["won"],
+                "entry_score": r["lifecycle_entry_score"],
+                "entry_price": r["lifecycle_entry_price"],
+            }
     return outcomes
 
 
@@ -156,29 +207,28 @@ MIN_TRADES_THRESHOLD = 30
 def analyze_threshold_sweep(
     trades: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
+    *,
+    since: str | None = None,
 ) -> Recommendation | None:
     """Simulate different gimme_threshold values against historical trades.
 
     Returns a recommendation if a better threshold is found, else None.
     """
-    opens = _open_trades(trades)
-    paired = _pair_closes(trades)
+    paired = _pair_closes(trades, since=since)
     if len(paired) < MIN_TRADES_THRESHOLD:
         return None
 
-    # Build outcome map. Resolution-first via _pair_closes —
-    # close-row edge is an entry artifact, not an outcome (#656).
-    # Any-loss aggregation (#668) is conservative here because the
-    # sweep only loosens on win-rate improvement.
-    outcomes = _outcomes_by_position(paired)
-
-    # Build score map from opens
-    scored: list[dict] = []  # type: ignore[type-arg]
-    for t in opens:
-        key = (t.get("ticker", ""), t.get("side", "yes"))
-        score = t.get("gimme_score", 0)
-        if key in outcomes:
-            scored.append({"score": score, "won": outcomes[key]})
+    # One scored entry per LIFECYCLE (#686), consumed directly from
+    # the paired records (entry_score rides them) — raw open rows are
+    # no longer iterated, which also drops the still-open inheritance
+    # bug. Resolution-first via _pair_closes (#656); any-loss within
+    # a lifecycle (#668) stays conservative because the sweep only
+    # loosens on win-rate improvement.
+    outcomes = _lifecycle_outcomes(paired)
+    scored: list[dict] = [  # type: ignore[type-arg]
+        {"score": o["entry_score"], "won": o["won"]}
+        for o in outcomes.values()
+    ]
 
     if len(scored) < MIN_TRADES_THRESHOLD:
         return None
@@ -254,6 +304,8 @@ MIN_TRADES_EDGE_DECAY = 30
 def analyze_edge_decay(
     trades: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
+    *,
+    since: str | None = None,
 ) -> Recommendation | None:
     """Detect if realized edge is shrinking over time.
 
@@ -262,7 +314,7 @@ def analyze_edge_decay(
     artifact (zeroed on synthetic closes, min_edge-gated otherwise) and
     cannot express realized decay (#656).
     """
-    paired = _pair_closes(trades)
+    paired = _pair_closes(trades, since=since)
     if len(paired) < MIN_TRADES_EDGE_DECAY:
         return None
 
@@ -358,6 +410,8 @@ MIN_TRADES_KELLY = 20
 def analyze_kelly_optimization(
     trades: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
+    *,
+    since: str | None = None,
 ) -> Recommendation | None:
     """Compute optimal Kelly fraction from realized win rate and payoffs.
 
@@ -365,7 +419,7 @@ def analyze_kelly_optimization(
     returns via _pair_closes — entry edge is identical on both legs of
     a trade and would corrupt the payoff ratio (#656).
     """
-    paired = _pair_closes(trades)
+    paired = _pair_closes(trades, since=since)
     if len(paired) < MIN_TRADES_KELLY:
         return None
 
@@ -437,25 +491,24 @@ MIN_TRADES_SCANNER = 30
 def analyze_scanner_parameters(
     trades: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
+    *,
+    since: str | None = None,
 ) -> Recommendation | None:
     """Analyze price distribution of winners vs losers for price range tuning."""
-    opens = _open_trades(trades)
-    paired = _pair_closes(trades)
+    paired = _pair_closes(trades, since=since)
     if len(paired) < MIN_TRADES_SCANNER:
         return None
 
-    # Build outcome map — resolution-first via _pair_closes (#656),
-    # with any-loss aggregation for partial closes (#668).
-    outcomes = _outcomes_by_position(paired)
-
-    # Get prices from opens
+    # One priced entry per LIFECYCLE (#686), from the paired records'
+    # entry_price — resolution-first via _pair_closes (#656),
+    # any-loss within a lifecycle (#668).
+    outcomes = _lifecycle_outcomes(paired)
     winner_prices: list[float] = []
     loser_prices: list[float] = []
-    for t in opens:
-        key = (t.get("ticker", ""), t.get("side", "yes"))
-        price = t.get("price", 0)
-        if key in outcomes and price > 0:
-            if outcomes[key]:
+    for o in outcomes.values():
+        price = o["entry_price"]
+        if price > 0:
+            if o["won"]:
                 winner_prices.append(price)
             else:
                 loser_prices.append(price)
@@ -517,6 +570,8 @@ MIN_SKIPS_AUDIT = 20
 def analyze_missed_opportunities(
     trades: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
+    *,
+    since: str | None = None,
 ) -> Recommendation | None:
     """Check skipped candidates that resolved favorably.
 
@@ -534,6 +589,13 @@ def analyze_missed_opportunities(
     # exclusion counts are surfaced in supporting_data so an audit
     # reconciles against the raw table.
     all_skips = [t for t in trades if t.get("action") == "skip"]
+    if since is not None:
+        # #686: self-consistent windowing when called directly —
+        # space->T normalization per the #680 lesson.
+        all_skips = [
+            t for t in all_skips
+            if str(t.get("timestamp", "")).replace(" ", "T") >= since
+        ]
     entry_skips = [
         t for t in all_skips
         if t.get("reason", "") not in NON_ENTRY_SKIP_REASONS
@@ -605,17 +667,28 @@ def run_all_analyses(
     trades: list[dict],  # type: ignore[type-arg]
     candidates: list[dict],  # type: ignore[type-arg]
     config: GimmesConfig,
+    *,
+    since: str | None = None,
 ) -> list[Recommendation]:
-    """Run all applicable analyses and return recommendations."""
+    """Run all applicable analyses and return recommendations.
+
+    ``since`` (#686) bounds the analysis window: paired closes and
+    skips before the cutoff are excluded so recommendations reflect
+    trading under CURRENT configs, not superseded ones. The pairing
+    walk itself always sees full history (an in-window close whose
+    open predates the window still prices correctly).
+    """
     results: list[Recommendation] = []
 
     analyses = [
-        lambda: analyze_threshold_sweep(trades, config),
-        lambda: analyze_edge_decay(trades, config),
+        lambda: analyze_threshold_sweep(trades, config, since=since),
+        lambda: analyze_edge_decay(trades, config, since=since),
         lambda: analyze_scoring_correlation(trades, candidates, config),
-        lambda: analyze_kelly_optimization(trades, config),
-        lambda: analyze_scanner_parameters(trades, config),
-        lambda: analyze_missed_opportunities(trades, config),
+        lambda: analyze_kelly_optimization(trades, config, since=since),
+        lambda: analyze_scanner_parameters(trades, config, since=since),
+        lambda: analyze_missed_opportunities(
+            trades, config, since=since,
+        ),
     ]
 
     for analysis in analyses:

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -855,3 +855,298 @@ def test_non_entry_reasons_single_source_of_truth() -> None:
 
     assert cli._NON_ENTRY_REASONS is NON_ENTRY_SKIP_REASONS
     assert NON_ENTRY_SKIP_REASONS <= cli._SKIP_REASONS
+
+
+class TestLifecycleOutcomes:
+    """#686: flat-book re-entries are separate lifecycles — an old
+    losing round trip can never ratchet a later winning re-entry to a
+    loss, and a still-open re-entry inherits nothing."""
+
+    def _lifecycle_trades(self) -> list[dict]:
+        """Lifecycle 0: open/close at a loss. Lifecycle 1 (same
+        ticker/side, flat book): open/close at a win."""
+        return [
+            {
+                "ticker": "KXRETRY", "action": "open", "side": "no",
+                "count": 10, "price": 0.60, "gimme_score": 85.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-03-01T10:00:00",
+            },
+            {
+                "ticker": "KXRETRY", "action": "close", "side": "no",
+                "count": 10, "price": 0.30, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T18:00:00",
+            },
+            {
+                "ticker": "KXRETRY", "action": "open", "side": "no",
+                "count": 10, "price": 0.55, "gimme_score": 85.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-04-01T10:00:00",
+            },
+            {
+                "ticker": "KXRETRY", "action": "close", "side": "no",
+                "count": 10, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-04-01T18:00:00",
+            },
+        ]
+
+    def test_pair_closes_emits_lifecycle_indices(self) -> None:
+        paired = _pair_closes(self._lifecycle_trades())
+        assert [r["lifecycle"] for r in paired] == [0, 1]
+        assert [r["won"] for r in paired] == [False, True]
+
+    def test_partial_close_does_not_increment_lifecycle(self) -> None:
+        """A partial close (book never flat) then more entries stays
+        one lifecycle."""
+        trades = [
+            {
+                "ticker": "KXP", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-03-01T10:00:00",
+            },
+            {
+                "ticker": "KXP", "action": "close", "side": "no",
+                "count": 4, "price": 0.70, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T12:00:00",
+            },
+            {
+                "ticker": "KXP", "action": "size_up", "side": "no",
+                "count": 5, "price": 0.55, "gimme_score": 82.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-03-01T14:00:00",
+            },
+            {
+                "ticker": "KXP", "action": "close", "side": "no",
+                "count": 11, "price": 0.80, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T18:00:00",
+            },
+        ]
+        paired = _pair_closes(trades)
+        assert [r["lifecycle"] for r in paired] == [0, 0]
+
+    def test_threshold_sweep_counts_lifecycles_independently(
+        self, config: GimmesConfig,
+    ) -> None:
+        """The ratchet fix: lifecycle 0 loses, lifecycle 1 wins — the
+        sweep must count one loss AND one win (pre-#686: two losses)."""
+        trades = _make_trades(
+            n_wins=25, n_losses=5, win_score=70, loss_score=85,
+        ) + self._lifecycle_trades()
+        rec = analyze_threshold_sweep(trades, config)
+        assert rec is not None
+        sweep = {
+            row["threshold"]: row
+            for row in json.loads(rec.supporting_data)
+        }
+        # At threshold 85: 5 baseline losses + KXRETRY's TWO
+        # lifecycles (one loss, one win).
+        assert sweep[85]["trades_taken"] == 7
+        assert sweep[85]["wins"] == 1
+
+    def test_still_open_reentry_inherits_nothing(
+        self, config: GimmesConfig,
+    ) -> None:
+        """The inheritance fix: a closed losing lifecycle plus a
+        currently-open re-entry (no close) yields exactly ONE scored
+        entry — the dangling open contributes nothing."""
+        trades = _make_trades(
+            n_wins=25, n_losses=5, win_score=70, loss_score=85,
+        ) + self._lifecycle_trades()[:2] + [{
+            "ticker": "KXRETRY", "action": "open", "side": "no",
+            "count": 10, "price": 0.55, "gimme_score": 85.0,
+            "edge": 0.1, "agent": "closer",
+            "timestamp": "2026-05-01T10:00:00",  # still open
+        }]
+        rec = analyze_threshold_sweep(trades, config)
+        assert rec is not None
+        sweep = {
+            row["threshold"]: row
+            for row in json.loads(rec.supporting_data)
+        }
+        # 5 baseline losses + ONE closed KXRETRY lifecycle; the open
+        # re-entry is not scored (pre-#686 it inherited the loss).
+        assert sweep[85]["trades_taken"] == 6
+        assert sweep[85]["wins"] == 0
+
+    def test_scanner_counts_lifecycles_independently(
+        self, config: GimmesConfig,
+    ) -> None:
+        trades = _make_trades(
+            n_wins=20, n_losses=15, win_price=0.72, loss_price=0.58,
+        ) + self._lifecycle_trades()
+        rec = analyze_scanner_parameters(trades, config)
+        assert rec is not None
+        # 20 winners + lifecycle 1's win; 15 losers + lifecycle 0's
+        # loss.
+        assert "n=21" in rec.rationale
+        assert "n=16" in rec.rationale
+
+
+class TestAnalysisWindow:
+    """#686: the since cutoff drops paired closes and skips before it,
+    post-pairing — an in-window close whose open predates the window
+    still prices correctly."""
+
+    def test_pair_closes_since_filters_post_walk(self) -> None:
+        trades = [
+            {
+                "ticker": "KXW", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-01-01T10:00:00",  # out of window
+            },
+            {
+                "ticker": "KXW", "action": "close", "side": "no",
+                "count": 10, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-06-01T10:00:00",  # in window
+            },
+        ]
+        paired = _pair_closes(trades, since="2026-05-01T00:00:00")
+        assert len(paired) == 1
+        # Anti-orphan: priced against the OUT-OF-WINDOW open.
+        assert paired[0]["realized_return"] == pytest.approx(0.40)
+        assert paired[0]["entry_price"] == pytest.approx(0.50)
+
+    def test_out_of_window_closes_dropped(self) -> None:
+        trades = [
+            {
+                "ticker": "KXOLD", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-01-01T10:00:00",
+            },
+            {
+                "ticker": "KXOLD", "action": "close", "side": "no",
+                "count": 10, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-01-02T10:00:00",
+            },
+        ]
+        assert _pair_closes(trades, since="2026-05-01T00:00:00") == []
+        assert len(_pair_closes(trades)) == 1  # default: all-time
+
+    def test_missed_opportunities_windows_skips(
+        self, config: GimmesConfig,
+    ) -> None:
+        """Skips before the cutoff drop out of the FNR denominator."""
+        recent = analyze_missed_opportunities(
+            TestMissedOpportunities._real_skips(), config,
+        )
+        windowed = analyze_missed_opportunities(
+            TestMissedOpportunities._real_skips(), config,
+            since="2099-01-01T00:00:00",
+        )
+        assert recent is not None
+        assert windowed is None  # everything out of window → gated
+
+
+class TestLifecycleEntryAttribution:
+    """#686 review: the sweep/scanner bucket a lifecycle by its
+    OPENING entry, not the most recent size_up before the close."""
+
+    def test_lifecycle_entry_fields_are_the_opening_entry(self) -> None:
+        from gimmes.strategy.advisor import _lifecycle_outcomes
+
+        trades = [
+            {
+                "ticker": "KXS", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-03-01T10:00:00",
+            },
+            {
+                "ticker": "KXS", "action": "size_up", "side": "no",
+                "count": 5, "price": 0.55, "gimme_score": 92.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-03-01T12:00:00",
+            },
+            {
+                "ticker": "KXS", "action": "close", "side": "no",
+                "count": 15, "price": 0.80, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-03-01T18:00:00",
+            },
+        ]
+        outcomes = _lifecycle_outcomes(_pair_closes(trades))
+        o = outcomes[("KXS", "no", 0)]
+        # The OPEN's score/price, not the size_up's (92.0/0.55).
+        assert o["entry_score"] == 80.0
+        assert o["entry_price"] == pytest.approx(0.50)
+
+    def test_straddling_lifecycle_windows_whole_not_tranches(
+        self,
+    ) -> None:
+        """#686 review: a lifecycle with a pre-cutoff losing tranche
+        and an in-window winning final close must keep BOTH tranches
+        (whole-lifecycle windowing) — per-tranche filtering would
+        strip the loss from the any-loss AND, biasing win rates UP."""
+        from gimmes.strategy.advisor import _lifecycle_outcomes
+
+        trades = [
+            {
+                "ticker": "KXSTR", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-01-01T10:00:00",
+            },
+            {  # losing partial, BEFORE the cutoff
+                "ticker": "KXSTR", "action": "close", "side": "no",
+                "count": 5, "price": 0.20, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-01-02T10:00:00",
+            },
+            {  # winning final close, AFTER the cutoff
+                "ticker": "KXSTR", "action": "close", "side": "no",
+                "count": 5, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-06-01T10:00:00",
+            },
+        ]
+        paired = _pair_closes(trades, since="2026-05-01T00:00:00")
+        assert len(paired) == 2  # whole lifecycle survives
+        outcomes = _lifecycle_outcomes(paired)
+        assert outcomes[("KXSTR", "no", 0)]["won"] is False  # any-loss
+
+    def test_space_format_close_retained_by_window(self) -> None:
+        """#680 lesson applied to the window filter: legacy
+        space-format timestamps normalize before comparison."""
+        trades = [
+            {
+                "ticker": "KXSP", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-05-20T10:00:00",
+            },
+            {
+                "ticker": "KXSP", "action": "close", "side": "no",
+                "count": 10, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-06-01 10:00:00",  # legacy format
+            },
+        ]
+        paired = _pair_closes(trades, since="2026-05-01T00:00:00")
+        assert len(paired) == 1
+
+    def test_run_all_analyses_threads_since(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#686: a far-future cutoff must yield NO recommendations
+        (everything windowed out) while the unwindowed call
+        recommends — pins the since threading through every lambda."""
+        from gimmes.strategy.advisor import run_all_analyses
+
+        trades = _make_trades(
+            n_wins=25, n_losses=5, win_score=70, loss_score=85,
+        )
+        unwindowed = run_all_analyses(trades, [], config)
+        windowed = run_all_analyses(
+            trades, [], config, since="2099-01-01T00:00:00",
+        )
+        assert unwindowed  # sanity: data produces recommendations
+        assert windowed == []

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -1113,6 +1113,29 @@ class TestLifecycleEntryAttribution:
         outcomes = _lifecycle_outcomes(paired)
         assert outcomes[("KXSTR", "no", 0)]["won"] is False  # any-loss
 
+    def test_same_day_mixed_formats_pair_correctly(self) -> None:
+        """PR #700 review: the pairing sort normalizes space->T — a
+        same-day legacy close after an ISO open must walk AFTER it
+        (raw string sort puts ' 10:00' before 'T09:00', orphaning the
+        close and silently shrinking the analysis sample)."""
+        trades = [
+            {
+                "ticker": "KXMIX", "action": "open", "side": "no",
+                "count": 10, "price": 0.50, "gimme_score": 80.0,
+                "edge": 0.1, "agent": "closer",
+                "timestamp": "2026-06-01T09:00:00",
+            },
+            {
+                "ticker": "KXMIX", "action": "close", "side": "no",
+                "count": 10, "price": 0.90, "gimme_score": 0.0,
+                "edge": 0.0, "agent": "closer",
+                "timestamp": "2026-06-01 10:00:00",  # legacy format
+            },
+        ]
+        paired = _pair_closes(trades)
+        assert len(paired) == 1
+        assert paired[0]["realized_return"] == pytest.approx(0.40)
+
     def test_space_format_close_retained_by_window(self) -> None:
         """#680 lesson applied to the window filter: legacy
         space-format timestamps normalize before comparison."""

--- a/tests/unit/test_lesson_window.py
+++ b/tests/unit/test_lesson_window.py
@@ -13,7 +13,6 @@ each action under its own generous limit; `lesson` additionally keeps
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from typer.testing import CliRunner
@@ -25,11 +24,22 @@ from gimmes.store import queries as queries_module
 runner = CliRunner()
 
 
+def _real_config(tmp_path: Path):  # type: ignore[no-untyped-def]
+    from gimmes.config import GimmesConfig, Mode
+
+    cfg = GimmesConfig(mode=Mode.DRIVING_RANGE)
+    # db_path is derived — override via object.__setattr__-safe route
+    cfg2 = cfg.model_copy(update={"db_path": tmp_path / "test.db"})
+    return cfg2
+
+
 def test_lesson_fetches_per_action_with_skips(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cfg = MagicMock()
-    cfg.db_path = tmp_path / "test.db"
+    # Real config (#686 review): a MagicMock fabricates attribute
+    # paths — the lesson_window_days placement bug was invisible
+    # until the real model was exercised.
+    cfg = _real_config(tmp_path)
     monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
 
     calls: list[dict] = []
@@ -49,6 +59,14 @@ def test_lesson_fetches_per_action_with_skips(
     # orphan old opens; no un-scoped legacy fetch remains.
     assert all(c.get("limit") == 100_000 for c in calls)
     assert not any(c.get("action") is None for c in calls)
+    # #686: the window bounds SKIPS at the DB (volume lives there);
+    # open/close/size_up stay unbounded — the pairing walk needs full
+    # history, the cutoff applies post-pairing.
+    for c in calls:
+        if c.get("action") == "skip":
+            assert c.get("since") is not None
+        else:
+            assert c.get("since") is None
 
 
 def test_lesson_feeds_all_actions_to_analyses(
@@ -59,8 +77,7 @@ def test_lesson_feeds_all_actions_to_analyses(
     analyze_missed_opportunities."""
     from gimmes.strategy import advisor as advisor_module
 
-    cfg = MagicMock()
-    cfg.db_path = tmp_path / "test.db"
+    cfg = _real_config(tmp_path)
     monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
 
     async def _sentinels(_db, **kwargs):  # type: ignore[no-untyped-def]
@@ -70,8 +87,11 @@ def test_lesson_feeds_all_actions_to_analyses(
 
     captured: list[list] = []
 
-    def _capture(trades, _candidates, _config):  # type: ignore[no-untyped-def]
+    windows: list = []
+
+    def _capture(trades, _candidates, _config, **kwargs):  # type: ignore[no-untyped-def]
         captured.append(trades)
+        windows.append(kwargs.get("since"))
         return []
 
     monkeypatch.setattr(advisor_module, "run_all_analyses", _capture)
@@ -81,3 +101,51 @@ def test_lesson_feeds_all_actions_to_analyses(
     assert len(captured) == 1
     fed_actions = {t["action"] for t in captured[0]}
     assert fed_actions == {"open", "close", "size_up", "skip"}
+    # #686: the window cutoff must actually reach the analyses.
+    assert windows == [None] or windows[0] is not None
+    assert windows[0] is not None and "T" in str(windows[0])
+
+
+def test_zero_window_means_all_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#686: lesson_window_days = 0 disables the window — every fetch
+    unbounded (the documented escape hatch for sparse deployments)."""
+    cfg = _real_config(tmp_path)
+    cfg.strategy.lesson_window_days = 0
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    calls: list[dict] = []
+
+    async def _spy(_db, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(kwargs)
+        return []
+
+    monkeypatch.setattr(queries_module, "get_trades", _spy)
+
+    result = runner.invoke(app, ["lesson"])
+    assert result.exit_code == 0, result.output
+    assert all(c.get("since") is None for c in calls)
+
+
+def test_truncation_warning_at_exact_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#686: a fetch returning exactly the 100k cap warns (no silent
+    caps); one row under stays silent."""
+    cfg = _real_config(tmp_path)
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    async def _spy(_db, **kwargs):  # type: ignore[no-untyped-def]
+        n = 100_000 if kwargs.get("action") == "skip" else 99_999
+        return [
+            {"action": kwargs["action"], "ticker": "X",
+             "timestamp": "2026-06-01T10:00:00"}
+        ] * n
+
+    monkeypatch.setattr(queries_module, "get_trades", _spy)
+
+    result = runner.invoke(app, ["lesson"])
+    assert result.exit_code == 0, result.output
+    assert result.output.count("hit the 100000-row limit") == 1
+    assert "'skip'" in result.output

--- a/tests/unit/test_lesson_window.py
+++ b/tests/unit/test_lesson_window.py
@@ -101,9 +101,11 @@ def test_lesson_feeds_all_actions_to_analyses(
     assert len(captured) == 1
     fed_actions = {t["action"] for t in captured[0]}
     assert fed_actions == {"open", "close", "size_up", "skip"}
-    # #686: the window cutoff must actually reach the analyses.
-    assert windows == [None] or windows[0] is not None
-    assert windows[0] is not None and "T" in str(windows[0])
+    # #686: the window cutoff must actually reach the analyses —
+    # default config implies a non-None ISO cutoff.
+    assert len(windows) == 1
+    assert windows[0] is not None
+    assert "T" in str(windows[0])
 
 
 def test_zero_window_means_all_time(

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -767,8 +767,6 @@ class TestGetTradesSince:
     space-format rows window correctly against the CLI's ISO cutoff."""
 
     async def test_since_filters_mixed_formats(self, db):
-        from datetime import UTC, datetime, timedelta
-
         from gimmes.store.queries import get_trades, insert_trade
 
         old = _open_trade("KXOLD-26JAN-T1", ts="2026-01-01T10:00:00+00:00")
@@ -788,10 +786,9 @@ class TestGetTradesSince:
         )
         await db.conn.commit()
 
-        cutoff = (
-            (datetime.now(UTC) - timedelta(days=90))
-            .replace(microsecond=0, tzinfo=None).isoformat()
-        )
+        # Fixed cutoff between the hard-coded rows — a now-relative
+        # cutoff would time-bomb the test (PR #700 review).
+        cutoff = "2026-06-01T00:00:00"
         rows = await get_trades(db, since=cutoff, limit=100)
         tickers = {r["ticker"] for r in rows}
         assert tickers == {"KXNEW-26JUL-T1", "KXSPACE-26JUL-T1"}

--- a/tests/unit/test_sync_positions.py
+++ b/tests/unit/test_sync_positions.py
@@ -667,26 +667,60 @@ class TestCorruptAnalyticsGuard:
         assert closes[0]["gimme_score"] == 0.0
         assert closes[0]["model_probability"] == 0.0
 
-    async def test_corrupt_caller_value_still_fails_loud(
+    async def test_corrupt_caller_value_skips_and_escalates(
         self, db, caplog,
     ):
-        """A corrupt POSITIONS row (mark > 1.0) is not an analytics
-        problem — the zeroed retry re-raises, and the guard must not
-        log a 'recorded with zeroed analytics' line for a row that was
-        rolled back."""
+        """#686 (rewrites the #668 fail-loud pin): a corrupt POSITIONS
+        row (mark > 1.0) no longer aborts the whole sync — the drift
+        close is SKIPPED with an ERROR log and an error_log row, no
+        lying 'recorded' line, and the sync commits."""
         import logging
 
-        from pydantic import ValidationError
+        from gimmes.store.queries import get_errors
 
         await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
         await upsert_position(
             db, _pos("KXCPI-26APR-T0.5", count=10, price=1.7),
         )
 
-        with caplog.at_level(logging.WARNING, logger="gimmes.store.queries"):
-            with pytest.raises(ValidationError):
-                await sync_positions(db, [])
+        with caplog.at_level(logging.ERROR, logger="gimmes.store.queries"):
+            await sync_positions(db, [])  # must NOT raise
         assert "recorded with zeroed analytics" not in caplog.text
+        assert "drift close SKIPPED" in caplog.text
+
+        # No lying close row for the corrupt ticker.
+        closes = [
+            t for t in await get_trades(db) if t["action"] == "close"
+        ]
+        assert closes == []
+        # The escalation is durable.
+        errors = await get_errors(db, limit=10)
+        assert any(
+            e["error_code"] == "corrupt_position_skipped"
+            for e in errors
+        )
+
+    async def test_corrupt_position_does_not_block_healthy_ones(
+        self, db,
+    ):
+        """#686: the healthy removed position still gets its drift
+        close when a corrupt sibling is skipped."""
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=1.7),  # corrupt
+        )
+        await insert_trade(db, _open_trade("KXHEALTHY-26APR-T1"))
+        await upsert_position(
+            db, _pos("KXHEALTHY-26APR-T1", count=10, price=0.42),
+        )
+
+        await sync_positions(db, [])
+
+        closes = [
+            t for t in await get_trades(db) if t["action"] == "close"
+        ]
+        assert len(closes) == 1
+        assert closes[0]["ticker"] == "KXHEALTHY-26APR-T1"
 
 
 class TestDriftCountClamp:
@@ -726,3 +760,97 @@ class TestDriftCountClamp:
         [c] = await get_trades(db)
         assert c["action"] == "close"
         assert c["count"] == 10
+
+
+class TestGetTradesSince:
+    """#686: the since filter compares via datetime() so legacy
+    space-format rows window correctly against the CLI's ISO cutoff."""
+
+    async def test_since_filters_mixed_formats(self, db):
+        from datetime import UTC, datetime, timedelta
+
+        from gimmes.store.queries import get_trades, insert_trade
+
+        old = _open_trade("KXOLD-26JAN-T1", ts="2026-01-01T10:00:00+00:00")
+        await insert_trade(db, old)
+        recent_t = _open_trade(
+            "KXNEW-26JUL-T1", ts="2026-07-01T10:00:00+00:00",
+        )
+        await insert_trade(db, recent_t)
+        # Legacy space-format row, recent — must be RETAINED.
+        await db.conn.execute(
+            """INSERT INTO trades (ticker, action, side, count, price,
+               model_probability, gimme_score, edge, kelly_fraction,
+               rationale, agent, timestamp)
+               VALUES ('KXSPACE-26JUL-T1', 'open', 'yes', 10, 0.6,
+                       0.9, 82, 0.25, 0.03, 'entry', 'closer',
+                       '2026-07-01 11:00:00')""",
+        )
+        await db.conn.commit()
+
+        cutoff = (
+            (datetime.now(UTC) - timedelta(days=90))
+            .replace(microsecond=0, tzinfo=None).isoformat()
+        )
+        rows = await get_trades(db, since=cutoff, limit=100)
+        tickers = {r["ticker"] for r in rows}
+        assert tickers == {"KXNEW-26JUL-T1", "KXSPACE-26JUL-T1"}
+
+
+class TestCorruptEscalationPaths:
+    """#686: the with-trade sync path and the rollback guarantee."""
+
+    async def test_sync_with_trade_skips_and_escalates(self, db):
+        from gimmes.store.queries import (
+            get_errors,
+            sync_positions_with_trade,
+        )
+
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=1.7),  # corrupt
+        )
+        trade = _open_trade("KXNEW-26JUL-T1", action="open")
+
+        row_id = await sync_positions_with_trade(db, [], trade)
+        assert row_id > 0  # the trade itself landed
+        errors = await get_errors(db, limit=10)
+        assert any(
+            e["error_code"] == "corrupt_position_skipped"
+            for e in errors
+        )
+
+    async def test_rollback_discards_escalations(self, db, monkeypatch):
+        """If the transaction aborts AFTER corrupt entries were
+        collected, no orphan error rows describe a sync that never
+        committed."""
+        from gimmes.store import queries as queries_module
+        from gimmes.store.queries import (
+            get_errors,
+            sync_positions_with_trade,
+        )
+
+        await insert_trade(db, _open_trade("KXCPI-26APR-T0.5"))
+        await upsert_position(
+            db, _pos("KXCPI-26APR-T0.5", count=10, price=1.7),  # corrupt
+        )
+
+        real = queries_module._insert_trade_row
+
+        async def _fail_on_trade(db_, trade):  # type: ignore[no-untyped-def]
+            if trade.ticker == "KXNEW-26JUL-T1":
+                raise RuntimeError("trade write exploded")
+            return await real(db_, trade)
+
+        monkeypatch.setattr(
+            queries_module, "_insert_trade_row", _fail_on_trade,
+        )
+        trade = _open_trade("KXNEW-26JUL-T1", action="open")
+
+        with pytest.raises(RuntimeError):
+            await sync_positions_with_trade(db, [], trade)
+        errors = await get_errors(db, limit=10)
+        assert not any(
+            e["error_code"] == "corrupt_position_skipped"
+            for e in errors
+        )


### PR DESCRIPTION
## Summary

Resolves the three #686 items deferred from #668. These analyses feed Pro's tuning of real-capital-bound parameters.

**1. Lifecycle-aware outcomes.** `_pair_closes` now emits a lifecycle index (incremented when an entry lands on a flat book after prior activity), and the threshold sweep + scanner consume paired records aggregated per `(ticker, side, lifecycle)` instead of iterating raw open rows. One refactor kills two bugs: the **any-loss ratchet** (an unresolved losing round trip permanently marked every later re-trade of the key a loss) and the **still-open inheritance bug** (a currently-open re-entry inherited the prior lifecycle's outcome). Review hardening: sweeps bucket by the lifecycle's *opening* entry — snapshotted at the increment point, since the per-close "most recent entry" fields would misattribute sized-up positions to the size-up's score/price (pinned by a direct `_lifecycle_outcomes` test); and the window filter drops whole *lifecycles* by last close rather than tranches, because per-tranche filtering would strip a straddling lifecycle's early losing tranches from the any-loss AND — biasing win rates up in exactly the loosening direction the rule guards.

**2. Bounded analysis window.** `strategy.lesson_window_days` (default 90 — empirically sized against the live DB: a 30-day window would leave 9 closes against the analyses' 20–30-trade gates and silently disable everything, strictly worse than all-time; 0 = all-time escape hatch). The cutoff applies **post-pairing** for open/close/size_up — the walk needs full history, so an in-window close whose open predates the window still prices against it (anti-orphan pinned) — and at the DB for skips, where the 21k-row volume lives, with a no-silent-caps truncation warning. The cutoff is naive-UTC second-truncated so the SQL `datetime()` path and the advisor's string compares window identically (SQLite's offset parsing verified empirically by two reviewers). **Review-caught crash:** the config field initially landed in `SizingConfig` while the CLI read `config.strategy` — every real `gimmes lesson` would have crashed, invisible behind MagicMock configs; the lesson tests now construct real `GimmesConfig` so attribute paths are type-checked.

**3. Corrupt-position skip-and-escalate.** A corrupt position row (mark > 1.0, negative count) previously aborted the entire `sync_positions` transaction every cycle until manual repair. Bounding the `Position` model is the wrong fix — fee-inclusive `avg_price` legitimately exceeds \$1, and validation at parse time would abort the whole portfolio fetch. Instead, the nested guard skips that single position's drift close with an ERROR naming the failing fields and a durable `error_log` row written **after** the transaction (`insert_error` commits; on rollback the exception propagates first, so no orphan error rows describe a sync that never committed — pinned). Healthy positions keep their closes; no lying row is ever written.

Closes #686

## Test plan

- `test_advisor.py` (+12): lifecycle indices, partial-close non-increment, ratchet fix (one loss + one win), still-open non-inheritance, scanner analog, opening-entry attribution, whole-lifecycle straddle windowing, anti-orphan pricing, space-format normalization, `run_all_analyses` since-threading.
- `test_lesson_window.py`: real-config harness, per-action `since` scoping, `0 = all-time`, truncation warning at exactly the cap (silent one row under).
- `test_sync_positions.py` (+4): skip-and-escalate rewrite of the #668 fail-loud pin, healthy-sibling continuation, with-trade path, rollback-discards-escalations, mixed-format real-DB `since` filtering.
- Full suite: **1963 passed** on frozen code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB