### PR TITLE
Fix #690: empty-book maker orders cancel instead of fabricating fills

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1245,6 +1245,30 @@ def order(
                 console.print(f"[red bold]Order FAILED: {exc}[/red bold]")
                 raise typer.Exit(1)
 
+            if result.status == "canceled":
+                # #690: a canceled order placed NOTHING — green
+                # "Order placed ... (status: canceled)" read as
+                # success to the Closer. Exit 1 routes agents into
+                # their order_failed skip path with a nameable cause,
+                # and the error row gives Groundskeeper the triage
+                # trail the caddie-master escalation keys on.
+                reason = result.reason or "not filled"
+                await _audit_row(ErrorLogEntry(
+                    severity=ErrorSeverity.WARNING,
+                    category=ErrorCategory.ORDER_FAILURE,
+                    error_code="order_canceled",
+                    component="cli.order", agent=agent,
+                    message=f"Order canceled for {ticker}: {reason}",
+                    context=json.dumps({
+                        "ticker": ticker, "side": side,
+                        "action": action, "reason": reason,
+                    }),
+                ), "Failed to log order cancel")
+                console.print(
+                    f"[red bold]Order NOT placed:"
+                    f" {rich_escape(reason)}[/red bold]"
+                )
+                raise typer.Exit(1)
             console.print(
                 f"[green]{label}Order placed:[/green] {result.order_id}"
                 f" (status: {result.status})"
@@ -2638,7 +2662,7 @@ def market_info(
 _SKIP_REASONS = frozenset({
     "cooldown", "research_failed", "review_reject", "validation_failed",
     "order_failed", "close_failed", "no_position", "price_moved",
-    "liquidity", "infra_failed", "already_traded",
+    "liquidity", "infra_failed", "already_traded", "order_canceled",
 })
 
 # Non-entry skips carry no entry decision — backfilling scan-time

--- a/src/gimmes/models/order.py
+++ b/src/gimmes/models/order.py
@@ -59,6 +59,9 @@ class Order(BaseModel):
     remaining_count: int = 0
     created_time: datetime | None = None
     client_order_id: str = ""
+    # #690: why a canceled order canceled (paper broker sets it; the
+    # real Kalshi path leaves it empty). Agents need a nameable cause.
+    reason: str = ""
 
     @property
     def is_open(self) -> bool:

--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -21,7 +21,12 @@ from gimmes.models.order import (
     OrderSide,
 )
 from gimmes.models.portfolio import Position
-from gimmes.paper.fill_simulator import FillResult, SimulatedFill, simulate_fill
+from gimmes.paper.fill_simulator import (
+    FillResult,
+    SimulatedFill,
+    has_opposing_liquidity,
+    simulate_fill,
+)
 from gimmes.paper.schema import PAPER_SCHEMA_SQL
 from gimmes.store.database import Database
 from gimmes.strategy.fees import DEFAULT_FEE_MULTIPLIERS, FeeMultipliers, fee_for_order
@@ -143,7 +148,14 @@ class PaperBroker:
             )
             pos_row = await cursor.fetchone()
             if pos_row is None or int(pos_row["count"]) < params.count:
-                return await self._reject_order(order_id, params, now)
+                held = int(pos_row["count"]) if pos_row else 0
+                return await self._reject_order(
+                    order_id, params, now,
+                    reason=(
+                        f"insufficient position: have {held}, need"
+                        f" {params.count}"
+                    ),
+                )
 
         # Run fill simulation
         result = simulate_fill(params, orderbook, fees=fees)
@@ -152,7 +164,16 @@ class PaperBroker:
         # Real markets have opposing flow that hits resting bids; paper mode
         # has none, so we fill at limit to enable same-cycle position
         # updates.  (#255)
-        if params.post_only and result.remaining_count > 0:
+        # #690: ONLY when the opposing side exists at all — an empty
+        # counterparty side means no market, and filling there would
+        # fabricate a fill nobody offered (the phantom ledger rows the
+        # #663 settle clamp had to defend against). The order cancels
+        # instead (status falls through to "canceled" below).
+        opposing_liquidity = has_opposing_liquidity(params, orderbook)
+        if (
+            params.post_only and result.remaining_count > 0
+            and opposing_liquidity
+        ):
             remaining = result.remaining_count
             limit_price = params.price
             fill_fee = fee_for_order(
@@ -172,13 +193,25 @@ class PaperBroker:
         # Determine status — any fill counts as executed (partial taker
         # fills abandon the remainder rather than resting).
         status = "executed" if result.total_filled > 0 else "canceled"
+        cancel_reason = ""
+        if status == "canceled" and not opposing_liquidity:
+            cancel_reason = (
+                "no opposing liquidity — empty book, no counterparty"
+                " at any price (#690)"
+            )
 
         # Pre-transaction balance validation
         if result.total_filled > 0 and params.action == OrderAction.BUY:
             cost = result.total_notional + result.total_fees
             balance = await self.get_balance()
             if balance < cost:
-                return await self._reject_order(order_id, params, now)
+                return await self._reject_order(
+                    order_id, params, now,
+                    reason=(
+                        f"insufficient balance: cost ${cost:,.2f} >"
+                        f" ${balance:,.2f}"
+                    ),
+                )
 
         # All writes in one atomic transaction
         async with self._db.transaction():
@@ -253,6 +286,7 @@ class PaperBroker:
             count=params.count,
             remaining_count=result.remaining_count,
             created_time=now,
+            reason=cancel_reason,
         )
 
     async def cancel_order(self, order_id: str) -> None:
@@ -271,17 +305,51 @@ class PaperBroker:
             return
 
         async with self._db.transaction():
-            # Refund reserved balance for unfilled contracts
+            # Refund reserved balance for unfilled contracts — BUYS
+            # only (#690 review): sells never reserve balance, so an
+            # unconditional refund fabricated paper money on the
+            # legacy-cleanup path this fix sanctions.
             remaining = int(row["remaining_count"])
-            price_cents = max(int(row["yes_price"]), int(row["no_price"]))
-            refund = remaining * price_cents / 100.0
-            await self._update_balance(refund)
+            if str(row["action"]) == "buy":
+                price_cents = max(
+                    int(row["yes_price"]), int(row["no_price"]),
+                )
+                refund = remaining * price_cents / 100.0
+                await self._update_balance(refund)
 
             await self._conn.execute(
                 "UPDATE paper_orders SET status = 'canceled',"
                 " updated_at = datetime('now') WHERE order_id = ?",
                 (order_id,),
             )
+
+            # #690 (#684 item 4): a NEVER-FILLED resting order's
+            # placement-time trade rows describe a non-event — annul
+            # them (action='skip', append-only ledger: no DELETE) so
+            # daily P&L / scorecard / the #663 settle-clamp residual
+            # math stop seeing an exit that never traded. A partially
+            # filled legacy row keeps its trade rows (warned).
+            if remaining == int(row["count"]):
+                await self._conn.execute(
+                    """UPDATE trades SET action = 'skip',
+                       reason = 'order_canceled',
+                       rationale = rationale || ?
+                       WHERE order_id = ?""",
+                    (
+                        " [#690 annulment: resting order canceled"
+                        " before any fill]",
+                        order_id,
+                    ),
+                )
+            else:
+                import logging
+
+                logging.getLogger("gimmes").warning(
+                    "canceled order %s was partially filled (%d/%d)"
+                    " — placement-time trade rows kept (#690)",
+                    order_id, int(row["count"]) - remaining,
+                    int(row["count"]),
+                )
 
     async def fill_resting_orders(
         self,
@@ -348,6 +416,19 @@ class PaperBroker:
                     no_price=price if side == OrderSide.NO else None,
                     post_only=True,
                 )
+
+                # #690: same empty-book guard as create_order — a
+                # legacy resting order against a dead book stays
+                # resting instead of fabricating a fill.
+                if not has_opposing_liquidity(params, orderbooks[ticker]):
+                    import logging
+
+                    logging.getLogger("gimmes").debug(
+                        "resting order %s skipped — no opposing"
+                        " liquidity on %s (#690)",
+                        row["order_id"], ticker,
+                    )
+                    continue
 
                 # Paper mode: fill at limit price unconditionally.
                 # Real markets have opposing flow that hits resting bids;
@@ -690,8 +771,10 @@ class PaperBroker:
         order_id: str,
         params: CreateOrderParams,
         now: datetime.datetime,
+        reason: str = "",
     ) -> Order:
-        """Record a canceled order and return it."""
+        """Record a canceled order and return it (#690: with a
+        nameable cause for the CLI/agent contract)."""
         await self._conn.execute(
             """INSERT INTO paper_orders
                (order_id, ticker, action, side, count, remaining_count,
@@ -724,6 +807,7 @@ class PaperBroker:
             count=params.count,
             remaining_count=params.count,
             created_time=now,
+            reason=reason,
         )
 
     async def _update_position_from_fills(

--- a/src/gimmes/paper/fill_simulator.py
+++ b/src/gimmes/paper/fill_simulator.py
@@ -124,6 +124,32 @@ def _simulate_maker_fill(
     )
 
 
+def has_opposing_liquidity(
+    params: CreateOrderParams,
+    orderbook: Orderbook,
+) -> bool:
+    """True when the order's counterparty side has ANY depth (#690).
+
+    Price-blind: the #255 maker fallback fills a non-marketable
+    remainder at its own limit — a patient maker plausibly gets met
+    when a REAL market exists — but an empty opposing side means no
+    counterparty at any price, and filling there is fabrication.
+    Counterparty sides: BUY YES <- no_bids (implied YES asks); BUY NO
+    <- yes_bids; SELL YES <- yes_bids; SELL NO <- no_bids.
+    """
+    if params.action == OrderAction.BUY:
+        levels = (
+            orderbook.no_bids if params.side == OrderSide.YES
+            else orderbook.yes_bids
+        )
+    else:
+        levels = (
+            orderbook.yes_bids if params.side == OrderSide.YES
+            else orderbook.no_bids
+        )
+    return any(lvl.quantity > 0 for lvl in levels)
+
+
 def _opposing_depth(
     params: CreateOrderParams,
     orderbook: Orderbook,

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -203,6 +203,10 @@ def _lifecycle_outcomes(
 # Single source of truth — cli._NON_ENTRY_REASONS aliases this set.
 NON_ENTRY_SKIP_REASONS = frozenset({
     "no_position", "close_failed", "infra_failed", "already_traded",
+    # #690: an annulled never-filled order is a non-event, not a
+    # missed entry — its inherited analytics would otherwise land it
+    # in the FNR numerator as an automatic false negative.
+    "order_canceled",
 })
 
 MIN_TRADES_THRESHOLD = 30

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -847,6 +847,15 @@ class TestMigrationV4:
         assert row[0] >= 4
 
 
+def test_annulled_order_rows_excluded_from_fnr() -> None:
+    """#690: an annulled never-filled order (reason='order_canceled')
+    carries real inherited analytics — it must be a NON-entry skip or
+    every liquidity cancel becomes an automatic false negative."""
+    from gimmes.strategy.advisor import NON_ENTRY_SKIP_REASONS
+
+    assert "order_canceled" in NON_ENTRY_SKIP_REASONS
+
+
 def test_non_entry_reasons_single_source_of_truth() -> None:
     """#670 review: the CLI's --reason gate and the advisor's audit
     exclusion must never drift — the CLI aliases the advisor set."""

--- a/tests/unit/test_fill_simulator.py
+++ b/tests/unit/test_fill_simulator.py
@@ -6,7 +6,10 @@ import pytest
 
 from gimmes.models.market import Orderbook, OrderbookLevel
 from gimmes.models.order import CreateOrderParams, OrderAction, OrderSide
-from gimmes.paper.fill_simulator import simulate_fill
+from gimmes.paper.fill_simulator import (
+    has_opposing_liquidity,
+    simulate_fill,
+)
 from gimmes.strategy.fees import FeeMultipliers
 
 
@@ -350,3 +353,52 @@ class TestEdgeCases:
         expected_fees = sum(f.fee for f in result.fills)
         assert abs(result.total_notional - expected_notional) < 0.001
         assert abs(result.total_fees - expected_fees) < 0.001
+
+
+class TestHasOpposingLiquidity:
+    """#690: the counterparty-side mapping, pinned per (action, side)
+    against one-sided books — a swapped branch or a both-sides check
+    must fail."""
+
+    @staticmethod
+    def _book(*, yes_bids=(), no_bids=()):
+        return Orderbook(
+            ticker="X",
+            yes_bids=[OrderbookLevel(price=p, quantity=q) for p, q in yes_bids],
+            no_bids=[OrderbookLevel(price=p, quantity=q) for p, q in no_bids],
+        )
+
+    @staticmethod
+    def _params(action, side):
+        return CreateOrderParams(
+            ticker="X", action=action, side=side, count=10,
+            yes_price=0.50 if side == OrderSide.YES else None,
+            no_price=0.50 if side == OrderSide.NO else None,
+            post_only=True,
+        )
+
+    def test_buy_yes_counterparty_is_no_bids(self) -> None:
+        p = self._params(OrderAction.BUY, OrderSide.YES)
+        assert has_opposing_liquidity(p, self._book(no_bids=[(0.4, 5)]))
+        assert not has_opposing_liquidity(p, self._book(yes_bids=[(0.4, 5)]))
+
+    def test_buy_no_counterparty_is_yes_bids(self) -> None:
+        p = self._params(OrderAction.BUY, OrderSide.NO)
+        assert has_opposing_liquidity(p, self._book(yes_bids=[(0.4, 5)]))
+        assert not has_opposing_liquidity(p, self._book(no_bids=[(0.4, 5)]))
+
+    def test_sell_yes_counterparty_is_yes_bids(self) -> None:
+        p = self._params(OrderAction.SELL, OrderSide.YES)
+        assert has_opposing_liquidity(p, self._book(yes_bids=[(0.4, 5)]))
+        assert not has_opposing_liquidity(p, self._book(no_bids=[(0.4, 5)]))
+
+    def test_sell_no_counterparty_is_no_bids(self) -> None:
+        p = self._params(OrderAction.SELL, OrderSide.NO)
+        assert has_opposing_liquidity(p, self._book(no_bids=[(0.4, 5)]))
+        assert not has_opposing_liquidity(p, self._book(yes_bids=[(0.4, 5)]))
+
+    def test_zero_quantity_level_is_not_liquidity(self) -> None:
+        p = self._params(OrderAction.BUY, OrderSide.YES)
+        assert not has_opposing_liquidity(
+            p, self._book(no_bids=[(0.4, 0)]),
+        )

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -1022,3 +1022,33 @@ class TestCloseInheritsEntryAnalytics:
         assert t.model_probability == 0.0
         assert t.edge == 0.0
         assert "position sync failed" not in _printed(mock_console).lower()
+
+
+class TestCanceledOrderContract:
+    """#690: a canceled order is a FAILURE to the caller — red
+    message with the broker's reason, exit 1, no trade row."""
+
+    def test_canceled_status_exits_nonzero_with_reason(self) -> None:
+        from gimmes.models.order import Order, OrderAction, OrderSide
+
+        canceled = Order(
+            order_id="paper-x", ticker="TEST-MKT",
+            action=OrderAction.BUY, side=OrderSide.YES,
+            status="canceled", count=10, remaining_count=10,
+            reason="no opposing liquidity — empty book, no"
+                   " counterparty at any price (#690)",
+        )
+        broker = _make_mock_broker()
+        broker.create_order = AsyncMock(return_value=canceled)
+        sync_spy = AsyncMock()
+
+        with patch(
+            "gimmes.store.queries.sync_positions_with_trade", sync_spy,
+        ):
+            result, mock_console, _ = _run_order_cli(broker)
+
+        assert result.exit_code == 1
+        out = _printed(mock_console)
+        assert "Order NOT placed" in out
+        assert "no opposing liquidity" in out
+        sync_spy.assert_not_awaited()  # no trade row for a non-event

--- a/tests/unit/test_paper_broker.py
+++ b/tests/unit/test_paper_broker.py
@@ -928,10 +928,13 @@ class TestNegativeBalanceGuard:
         self, broker: PaperBroker, orderbook: Orderbook
     ) -> None:
         """Maker BUY that would exceed available balance is rejected."""
+        # #690: give the book opposing depth so the BALANCE guard is
+        # what trips — an empty book now cancels for its own reason
+        # and would silently stop pinning the balance check.
         ob = Orderbook(
             ticker="EXPENSIVE",
             yes_bids=[],
-            no_bids=[],  # No depth, but fills immediately in paper mode
+            no_bids=[OrderbookLevel(price=0.30, quantity=20_000)],
         )
         params = CreateOrderParams(
             ticker="EXPENSIVE",
@@ -943,6 +946,9 @@ class TestNegativeBalanceGuard:
         )
         order = await broker.create_order(params, ob)
         assert order.status == "canceled"
+        # Pin WHICH cancel fired (#690): the balance guard, not the
+        # empty-book refusal.
+        assert "insufficient balance" in order.reason
 
         balance = await broker.get_balance()
         assert balance == 10_000.00
@@ -1222,3 +1228,208 @@ class TestSettleLedgerClamp:
         ]
         assert len(settlement) == 1
         assert settlement[0]["count"] == 10  # broker count, not 20
+
+
+class TestEmptyBookMakerRefusal:
+    """#690: a maker order whose OPPOSING side is completely empty
+    cancels instead of fabricating a fill at its own limit — there is
+    no counterparty at any price. Non-marketable makers with a real
+    book keep the #255 immediate fill."""
+
+    @staticmethod
+    def _empty_book(ticker: str = "KXDEAD") -> Orderbook:
+        return Orderbook(ticker=ticker, yes_bids=[], no_bids=[])
+
+    @pytest.mark.asyncio
+    async def test_buy_yes_empty_book_cancels(
+        self, broker: PaperBroker,
+    ) -> None:
+        params = CreateOrderParams(
+            ticker="KXDEAD", action=OrderAction.BUY,
+            side=OrderSide.YES, count=10, yes_price=0.70,
+            post_only=True,
+        )
+        order = await broker.create_order(params, self._empty_book())
+        assert order.status == "canceled"
+        assert order.remaining_count == 10
+        assert "no opposing liquidity" in order.reason
+        assert await broker.get_balance() == 10_000.00
+        assert await broker.get_positions() == []
+
+    @pytest.mark.asyncio
+    async def test_buy_no_empty_book_cancels(
+        self, broker: PaperBroker,
+    ) -> None:
+        params = CreateOrderParams(
+            ticker="KXDEAD", action=OrderAction.BUY,
+            side=OrderSide.NO, count=10, no_price=0.40,
+            post_only=True,
+        )
+        order = await broker.create_order(params, self._empty_book())
+        assert order.status == "canceled"
+        assert await broker.get_balance() == 10_000.00
+
+    @pytest.mark.asyncio
+    async def test_sell_yes_empty_book_cancels(
+        self, broker: PaperBroker, orderbook: Orderbook,
+    ) -> None:
+        """Seed via a liquid book, then try to close on a dead one."""
+        buy = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.BUY,
+            side=OrderSide.YES, count=10, yes_price=0.70,
+            post_only=True,
+        )
+        await broker.create_order(buy, orderbook)
+        balance_after_buy = await broker.get_balance()
+
+        sell = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.SELL,
+            side=OrderSide.YES, count=10, yes_price=0.68,
+            post_only=True,
+        )
+        order = await broker.create_order(
+            sell, self._empty_book("TEST-MKT"),
+        )
+        assert order.status == "canceled"
+        assert "no opposing liquidity" in order.reason
+        # Position intact, no proceeds credited.
+        [pos] = await broker.get_positions()
+        assert pos.count == 10
+        assert await broker.get_balance() == balance_after_buy
+
+    @pytest.mark.asyncio
+    async def test_sell_no_empty_book_cancels(
+        self, broker: PaperBroker,
+    ) -> None:
+        """Fourth direction: SELL NO against empty no_bids."""
+        buy_book = Orderbook(
+            ticker="TEST-MKT",
+            yes_bids=[OrderbookLevel(price=0.68, quantity=200)],
+            no_bids=[OrderbookLevel(price=0.30, quantity=500)],
+        )
+        buy = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.BUY,
+            side=OrderSide.NO, count=10, no_price=0.32,
+            post_only=True,
+        )
+        await broker.create_order(buy, buy_book)
+
+        sell = CreateOrderParams(
+            ticker="TEST-MKT", action=OrderAction.SELL,
+            side=OrderSide.NO, count=10, no_price=0.35,
+            post_only=True,
+        )
+        order = await broker.create_order(
+            sell, self._empty_book("TEST-MKT"),
+        )
+        assert order.status == "canceled"
+        assert "no opposing liquidity" in order.reason
+
+    @pytest.mark.asyncio
+    async def test_canceled_order_row_kept_for_audit(
+        self, broker: PaperBroker,
+    ) -> None:
+        params = CreateOrderParams(
+            ticker="KXDEAD", action=OrderAction.BUY,
+            side=OrderSide.YES, count=10, yes_price=0.70,
+            post_only=True,
+        )
+        order = await broker.create_order(params, self._empty_book())
+        cursor = await broker._conn.execute(
+            "SELECT status FROM paper_orders WHERE order_id = ?",
+            (order.order_id,),
+        )
+        row = await cursor.fetchone()
+        assert row is not None and row["status"] == "canceled"
+
+    @pytest.mark.asyncio
+    async def test_resting_order_stays_resting_on_dead_book(
+        self, broker: PaperBroker,
+    ) -> None:
+        """fill_resting_orders must not fabricate either — a legacy
+        resting order against a dead book stays resting."""
+        await broker._conn.execute(
+            """INSERT INTO paper_orders
+               (order_id, ticker, action, side, count, remaining_count,
+                yes_price, no_price, status, post_only, created_at,
+                updated_at)
+               VALUES ('legacy-1', 'KXDEAD', 'buy', 'yes', 10, 10,
+                       70, 0, 'resting', 1, datetime('now'),
+                       datetime('now'))""",
+        )
+        await broker._db.conn.commit()
+
+        filled = await broker.fill_resting_orders(
+            {"KXDEAD": self._empty_book()},
+        )
+        assert filled == []
+        cursor = await broker._conn.execute(
+            "SELECT status FROM paper_orders WHERE order_id = 'legacy-1'",
+        )
+        assert (await cursor.fetchone())["status"] == "resting"
+
+
+class TestCancelOrderAnnulment:
+    """#690 (#684 item 4): canceling a never-filled resting order
+    annuls its placement-time trade rows (action='skip') so the
+    ledger stops seeing an exit that never traded."""
+
+    async def _seed_resting_with_close_row(
+        self, broker: PaperBroker, *, remaining: int = 10,
+    ) -> None:
+        from gimmes.models.trade import TradeDecision
+        from gimmes.store.queries import insert_trade
+
+        await broker._conn.execute(
+            """INSERT INTO paper_orders
+               (order_id, ticker, action, side, count, remaining_count,
+                yes_price, no_price, status, post_only, created_at,
+                updated_at)
+               VALUES ('legacy-2', 'KXOLD', 'sell', 'yes', 10, ?,
+                       68, 0, 'resting', 1, datetime('now'),
+                       datetime('now'))""",
+            (remaining,),
+        )
+        await broker._db.conn.commit()
+        await insert_trade(broker._db, TradeDecision(
+            ticker="KXOLD", action=TradeDecision.Action.CLOSE,
+            side="yes", count=10, price=0.68,
+            rationale="placement-time close",
+            order_id="legacy-2",
+        ))
+
+    @pytest.mark.asyncio
+    async def test_never_filled_cancel_annuls_trade_rows(
+        self, broker: PaperBroker,
+    ) -> None:
+        from gimmes.store.queries import get_daily_pnl, get_trades
+
+        await self._seed_resting_with_close_row(broker)
+        await broker.cancel_order("legacy-2")
+
+        rows = await get_trades(broker._db, ticker="KXOLD")
+        assert len(rows) == 1
+        assert rows[0]["action"] == "skip"
+        assert rows[0]["reason"] == "order_canceled"
+        assert "#690 annulment" in rows[0]["rationale"]
+        # The phantom exit no longer reaches daily P&L.
+        assert await get_daily_pnl(broker._db) == 0.0
+        # #690 review: SELLs never reserved balance — canceling one
+        # must not fabricate a refund.
+        assert await broker.get_balance() == 10_000.00
+
+    @pytest.mark.asyncio
+    async def test_partially_filled_cancel_keeps_trade_rows(
+        self, broker: PaperBroker, caplog,
+    ) -> None:
+        import logging
+
+        from gimmes.store.queries import get_trades
+
+        await self._seed_resting_with_close_row(broker, remaining=4)
+        with caplog.at_level(logging.WARNING, logger="gimmes"):
+            await broker.cancel_order("legacy-2")
+
+        rows = await get_trades(broker._db, ticker="KXOLD")
+        assert rows[0]["action"] == "close"  # kept
+        assert "partially filled" in caplog.text


### PR DESCRIPTION
## Summary

Resolves #690 (absorbing #684 item 4). The #255 maker fallback filled a post-only remainder at its own limit price **unconditionally** — including against a completely empty opposing side, fabricating fills no counterparty offered and feeding phantom rows into the live paper ledger.

**The refusal is scoped exactly to the fabrication.** `has_opposing_liquidity` (price-blind counterparty-side check: BUY YES ← no_bids, BUY NO ← yes_bids, SELL YES ← yes_bids, SELL NO ← no_bids; pinned per-direction against one-sided books) gates the fallback: a *non-marketable maker with a real book* keeps the deliberate #255 immediate fill — zero of its ten pins broke — while an empty counterparty side cancels with a nameable reason. The same guard keeps legacy resting orders resting on dead books.

**The canceled contract is now honest.** Previously the CLI printed green "Order placed … (status: canceled)" and exited 0 — the Closer read failure as success. Now: red "Order NOT placed: {reason}" + exit 1 + an ORDER_FAILURE error row (review: the caddie-master escalation's "Groundskeeper triages repeated close_failed errors" had no data behind it). `Order.reason` names every cancel cause, including the previously-unnameable `_reject_order` paths (insufficient position/balance with specifics).

**The cancel path annuls phantoms.** Canceling a never-filled resting order flips its placement-time trade rows to `action='skip'`, `reason='order_canceled'` (append-only ledger — no DELETE), which self-heals the #663 settle-clamp residual math and daily P&L. Review additions: `order_canceled` joined the non-entry skip set (annulled rows carry real inherited analytics and would otherwise land in the missed-opportunity FNR as automatic false negatives), and the cancel refund is **BUY-only** — sells never reserved balance, and the unconditional refund fabricated paper money on this exact cleanup path.

## Test plan

- `TestEmptyBookMakerRefusal` (6): all four directions, balance/position invariance, audit row, resting-stays-resting.
- `TestCancelOrderAnnulment` (2): annulment with daily-P&L + balance invariance; partial fills keep rows + warn.
- `TestHasOpposingLiquidity` (5): per-direction side mapping against one-sided books; zero-quantity levels aren't liquidity.
- CLI contract test (exit 1, reason surfaced, no trade row); balance-guard fixture now pins *which* cancel fired; FNR exclusion pin.
- Full suite: **1979 passed** on frozen code.

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB