### PR TITLE
Fix #696: disk candle cache for backtest reruns and parameter sweeps

### DIFF
--- a/src/gimmes/backtest/candle_cache.py
+++ b/src/gimmes/backtest/candle_cache.py
@@ -9,8 +9,10 @@ cached, preserving the #655 fetch_failures visibility (a systemic 404
 must keep failing loudly, not become a cached miss).
 
 Failure doctrine: any cache error degrades to fetch-through with ONE
-warning per run and never aborts the backtest. A corrupt cache file is
-recoverable by deleting ~/.gimmes/backtest_cache.db.
+warning per CandleCache instance (the CLI creates one per run) and
+never aborts the backtest; the degraded connection is closed promptly.
+A corrupt cache file is recoverable by deleting
+$GIMMES_HOME/backtest_cache.db.
 """
 
 from __future__ import annotations
@@ -84,6 +86,9 @@ class CandleCache:
             await self._conn.commit()
         except Exception as exc:  # noqa: BLE001 — degrade, never abort
             self._degrade(exc)
+            # A degraded cache is never used again this run — release
+            # the file handle and WAL/shm locks promptly.
+            await self.close()
 
     async def close(self) -> None:
         if self._conn is not None:
@@ -120,6 +125,7 @@ class CandleCache:
             candles = [Candle(**d) for d in json.loads(row[0])]
         except Exception as exc:  # noqa: BLE001 — corrupt row/file
             self._degrade(exc)
+            await self.close()
             return None
         self.hits += 1
         return candles
@@ -148,6 +154,7 @@ class CandleCache:
             await self._conn.commit()
         except Exception as exc:  # noqa: BLE001
             self._degrade(exc)
+            await self.close()
 
     def _degrade(self, exc: Exception) -> None:
         if not self._disabled:

--- a/src/gimmes/backtest/candle_cache.py
+++ b/src/gimmes/backtest/candle_cache.py
@@ -1,0 +1,159 @@
+"""On-disk candle cache for backtest reruns (#696).
+
+Settled-market candle history is immutable, so cached windows never
+invalidate: keys are (ticker, start_ts, end_ts, period_interval), and
+each window derives from the market's fixed close_time — parameter
+sweeps hit 100% warm. Successful fetches are cached INCLUDING empty
+lists (negative caching is what makes reruns fast); failures are never
+cached, preserving the #655 fetch_failures visibility (a systemic 404
+must keep failing loudly, not become a cached miss).
+
+Failure doctrine: any cache error degrades to fetch-through with ONE
+warning per run and never aborts the backtest. A corrupt cache file is
+recoverable by deleting ~/.gimmes/backtest_cache.db.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import zlib
+from dataclasses import asdict
+from pathlib import Path
+
+import aiosqlite
+
+from gimmes.kalshi.historical import Candle
+
+logger = logging.getLogger(__name__)
+
+def _schema_fingerprint() -> int:
+    """31-bit fingerprint of the Candle field set, stamped into
+    ``PRAGMA user_version``. Any Candle evolution changes it, and a
+    mismatched cache is dropped wholesale on open — otherwise a field
+    added WITH a default would deserialize old rows cleanly with
+    stale/default values (silently diverging cached runs from
+    --no-cache runs), and a removed field would degrade every future
+    run until the user manually deleted the DB (review-found)."""
+    names = ",".join(sorted(Candle.__dataclass_fields__))
+    return zlib.crc32(names.encode()) & 0x7FFFFFFF
+
+
+_SCHEMA = """CREATE TABLE IF NOT EXISTS candles (
+    ticker TEXT NOT NULL,
+    start_ts INTEGER NOT NULL,
+    end_ts INTEGER NOT NULL,
+    period_interval INTEGER NOT NULL,
+    candles_json TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    PRIMARY KEY (ticker, start_ts, end_ts, period_interval)
+)"""
+
+
+class CandleCache:
+    """Async SQLite-backed cache; ``get`` returns None on MISS and a
+    list (possibly empty — a legitimate hit) on HIT."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._conn: aiosqlite.Connection | None = None
+        self._disabled = False
+        self.hits = 0
+
+    async def open(self) -> None:
+        try:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = await aiosqlite.connect(self.db_path)
+            await self._conn.execute("PRAGMA journal_mode=WAL")
+            await self._conn.execute("PRAGMA busy_timeout=5000")
+            fingerprint = _schema_fingerprint()
+            async with self._conn.execute(
+                "PRAGMA user_version",
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None or row[0] != fingerprint:
+                # Candle changed shape (or the DB is brand new):
+                # settled history is refetchable, so drop everything
+                # rather than risk misreading old rows.
+                await self._conn.execute("DROP TABLE IF EXISTS candles")
+                await self._conn.execute(
+                    f"PRAGMA user_version = {fingerprint}",
+                )
+            await self._conn.execute(_SCHEMA)
+            await self._conn.commit()
+        except Exception as exc:  # noqa: BLE001 — degrade, never abort
+            self._degrade(exc)
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            try:
+                await self._conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._conn = None
+
+    async def __aenter__(self) -> CandleCache:
+        await self.open()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+    async def get(
+        self, ticker: str, *, start_ts: int, end_ts: int,
+        period_interval: int,
+    ) -> list[Candle] | None:
+        """Cached candles for the window, or None on miss/disabled."""
+        if self._disabled or self._conn is None:
+            return None
+        try:
+            async with self._conn.execute(
+                """SELECT candles_json FROM candles
+                   WHERE ticker = ? AND start_ts = ? AND end_ts = ?
+                     AND period_interval = ?""",
+                (ticker, start_ts, end_ts, period_interval),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None:
+                return None
+            candles = [Candle(**d) for d in json.loads(row[0])]
+        except Exception as exc:  # noqa: BLE001 — corrupt row/file
+            self._degrade(exc)
+            return None
+        self.hits += 1
+        return candles
+
+    async def put(
+        self, ticker: str, *, start_ts: int, end_ts: int,
+        period_interval: int, candles: list[Candle],
+    ) -> None:
+        """Write-through a SUCCESSFUL fetch (empty lists included —
+        immutable negative caching). Callers must never route
+        failures here."""
+        if self._disabled or self._conn is None:
+            return
+        try:
+            await self._conn.execute(
+                """INSERT OR REPLACE INTO candles
+                   (ticker, start_ts, end_ts, period_interval,
+                    candles_json, fetched_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    ticker, start_ts, end_ts, period_interval,
+                    json.dumps([asdict(c) for c in candles]),
+                    int(time.time()),
+                ),
+            )
+            await self._conn.commit()
+        except Exception as exc:  # noqa: BLE001
+            self._degrade(exc)
+
+    def _degrade(self, exc: Exception) -> None:
+        if not self._disabled:
+            logger.warning(
+                "candle cache disabled (%s: %s) — fetching through"
+                " for the rest of this run (#696)",
+                type(exc).__name__, exc,
+            )
+        self._disabled = True

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -7,6 +7,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 
+from gimmes.backtest.candle_cache import CandleCache
 from gimmes.config import GimmesConfig
 from gimmes.kalshi.client import KalshiClient
 from gimmes.kalshi.historical import Candle, get_candlesticks
@@ -256,28 +257,50 @@ async def _fetch_entry_candle(
     entry_ts: int,
     cache: dict[str, list[Candle]],
     failed: set[str],
+    disk: CandleCache | None = None,
 ) -> Candle | None:
     """The ticker's entry-day candle, or None when no candle ends at
     or before entry_ts. The fetch window ends AT entry_ts, so future
     data structurally cannot leak into the engine (#655). Fetch
     failures degrade to None (debug-logged); classification of the
     unusable cases (no history vs one-sided quote) happens at the
-    call site so the funnel can count them separately (#666)."""
+    call site so the funnel can count them separately (#666).
+
+    ``disk`` (#696): a CandleCache consulted between the in-memory
+    miss and the API call, written through on SUCCESS only — a
+    failure never reaches ``put``, structurally (it lives in the
+    except branch), so the #655 fetch_failures visibility is intact
+    on warm reruns.
+    """
     if ticker not in cache:
-        try:
-            cache[ticker] = await get_candlesticks(
-                client, ticker,
-                start_ts=entry_ts - CANDLE_LOOKBACK_DAYS * 86400,
-                end_ts=entry_ts,
-                period_interval=1440,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("candle fetch failed for %s: %s", ticker, exc)
-            cache[ticker] = []
-            # A FAILED fetch is not empty history — the caller
-            # keeps systemic API failures (the #655 endpoint 404
-            # signature) out of the data-sparsity counters (#666).
-            failed.add(ticker)
+        window = {
+            "start_ts": entry_ts - CANDLE_LOOKBACK_DAYS * 86400,
+            "end_ts": entry_ts,
+            "period_interval": 1440,
+        }
+        cached = None
+        if disk is not None:
+            cached = await disk.get(ticker, **window)
+        if cached is not None:
+            cache[ticker] = cached
+        else:
+            try:
+                candles = await get_candlesticks(
+                    client, ticker, **window,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "candle fetch failed for %s: %s", ticker, exc,
+                )
+                cache[ticker] = []
+                # A FAILED fetch is not empty history — the caller
+                # keeps systemic API failures (the #655 endpoint 404
+                # signature) out of the data-sparsity counters (#666).
+                failed.add(ticker)
+            else:
+                cache[ticker] = candles
+                if disk is not None:
+                    await disk.put(ticker, candles=candles, **window)
     return entry_candle_at(cache[ticker], entry_ts)
 
 
@@ -369,6 +392,7 @@ async def run_backtest(
     config: BacktestConfig,
     *,
     fees: FeeMultipliers = DEFAULT_FEE_MULTIPLIERS,
+    candle_cache: CandleCache | None = None,
 ) -> BacktestResult:
     """Run a backtest over historical settled markets.
 
@@ -485,7 +509,7 @@ async def run_backtest(
     # optimistically). One candle fetch per settled market, behind the
     # client's token bucket (~3 min for a full multi-series run).
     original_by_ticker = {m.ticker: m for m in settled}
-    candle_cache: dict[str, list[Candle]] = {}
+    memory_cache: dict[str, list[Candle]] = {}
     entry_candles: dict[str, Candle] = {}
     entry_times: dict[str, datetime] = {}
     skipped_no_candle = 0
@@ -493,6 +517,10 @@ async def run_backtest(
     skipped_one_sided = 0
     fetch_failures = 0
     failed_fetches: set[str] = set()
+    # Snapshot so the summary below logs THIS run's hits — a sweep
+    # driver sharing one CandleCache across run_backtest calls would
+    # otherwise see cumulative hits and negative "API fetches".
+    disk_hits_before = candle_cache.hits if candle_cache is not None else 0
     if (
         gc.scanner.min_days_to_resolution > ENTRY_OFFSET_DAYS
         or gc.scanner.max_days_to_resolution <= ENTRY_OFFSET_DAYS
@@ -518,8 +546,8 @@ async def run_backtest(
         entry_time = close_time - timedelta(days=ENTRY_OFFSET_DAYS)
         entry_ts = int(entry_time.timestamp())
         candle = await _fetch_entry_candle(
-            client, m.ticker, entry_ts, candle_cache,
-            failed=failed_fetches,
+            client, m.ticker, entry_ts, memory_cache,
+            failed=failed_fetches, disk=candle_cache,
         )
         if candle is None and m.ticker in failed_fetches:
             # Distinguish a FAILED fetch from genuinely-empty history:
@@ -577,6 +605,14 @@ async def run_backtest(
     # multi-minute fetch pass would leave days-to-resolution just
     # under ENTRY_OFFSET_DAYS and silently zero out configs with
     # min_days_to_resolution == ENTRY_OFFSET_DAYS (review-found).
+    if candle_cache is not None:
+        disk_hits = candle_cache.hits - disk_hits_before
+        logger.info(
+            "candle pass: %d unique tickers — %d disk-cache hits,"
+            " %d API fetch attempts (#696)",
+            len(memory_cache), disk_hits,
+            len(memory_cache) - disk_hits,
+        )
     synthetic_close = datetime.now(UTC) + timedelta(
         days=ENTRY_OFFSET_DAYS, seconds=60,
     )

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4382,8 +4382,8 @@ def backtest(
     no_cache: bool = typer.Option(
         False, "--no-cache",
         help="Bypass the on-disk candle cache at"
-             " $GIMMES_HOME/backtest_cache.db (default ~/.gimmes)"
-             " (#696)",
+             " $GIMMES_HOME/backtest_cache.db (GIMMES_HOME defaults"
+             " to ~/.gimmes) (#696)",
     ),
 ) -> None:
     """Backtest the gimme strategy on historical settled markets."""

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4379,6 +4379,12 @@ def backtest(
         help="Conservative fill model: entries pay the ask (taker)"
              " instead of the midpoint, with taker fees (#682)",
     ),
+    no_cache: bool = typer.Option(
+        False, "--no-cache",
+        help="Bypass the on-disk candle cache at"
+             " $GIMMES_HOME/backtest_cache.db (default ~/.gimmes)"
+             " (#696)",
+    ),
 ) -> None:
     """Backtest the gimme strategy on historical settled markets."""
     config = load_config()
@@ -4416,11 +4422,13 @@ def backtest(
         )
         # #666: the selection replay fetches candles for every scanned
         # market (~minutes) — surface the engine's progress logs so
-        # the run doesn't look hung. Scoped to the backtest logger;
-        # INFO records are otherwise dropped (no root handler).
+        # the run doesn't look hung. Scoped to the backtest PARENT
+        # logger so the candle cache's degradation warning (#696) is
+        # also visible; INFO records are otherwise dropped (no root
+        # handler, and lastResort visibility is incidental).
         import logging
 
-        bt_logger = logging.getLogger("gimmes.backtest.engine")
+        bt_logger = logging.getLogger("gimmes.backtest")
         bt_logger.setLevel(logging.INFO)
         if not bt_logger.handlers:
             handler = logging.StreamHandler()
@@ -4430,7 +4438,21 @@ def backtest(
             # ancestor handlers (duplicate lines)
             bt_logger.propagate = False
         async with KalshiClient(config) as client:
-            result = await run_backtest(client, bt_config)
+            if no_cache:
+                result = await run_backtest(client, bt_config)
+            else:
+                # #696: settled-market candles are immutable — the
+                # disk cache makes reruns/parameter sweeps near-
+                # instant. Corruption degrades to fetch-through.
+                from gimmes.backtest.candle_cache import CandleCache
+                from gimmes.config import GIMMES_HOME
+
+                async with CandleCache(
+                    GIMMES_HOME / "backtest_cache.db",
+                ) as cache:
+                    result = await run_backtest(
+                        client, bt_config, candle_cache=cache,
+                    )
 
         if json_output:
             console.print_json(json.dumps(backtest_result_to_json(result)))

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -1291,8 +1291,10 @@ class TestTakerFillReviewPins(_EntryDayHarness):
         assert result.skipped_zero_sizing == 1  # one market
 
 
-def test_cli_taker_fill_flag_wired() -> None:
-    """#682: --taker-fill reaches BacktestConfig through the CLI."""
+def _invoke_backtest_cli(tmp_path, *extra_args):
+    """Run the backtest CLI with run_backtest faked out; returns
+    (result, captured) where captured records the config and the
+    candle_cache kwarg the CLI passed."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from typer.testing import CliRunner
@@ -1302,8 +1304,9 @@ def test_cli_taker_fill_flag_wired() -> None:
 
     captured: dict = {}
 
-    async def _fake_run(client, config):
+    async def _fake_run(client, config, **kwargs):
         captured["config"] = config
+        captured["cache"] = kwargs.get("candle_cache")
         return BacktestResult(
             config=config, trades=[], final_balance=10_000.0,
             equity_curve=[], markets_scanned=0,
@@ -1326,11 +1329,166 @@ def test_cli_taker_fill_flag_wired() -> None:
         patch("gimmes.backtest.engine.run_backtest", _fake_run),
         # the backtest command opens its own KalshiClient
         patch("gimmes.kalshi.client.KalshiClient", _FakeClient),
+        # #696 review: the default path builds the cache at
+        # GIMMES_HOME — patched to tmp_path so the test never
+        # writes into the user's real ~/.gimmes (the CLI imports
+        # GIMMES_HOME lazily, so the module attribute is live).
+        patch("gimmes.config.GIMMES_HOME", tmp_path),
     ):
         result = CliRunner().invoke(app, [
             "backtest", "--from", "2026-05-01", "--to", "2026-05-10",
-            "--taker-fill", "--json",
+            "--json", *extra_args,
         ])
+    return result, captured
 
+
+def test_cli_taker_fill_flag_wired(tmp_path) -> None:
+    """#682: --taker-fill reaches BacktestConfig through the CLI."""
+    result, captured = _invoke_backtest_cli(tmp_path, "--taker-fill")
     assert result.exit_code == 0, result.output
     assert captured["config"].taker_fill is True
+    # #696: the default path constructs a real CandleCache on disk.
+    assert captured["cache"] is not None
+    assert (tmp_path / "backtest_cache.db").exists()
+
+
+def test_cli_no_cache_flag_bypasses_disk(tmp_path) -> None:
+    """#696: --no-cache never constructs a cache or touches disk."""
+    result, captured = _invoke_backtest_cli(tmp_path, "--no-cache")
+    assert result.exit_code == 0, result.output
+    assert captured["cache"] is None
+    assert not (tmp_path / "backtest_cache.db").exists()
+
+
+class TestDiskCandleCache(_EntryDayHarness):
+    """#696: warm reruns make zero API calls with identical results;
+    failures are never cached (the #655 visibility holds warm)."""
+
+    @pytest.mark.asyncio
+    async def test_cold_then_warm_rerun_zero_fetches(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        from gimmes.backtest.candle_cache import CandleCache
+
+        markets = self._markets()
+        m = markets[0]
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m), yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        calls = self._stub(monkeypatch, markets, candles)
+        config = self._permissive_config()
+
+        async with CandleCache(tmp_path / "c.db") as cache:
+            first = await run_backtest(
+                client=None, config=config, candle_cache=cache,
+            )
+        cold_calls = len(calls)
+        assert cold_calls >= 1
+
+        async with CandleCache(tmp_path / "c.db") as cache:
+            second = await run_backtest(
+                client=None, config=config, candle_cache=cache,
+            )
+        assert len(calls) == cold_calls  # ZERO new API calls warm
+        assert cache.hits >= 1
+        assert len(second.trades) == len(first.trades)
+        assert second.trades[0].entry_price == pytest.approx(
+            first.trades[0].entry_price,
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_history_negative_cached(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        from gimmes.backtest.candle_cache import CandleCache
+
+        markets = self._markets()
+        m = markets[0]
+        calls = self._stub(monkeypatch, markets, {m.ticker: []})
+        config = self._permissive_config()
+
+        async with CandleCache(tmp_path / "c.db") as cache:
+            first = await run_backtest(
+                client=None, config=config, candle_cache=cache,
+            )
+        cold_calls = len(calls)
+        assert first.skipped_no_candle == 1
+
+        async with CandleCache(tmp_path / "c.db") as cache:
+            second = await run_backtest(
+                client=None, config=config, candle_cache=cache,
+            )
+        assert len(calls) == cold_calls  # negative cache hit
+        # The funnel is undistorted warm.
+        assert second.skipped_no_candle == 1
+
+    @pytest.mark.asyncio
+    async def test_failures_never_cached(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        from gimmes.backtest.candle_cache import CandleCache
+
+        markets = self._markets()
+        m = markets[0]
+        calls = self._stub(
+            monkeypatch, markets,
+            {m.ticker: RuntimeError("endpoint 404")},
+        )
+        config = self._permissive_config()
+
+        async with CandleCache(tmp_path / "c.db") as cache:
+            first = await run_backtest(
+                client=None, config=config, candle_cache=cache,
+            )
+        cold_calls = len(calls)
+        assert first.fetch_failures == 1
+
+        async with CandleCache(tmp_path / "c.db") as cache:
+            second = await run_backtest(
+                client=None, config=config, candle_cache=cache,
+            )
+        # The fetch RETRIES warm — a failure is not empty history.
+        assert len(calls) == cold_calls * 2
+        assert second.fetch_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_engine_uses_the_documented_window_keys(
+        self, monkeypatch,
+    ) -> None:
+        """A recording fake pins the cache-key contract: the window
+        derives from close_time, making sweep keys stable."""
+        from gimmes.backtest.engine import (
+            CANDLE_LOOKBACK_DAYS,
+        )
+
+        markets = self._markets()
+        m = markets[0]
+        entry_ts = self._entry_ts(m)
+        candles = {m.ticker: [_make_candle(
+            ts=entry_ts, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+
+        recorded: list[dict] = []
+
+        class _FakeCache:
+            hits = 0
+
+            async def get(self, ticker, **kw):
+                recorded.append({"op": "get", "ticker": ticker, **kw})
+                return None
+
+            async def put(self, ticker, *, candles, **kw):
+                recorded.append({"op": "put", "ticker": ticker, **kw})
+
+        await run_backtest(
+            client=None, config=self._permissive_config(),
+            candle_cache=_FakeCache(),
+        )
+        gets = [r for r in recorded if r["op"] == "get"]
+        puts = [r for r in recorded if r["op"] == "put"]
+        assert gets and puts
+        for r in gets + puts:
+            assert r["end_ts"] == entry_ts
+            assert r["start_ts"] == entry_ts - CANDLE_LOOKBACK_DAYS * 86400
+            assert r["period_interval"] == 1440

--- a/tests/unit/test_candle_cache.py
+++ b/tests/unit/test_candle_cache.py
@@ -124,6 +124,22 @@ async def test_put_failure_degrades_not_raises(
     assert len(warnings) == 1
 
 
+async def test_degrade_closes_connection_promptly(tmp_path: Path) -> None:
+    """Degrading must also release the file handle and WAL/shm locks
+    (the cache is never used again this run) — and _disabled must be
+    set independently of the close, since it alone carries the
+    one-warning guarantee (review-found: without this pin, a mutant
+    that never sets _disabled passes every degradation test)."""
+    async with CandleCache(tmp_path / "c.db") as cache:
+        async def _boom(*args: object, **kwargs: object) -> None:
+            raise sqlite3.OperationalError("disk I/O error")
+
+        cache._conn.execute = _boom  # type: ignore[method-assign]
+        await cache.put("KX1", candles=[_candle()], **_WINDOW)
+        assert cache._conn is None  # handle released on degrade
+        assert cache._disabled
+
+
 async def test_corrupt_file_degrades_with_one_warning(
     tmp_path: Path, caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -134,6 +150,7 @@ async def test_corrupt_file_degrades_with_one_warning(
         logging.WARNING, logger="gimmes.backtest.candle_cache",
     ):
         async with CandleCache(path) as cache:
+            assert cache._conn is None  # open-failure closes promptly
             assert await cache.get("KX1", **_WINDOW) is None
             await cache.put("KX1", candles=[_candle()], **_WINDOW)
             assert await cache.get("KX1", **_WINDOW) is None

--- a/tests/unit/test_candle_cache.py
+++ b/tests/unit/test_candle_cache.py
@@ -1,0 +1,166 @@
+"""Disk candle cache (#696): immutable settled-market windows, empty
+lists as legitimate hits (negative caching), failures never cached,
+and corruption degrading to fetch-through with one warning."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from gimmes.backtest.candle_cache import CandleCache
+from gimmes.kalshi.historical import Candle
+
+
+@pytest.fixture(autouse=True)
+def _propagate_to_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The backtest CLI sets propagate=False on the gimmes.backtest
+    logger (it owns its handler's output); caplog captures at ROOT,
+    so any CLI test running first would strand this module's warning
+    assertions. Restore propagation here — order-independence, not a
+    behavior change (monkeypatch undoes it per test)."""
+    monkeypatch.setattr(
+        logging.getLogger("gimmes.backtest"), "propagate", True,
+    )
+
+
+def _candle(ts: int = 1_750_000_000, price: float = 0.42) -> Candle:
+    return Candle(
+        end_period_ts=ts,
+        yes_bid_open=price - 0.01, yes_bid_high=price,
+        yes_bid_low=price - 0.03, yes_bid_close=price - 0.01,
+        yes_ask_open=price + 0.01, yes_ask_high=price + 0.03,
+        yes_ask_low=price, yes_ask_close=price + 0.01,
+        price_open=price, price_high=price + 0.02,
+        price_low=price - 0.02, price_close=price,
+        volume=123,
+        open_interest=456,
+    )
+
+
+_WINDOW = {"start_ts": 100, "end_ts": 400, "period_interval": 1440}
+
+
+async def test_miss_put_hit_roundtrips_all_fields(tmp_path: Path) -> None:
+    async with CandleCache(tmp_path / "c.db") as cache:
+        assert await cache.get("KX1", **_WINDOW) is None
+        original = [_candle(), _candle(ts=1_750_086_400, price=0.55)]
+        await cache.put("KX1", candles=original, **_WINDOW)
+        got = await cache.get("KX1", **_WINDOW)
+    assert got == original  # dataclass equality — all 15 fields
+    assert cache.hits == 1
+
+
+async def test_empty_list_is_a_hit_not_a_miss(tmp_path: Path) -> None:
+    """Negative caching: empty settled history is immutable and valid
+    — None means miss, [] means hit."""
+    async with CandleCache(tmp_path / "c.db") as cache:
+        await cache.put("KXEMPTY", candles=[], **_WINDOW)
+        got = await cache.get("KXEMPTY", **_WINDOW)
+    assert got == []
+    assert got is not None
+    assert cache.hits == 1
+
+
+async def test_key_discrimination(tmp_path: Path) -> None:
+    async with CandleCache(tmp_path / "c.db") as cache:
+        await cache.put("KX1", candles=[_candle()], **_WINDOW)
+        assert await cache.get(
+            "KX1", start_ts=999, end_ts=400, period_interval=1440,
+        ) is None
+        assert await cache.get(
+            "KX1", start_ts=100, end_ts=400, period_interval=60,
+        ) is None
+        assert await cache.get("KX2", **_WINDOW) is None
+
+
+async def test_persists_across_instances(tmp_path: Path) -> None:
+    path = tmp_path / "c.db"
+    async with CandleCache(path) as cache:
+        await cache.put("KX1", candles=[_candle()], **_WINDOW)
+    async with CandleCache(path) as fresh:
+        got = await fresh.get("KX1", **_WINDOW)
+    assert got == [_candle()]
+
+
+async def test_schema_drift_drops_and_self_heals(tmp_path: Path) -> None:
+    """A Candle-shape change (stale user_version fingerprint) drops
+    the whole cache on open instead of misreading old rows — and the
+    cache repopulates rather than degrading forever."""
+    path = tmp_path / "c.db"
+    async with CandleCache(path) as cache:
+        await cache.put("KX1", candles=[_candle()], **_WINDOW)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA user_version = 1")  # stale fingerprint
+    conn.commit()
+    conn.close()
+
+    async with CandleCache(path) as fresh:
+        assert await fresh.get("KX1", **_WINDOW) is None  # dropped
+        await fresh.put("KX1", candles=[_candle()], **_WINDOW)
+        assert await fresh.get("KX1", **_WINDOW) == [_candle()]
+
+
+async def test_put_failure_degrades_not_raises(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A mid-run write failure (disk full, dropped connection) must
+    not abort the backtest — the engine calls put unguarded."""
+    async with CandleCache(tmp_path / "c.db") as cache:
+        async def _boom(*args: object, **kwargs: object) -> None:
+            raise sqlite3.OperationalError("disk I/O error")
+
+        cache._conn.execute = _boom  # type: ignore[method-assign]
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.candle_cache",
+        ):
+            await cache.put("KX1", candles=[_candle()], **_WINDOW)
+            assert await cache.get("KX1", **_WINDOW) is None
+    warnings = [
+        r for r in caplog.records if "candle cache disabled" in r.message
+    ]
+    assert len(warnings) == 1
+
+
+async def test_corrupt_file_degrades_with_one_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    path = tmp_path / "c.db"
+    path.write_bytes(b"this is not a sqlite database at all........")
+
+    with caplog.at_level(
+        logging.WARNING, logger="gimmes.backtest.candle_cache",
+    ):
+        async with CandleCache(path) as cache:
+            assert await cache.get("KX1", **_WINDOW) is None
+            await cache.put("KX1", candles=[_candle()], **_WINDOW)
+            assert await cache.get("KX1", **_WINDOW) is None
+    warnings = [
+        r for r in caplog.records if "candle cache disabled" in r.message
+    ]
+    assert len(warnings) == 1  # exactly one, not per-op spam
+
+
+async def test_corrupt_row_degrades_not_crashes(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    path = tmp_path / "c.db"
+    async with CandleCache(path) as cache:
+        await cache.put("KX1", candles=[_candle()], **_WINDOW)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "UPDATE candles SET candles_json = 'not json' WHERE ticker='KX1'",
+    )
+    conn.commit()
+    conn.close()
+
+    with caplog.at_level(
+        logging.WARNING, logger="gimmes.backtest.candle_cache",
+    ):
+        async with CandleCache(path) as fresh:
+            assert await fresh.get("KX1", **_WINDOW) is None
+    assert any(
+        "candle cache disabled" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary

Settled-market candle history is immutable, so this caches it on disk keyed `(ticker, start_ts, end_ts, period_interval)`. Windows derive from each market's fixed `close_time`, so backtest reruns and parameter sweeps hit 100% warm and skip the ~minutes-long candle fetch pass entirely.

- **`CandleCache`** (aiosqlite, WAL, at `$GIMMES_HOME/backtest_cache.db`): `get` returns `None` on miss and a list on hit — an **empty list is a hit** (negative caching of genuinely empty history is what makes reruns fast). `put` write-through on successful fetches only.
- **Failures are never cached**: the engine's `try/except/else` makes caching a failed fetch structurally impossible, so the #655 `fetch_failures` visibility is intact on warm reruns — a systemic API failure retries and fails loudly every run instead of masquerading as data sparsity.
- **Degrade, never abort**: any cache error (corrupt file, corrupt row, mid-run write failure) falls back to fetch-through with exactly one warning. Recovery is deleting the DB file.
- **Schema-drift protection** (review-found): `PRAGMA user_version` is stamped with a fingerprint of the `Candle` field set; any dataclass evolution drops the cache wholesale on open. Without it, a field added *with a default* would silently deserialize stale rows (cached runs diverging from `--no-cache` runs), and a removed field would degrade every future run until manual deletion.
- **CLI**: cache on by default; `--no-cache` bypasses it entirely (no construction, no disk touch — pinned by test). The backtest logging handler moved to the `gimmes.backtest` parent logger so the cache's degradation warning is deliberately visible rather than riding on Python's last-resort handler.
- **Engine** logs a per-run hit/fetch summary, snapshot-deltaed so a sweep driver sharing one cache instance across `run_backtest` calls logs correct numbers.

Review pipeline: three review agents (code review, silent-failure hunt, test analysis) + simplifier pass (no changes needed). The one ≥80 finding — the CLI wiring test writing a real `~/.gimmes/backtest_cache.db` (flagged independently at 90/85, empirically confirmed) — is fixed by patching `GIMMES_HOME`; sub-threshold fixes taken: schema fingerprint, hits snapshot, cursor lifecycle, `--no-cache` help text, logger scope.

**Deferred** (issue creation was permission-blocked this session; needs filing): `get_candlesticks` parses a 200 response *missing* the `candlesticks` key as empty history via `data.get("candlesticks", [])` — under this cache that anomaly would be negative-cached permanently. Proposed fix is raising on the missing key so shape anomalies route into the failed path; deferred because it changes behavior for all call sites.

Closes #696

## Test plan

- 10 new tests: 8 unit (`tests/unit/test_candle_cache.py`: round-trip of all 15 Candle fields, empty-list-as-hit, key discrimination, cross-instance persistence, schema-drift drop-and-self-heal, put-failure degradation, corrupt-file and corrupt-row degradation with exactly one warning) + `TestDiskCandleCache` integration (cold-then-warm rerun with **zero** API calls and identical trades; empty-history negative caching with `skipped_no_candle` counted both runs; failure retried warm with `fetch_failures == 1` both runs; window-key contract via recording fake).
- CLI: default path constructs the cache (in a patched `GIMMES_HOME`), `--no-cache` passes `None` and touches no disk.
- Full suite: **1997 passed** (16:11). Existing pins untouched — `run_backtest`'s `candle_cache` defaults to `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB