### PR TITLE
Fix #695: side-scoped, format-normalized open matching in the canonical daily-P&L SQL

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1316,7 +1316,7 @@ def order(
                             thesis = ""
                             if size_up:
                                 open_trade = await get_open_trade_for_ticker(
-                                    db, ticker,
+                                    db, ticker, side=side,
                                 )
                                 if open_trade:
                                     thesis = open_trade.get("thesis", "")

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -927,13 +927,21 @@ async def clear_all_candidates(db: Database) -> int:
 # settlement closes included). Shared with the read-only clubhouse
 # (clubhouse/data.py get_risk) so the dashboard's risk panel can never
 # drift from the daily-loss-limit trigger the loop reads (#680).
+# #695: side-scoped open matching + replace(' ','T') timestamp
+# normalization in BOTH the WHERE and the ORDER BY — the raw string
+# compare let a LATER space-format open match an EARLIER ISO close
+# (' ' < 'T'), and the raw sort ranked every ISO row above every
+# space-format row, picking the wrong "most recent" open.
 DAILY_PNL_SQL = """SELECT COALESCE(SUM(
             (c.price - COALESCE(
                 (SELECT price FROM trades o
                  WHERE o.ticker = c.ticker
+                   AND o.side = c.side
                    AND o.action = 'open'
-                   AND o.timestamp <= c.timestamp
-                 ORDER BY o.timestamp DESC
+                   AND replace(o.timestamp, ' ', 'T')
+                       <= replace(c.timestamp, ' ', 'T')
+                 ORDER BY replace(o.timestamp, ' ', 'T') DESC,
+                          o.id DESC
                  LIMIT 1),
             0)) * c.count
         ), 0) as daily_pnl
@@ -947,8 +955,21 @@ async def get_daily_pnl(db: Database, *, today: str | None = None) -> float:
     """Calculate realized P&L from close trades for a given date (defaults to today).
 
     For each close trade on the target date, finds the most recent open trade
-    on the same ticker that occurred before the close, then computes:
+    on the same ticker AND SIDE that occurred before the close (#695 —
+    sides are independent positions; timestamps compare after
+    replace(' ', 'T') normalization so legacy space-format rows order
+    chronologically, the #661/#680 pattern), then computes:
     (close_price - open_price) * count.
+
+    Intentional approximation (#695): the entry price is the MOST
+    RECENT open's price, not a size-weighted average across scale-ins
+    (size_up rows are excluded from the subquery). After a scale-in,
+    per-contract P&L is measured against the last full open, not true
+    average cost. Deliberate — this value feeds the real-capital
+    daily-loss trigger (check_daily_loss) and the clubhouse risk panel
+    via the shared constant (#680), and both must move together; do
+    not change the averaging here without revisiting the trigger
+    semantics.
 
     Synthetic reconcile-divergence close trades (agent='reconcile', written
     by `_log_reconcile_closes` per #609) are EXCLUDED from daily P&L because
@@ -1082,13 +1103,23 @@ async def get_candidate_for_ticker(
     return [dict(row) for row in rows]
 
 
-async def get_open_trade_for_ticker(db: Database, ticker: str) -> dict | None:  # type: ignore[type-arg]
-    """Return the most recent open trade record for a ticker, or None."""
-    cursor = await db.conn.execute(
-        "SELECT * FROM trades WHERE ticker = ? AND action = 'open'"
-        " ORDER BY timestamp DESC LIMIT 1",
-        (ticker,),
-    )
+async def get_open_trade_for_ticker(
+    db: Database, ticker: str, side: str | None = None,
+) -> dict | None:  # type: ignore[type-arg]
+    """Return the most recent open trade record for a ticker, or None.
+
+    #695: normalized ordering (the #661 pattern) so legacy space-
+    format rows rank chronologically, and an optional ``side`` scope
+    for side='both' holdings (the size_up thesis-inheritance caller
+    must not read the other leg's thesis).
+    """
+    query = "SELECT * FROM trades WHERE ticker = ? AND action = 'open'"
+    params: list[object] = [ticker]
+    if side:
+        query += " AND side = ?"
+        params.append(side)
+    query += " ORDER BY replace(timestamp, ' ', 'T') DESC, id DESC LIMIT 1"
+    cursor = await db.conn.execute(query, params)
     row = await cursor.fetchone()
     return dict(row) if row else None
 
@@ -1110,7 +1141,7 @@ async def get_entry_analytics(
         "SELECT model_probability, gimme_score, edge, kelly_fraction"
         " FROM trades WHERE ticker = ? AND side = ?"
         " AND action IN ('open', 'size_up')"
-        " ORDER BY timestamp DESC, id DESC LIMIT 1",
+        " ORDER BY replace(timestamp, ' ', 'T') DESC, id DESC LIMIT 1",
         (ticker, side),
     )
     row = await cursor.fetchone()

--- a/tests/unit/test_daily_pnl.py
+++ b/tests/unit/test_daily_pnl.py
@@ -26,10 +26,12 @@ def _trade(
     count: int = 10,
     edge: float = 0.15,
     timestamp: datetime | None = None,
+    side: str = "yes",
 ) -> TradeDecision:
     return TradeDecision(
         ticker=ticker,
         action=TradeDecision.Action(action),
+        side=side,
         price=price,
         count=count,
         edge=edge,
@@ -331,3 +333,118 @@ class TestRestingSellNoDoubleCount:
         assert await get_daily_pnl(db) == pytest.approx(
             (0.90 - 0.70) * 10,
         )
+
+
+class TestDailyPnlSideScopedMatching:
+    """#695: sides are independent positions — a close must match its
+    own side's open, never a nearer opposite-side one."""
+
+    async def test_close_matches_same_side_open_not_nearer_opposite(
+        self, db: Database,
+    ) -> None:
+        t0 = datetime.now(UTC)
+        await insert_trade(db, _trade(
+            action="open", price=0.60, side="yes",
+            timestamp=t0 - timedelta(hours=3),
+        ))
+        await insert_trade(db, _trade(
+            action="open", price=0.30, side="no",
+            timestamp=t0 - timedelta(hours=2),  # nearer, wrong side
+        ))
+        await insert_trade(db, _trade(
+            action="close", price=0.70, side="yes", timestamp=t0,
+        ))
+        # Side-blind picked the nearer NO open: (0.70-0.30)*10 = 4.0.
+        assert await get_daily_pnl(db) == pytest.approx(1.0)
+
+    async def test_only_opposite_side_open_falls_back_to_zero_entry(
+        self, db: Database,
+    ) -> None:
+        t0 = datetime.now(UTC)
+        await insert_trade(db, _trade(
+            action="open", price=0.40, side="yes",
+            timestamp=t0 - timedelta(hours=1),
+        ))
+        await insert_trade(db, _trade(
+            action="close", price=0.50, side="no", timestamp=t0,
+        ))
+        # Side-blind matched cross-side: (0.50-0.40)*10 = 1.0. Correct
+        # is the zero-entry COALESCE fallback.
+        assert await get_daily_pnl(db) == pytest.approx(5.0)
+
+
+class TestDailyPnlMixedTimestampFormats:
+    """#695: raw string compare let a LATER space-format open match an
+    EARLIER ISO close (' ' < 'T'), and the raw sort ranked ISO rows
+    above space-format ones."""
+
+    @staticmethod
+    async def _raw_open(db: Database, *, price: float, ts: str) -> None:
+        await db.conn.execute(
+            """INSERT INTO trades (ticker, action, side, count, price,
+               model_probability, gimme_score, edge, kelly_fraction,
+               rationale, agent, timestamp)
+               VALUES ('KXTEST', 'open', 'yes', 10, ?, 0.8, 70, 0.1,
+                       0.02, 'legacy', 'closer', ?)""",
+            (price, ts),
+        )
+        await db.conn.commit()
+
+    async def test_space_format_open_after_close_does_not_match(
+        self, db: Database,
+    ) -> None:
+        from datetime import datetime as dt
+
+        today = dt.now(UTC).strftime("%Y-%m-%d")
+        # SINGLE space-format open LATER than the close — a second
+        # earlier ISO open would let the raw ORDER BY mask the WHERE
+        # bug by ranking the ISO row first.
+        await self._raw_open(db, price=0.90, ts=f"{today} 15:00:00")
+        await insert_trade(db, _trade(
+            action="close", price=0.50,
+            timestamp=dt.fromisoformat(f"{today}T14:00:00+00:00"),
+        ))
+        # Pre-fix: (0.50-0.90)*10 = -4.0. Post-fix: zero-entry
+        # fallback (0.50-0)*10 = 5.0. today= pins the date against a
+        # UTC-midnight rollover mid-test.
+        assert await get_daily_pnl(db, today=today) == pytest.approx(5.0)
+
+    async def test_space_format_open_orders_correctly(
+        self, db: Database,
+    ) -> None:
+        from datetime import datetime as dt
+
+        today = dt.now(UTC).strftime("%Y-%m-%d")
+        await insert_trade(db, _trade(
+            action="open", price=0.40,
+            timestamp=dt.fromisoformat(f"{today}T10:00:00+00:00"),
+        ))
+        # The REAL most-recent open, in legacy format.
+        await self._raw_open(db, price=0.60, ts=f"{today} 12:00:00")
+        await insert_trade(db, _trade(
+            action="close", price=0.70,
+            timestamp=dt.fromisoformat(f"{today}T13:00:00+00:00"),
+        ))
+        # Raw ORDER BY ranked the ISO 10:00 row first: (0.70-0.40)*10
+        # = 3.0. Normalized picks the 12:00 space open.
+        assert await get_daily_pnl(db, today=today) == pytest.approx(1.0)
+
+
+    async def test_same_second_ties_break_by_id(
+        self, db: Database,
+    ) -> None:
+        """#695 review: legacy second-precision rows can tie — the
+        id DESC tie-break makes the pick deterministic (latest
+        insert), not engine-arbitrary."""
+        from datetime import datetime as dt
+
+        today = dt.now(UTC).strftime("%Y-%m-%d")
+        await self._raw_open(db, price=0.20, ts=f"{today} 09:00:00")
+        await self._raw_open(db, price=0.55, ts=f"{today} 09:00:00")
+        await insert_trade(db, _trade(
+            action="close", price=0.60,
+            timestamp=dt.fromisoformat(f"{today}T10:00:00+00:00"),
+        ))
+        # Without the tie-break sqlite picked the FIRST open (0.20)
+        # → 4.0; deterministic latest-insert pick → 0.5.
+        assert await get_daily_pnl(db, today=today) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

Resolves #695. `DAILY_PNL_SQL` — the number behind `check_daily_loss` (the real-capital daily-loss trigger) and the clubhouse risk panel via the shared #680 constant — matched the open leg by ticker only, comparing raw timestamp strings.

**Side-scoped matching.** Under `side='both'`, a close could match the *nearer opposite side's* open (independent positions), skewing the trigger in either direction. `AND o.side = c.side` now mirrors the already-side-scoped `count_opened_closed`.

**Format-normalized comparison AND ordering.** `' ' < 'T'` lexically, so a *later* space-format open wrongly satisfied `o.timestamp <= c.timestamp` against an *earlier* ISO close — and the fix had to cover the ORDER BY too: the raw sort ranked every ISO row above every space-format row, so the WHERE fix alone would admit the right candidates then pick the wrong "most recent" (plan-caught). Both use the house `replace(' ','T')` pattern with an `o.id DESC` tie-break. The review **empirically reproduced all four failure modes** against the old SQL in a scratch DB — each new test's pre-fix number matches its comment exactly (4.0→1.0, 1.0→5.0, −4.0→5.0, 3.0→1.0).

**Documented approximation.** The entry price is the most-recent open, not a size-weighted average across scale-ins — deliberate, documented in the docstring with a warning that changing the averaging changes what the trigger trips on.

**Review extensions:** the identical two defects fixed in the sibling queries `get_open_trade_for_ticker` (plus a `side` scope — the size_up thesis-inheritance caller must not read the other leg's thesis under `both`) and `get_entry_analytics`' ordering; the lexical-vs-`datetime()` normalization choice documented (microsecond preservation, no NULLed rows); the new tests' UTC-midnight flake window closed via explicit `today=`; the same-second id tie-break pinned (0.5 vs engine-arbitrary 4.0).

## Test plan

- `TestDailyPnlSideScopedMatching` (2) + `TestDailyPnlMixedTimestampFormats` (3, incl. the tie-break pin) — each constructed so the pre-fix number differs, verified failing under the old SQL.
- Clubhouse parity holds via the existing shared-constant test; zero existing pins broke (all fixtures single-side ISO-T).
- Full suite: **1984 passed** on frozen code.

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB