### PR TITLE
Fix #704: candlestick shape anomalies raise instead of parsing as empty/zero data

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -270,7 +270,9 @@ async def _fetch_entry_candle(
     miss and the API call, written through on SUCCESS only — a
     failure never reaches ``put``, structurally (it lives in the
     except branch), so the #655 fetch_failures visibility is intact
-    on warm reruns.
+    on warm reruns. get_candlesticks raises on envelope/shape
+    anomalies (#704), so a renamed field lands in ``failed`` too —
+    counted, never cached.
     """
     if ticker not in cache:
         window = {

--- a/src/gimmes/kalshi/historical.py
+++ b/src/gimmes/kalshi/historical.py
@@ -49,7 +49,26 @@ def _ohlc(group: dict, field: str) -> float:  # type: ignore[type-arg]
         return 0.0
 
 
-def _require_close(group: object, name: str) -> None:
+def _quote_group(data: dict, name: str) -> dict:  # type: ignore[type-arg]
+    """Normalize a candle's quote group. Absent or JSON-null is
+    treated as equivalent to the VERIFIED group-omission case (quiet
+    periods — keeps the legacy zero-default path; null is the classic
+    nil-without-omitempty serialization of the same state); any other
+    non-dict value is a shape anomaly
+    that must raise the documented ValueError, not leak an
+    AttributeError/TypeError out of _ohlc (#704)."""
+    value = data.get(name)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"candle {name} group is not an object:"
+            f" {type(value).__name__}",
+        )
+    return value
+
+
+def _require_close(group: dict, name: str) -> None:  # type: ignore[type-arg]
     """A non-empty quote group must carry a NUMERIC close in a known
     spelling. A missing key means an API rename (#655: close ->
     close_dollars) and a non-coercible value means a value-shape
@@ -61,11 +80,6 @@ def _require_close(group: object, name: str) -> None:
     and the `price` group is verifiably partial)."""
     if not group:
         return
-    if not isinstance(group, dict):
-        raise ValueError(
-            f"candle {name} group is not an object:"
-            f" {type(group).__name__}",
-        )
     if "close_dollars" not in group and "close" not in group:
         raise ValueError(
             f"candle {name} group has no close field: {sorted(group)}",
@@ -89,15 +103,22 @@ def _parse_candle(data: dict) -> Candle:  # type: ignore[type-arg]
         raise ValueError(
             f"candle has no end_period_ts field: {sorted(data)}",
         )
-    yes_bid = data.get("yes_bid", {})
-    yes_ask = data.get("yes_ask", {})
-    price = data.get("price", {})
-    # Only the groups the backtest consumes — the live `price` group
-    # is verifiably partial (open/close only), so no guard there.
+    try:
+        end_period_ts = int(data["end_period_ts"])
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"candle end_period_ts is not numeric:"
+            f" {data['end_period_ts']!r}",
+        ) from None
+    yes_bid = _quote_group(data, "yes_bid")
+    yes_ask = _quote_group(data, "yes_ask")
+    price = _quote_group(data, "price")
+    # Close guard only on the groups the backtest consumes — the live
+    # `price` group is verifiably partial (open/close only).
     _require_close(yes_bid, "yes_bid")
     _require_close(yes_ask, "yes_ask")
     return Candle(
-        end_period_ts=int(data["end_period_ts"]),
+        end_period_ts=end_period_ts,
         yes_bid_open=_ohlc(yes_bid, "open"),
         yes_bid_high=_ohlc(yes_bid, "high"),
         yes_bid_low=_ohlc(yes_bid, "low"),

--- a/src/gimmes/kalshi/historical.py
+++ b/src/gimmes/kalshi/historical.py
@@ -49,13 +49,55 @@ def _ohlc(group: dict, field: str) -> float:  # type: ignore[type-arg]
         return 0.0
 
 
+def _require_close(group: object, name: str) -> None:
+    """A non-empty quote group must carry a NUMERIC close in a known
+    spelling. A missing key means an API rename (#655: close ->
+    close_dollars) and a non-coercible value means a value-shape
+    change — either way the zero-default would mint an all-zero
+    candle that parses, gets disk-cached (#696), and miscounts as a
+    one-sided quote (#704). A PRESENT close key with value 0 is a
+    legal 0.00 quote and passes; empty/missing groups keep the legacy
+    zero-default behavior (live data verifiably omits whole groups,
+    and the `price` group is verifiably partial)."""
+    if not group:
+        return
+    if not isinstance(group, dict):
+        raise ValueError(
+            f"candle {name} group is not an object:"
+            f" {type(group).__name__}",
+        )
+    if "close_dollars" not in group and "close" not in group:
+        raise ValueError(
+            f"candle {name} group has no close field: {sorted(group)}",
+        )
+    value = group.get("close_dollars", group.get("close"))
+    try:
+        float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"candle {name} close is not numeric: {value!r}",
+        ) from None
+
+
 def _parse_candle(data: dict) -> Candle:  # type: ignore[type-arg]
     """Parse a candlestick from the Kalshi API response."""
+    if "end_period_ts" not in data:
+        # The engine selects the entry candle and staleness-checks by
+        # this timestamp — a renamed key would zero-default, price
+        # every market from an arbitrary candle, and disk-cache the
+        # result (#704).
+        raise ValueError(
+            f"candle has no end_period_ts field: {sorted(data)}",
+        )
     yes_bid = data.get("yes_bid", {})
     yes_ask = data.get("yes_ask", {})
     price = data.get("price", {})
+    # Only the groups the backtest consumes — the live `price` group
+    # is verifiably partial (open/close only), so no guard there.
+    _require_close(yes_bid, "yes_bid")
+    _require_close(yes_ask, "yes_ask")
     return Candle(
-        end_period_ts=int(data.get("end_period_ts", 0)),
+        end_period_ts=int(data["end_period_ts"]),
         yes_bid_open=_ohlc(yes_bid, "open"),
         yes_bid_high=_ohlc(yes_bid, "high"),
         yes_bid_low=_ohlc(yes_bid, "low"),
@@ -185,6 +227,13 @@ async def get_candlesticks(
 
     Returns:
         List of Candle objects sorted by end_period_ts ascending.
+
+    Raises:
+        ValueError: when the response body is not a dict containing a
+            ``candlesticks`` key, or a candle's quote group lacks any
+            recognized close field — a shape anomaly must land in the
+            backtest's fetch_failures counter, never in the disk
+            cache's permanent negative entries (#704).
     """
     params: dict[str, str | int] = {
         "start_ts": start_ts,
@@ -196,6 +245,18 @@ async def get_candlesticks(
         f"/series/{series_ticker}/markets/{ticker}/candlesticks",
         params=params,
     )
-    candles = [_parse_candle(c) for c in data.get("candlesticks", [])]
+    candles_raw = data.get("candlesticks") if isinstance(data, dict) else None
+    if not isinstance(candles_raw, list):
+        # Missing/non-list value != present-but-empty list: a shape
+        # change (field rename, error-in-200 body, null value) must
+        # surface as a fetch failure the engine can count, not parse
+        # as empty history the disk cache would negative-cache
+        # permanently (#704).
+        raise ValueError(
+            f"Unexpected candlesticks response for {ticker}: no"
+            f" 'candlesticks' list (got"
+            f" {sorted(data) if isinstance(data, dict) else type(data).__name__})",
+        )
+    candles = [_parse_candle(c) for c in candles_raw]
     candles.sort(key=lambda c: c.end_period_ts)
     return candles

--- a/tests/unit/test_historical.py
+++ b/tests/unit/test_historical.py
@@ -245,13 +245,34 @@ class TestParseCandleRenameDetection:
             })
 
     def test_non_dict_group_raises(self) -> None:
-        """A scalar group value raises the documented ValueError, not
-        garbled substring-membership semantics."""
-        with pytest.raises(ValueError, match="yes_bid"):
+        """A scalar group value raises the documented ValueError from
+        the _quote_group guard — the match pins WHICH guard fired
+        (review-found: a bare group-name match passed coincidentally
+        via substring membership on the string), and the int case has
+        no such coincidence to hide behind."""
+        for bad in ("0.34", 34):
+            with pytest.raises(
+                ValueError, match="yes_bid group is not an object",
+            ):
+                _parse_candle({
+                    "end_period_ts": 1,
+                    "yes_bid": bad,
+                    "yes_ask": {"close_dollars": "0.3600"},
+                })
+
+    def test_non_dict_price_group_raises(self) -> None:
+        """The object-shape guard covers price too (new in #704 —
+        the close guard stays yes_bid/yes_ask-only, but a scalar
+        price group is still a shape anomaly, not zero-defaultable
+        data)."""
+        with pytest.raises(
+            ValueError, match="price group is not an object",
+        ):
             _parse_candle({
                 "end_period_ts": 1,
-                "yes_bid": "0.34",
+                "yes_bid": {"close_dollars": "0.3400"},
                 "yes_ask": {"close_dollars": "0.3600"},
+                "price": "0.35",
             })
 
     def test_missing_end_period_ts_raises(self) -> None:
@@ -263,6 +284,30 @@ class TestParseCandleRenameDetection:
                 "yes_bid": {"close_dollars": "0.3400"},
                 "yes_ask": {"close_dollars": "0.3600"},
             })
+
+    def test_non_numeric_end_period_ts_raises(self) -> None:
+        """A present-but-null timestamp raises the documented
+        ValueError, not a TypeError from int(None) (Copilot-found)."""
+        with pytest.raises(ValueError, match="end_period_ts"):
+            _parse_candle({
+                "end_period_ts": None,
+                "yes_bid": {"close_dollars": "0.3400"},
+                "yes_ask": {"close_dollars": "0.3600"},
+            })
+
+    def test_null_group_treated_as_omitted(self) -> None:
+        """JSON null for a quote group means omission (legal in quiet
+        periods) — zero-defaults, no raise, and no AttributeError from
+        _ohlc on None (Copilot-found)."""
+        candle = _parse_candle({
+            "end_period_ts": 1,
+            "yes_bid": None,
+            "yes_ask": {"close_dollars": "0.3600"},
+            "price": None,
+        })
+        assert candle.yes_bid_close == 0.0
+        assert candle.yes_ask_close == 0.36
+        assert candle.price_close == 0.0
 
 
 class TestListAllHistoricalMarketsFiltering:

--- a/tests/unit/test_historical.py
+++ b/tests/unit/test_historical.py
@@ -139,6 +139,131 @@ class TestGetCandlesticks:
 
         assert candles == []
 
+    @pytest.mark.asyncio
+    async def test_missing_candlesticks_key_raises(
+        self, mock_client: AsyncMock,
+    ) -> None:
+        """#704: missing key != empty history. A shape change (field
+        rename, error-in-200 body) must raise so the engine counts a
+        fetch failure — parsing it as [] would let the #696 disk
+        cache negative-cache the anomaly permanently. The ticker is
+        pinned in the message — it is the operator's only lead."""
+        mock_client.get.return_value = {"error": {"code": "internal"}}
+
+        with pytest.raises(ValueError, match=r"KXTEST.*candlesticks"):
+            await get_candlesticks(
+                mock_client, "KXTEST",
+                start_ts=1700000000, end_ts=1700100000,
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_dict_body_raises(
+        self, mock_client: AsyncMock,
+    ) -> None:
+        """#704: a 200 whose JSON body is not a dict must raise the
+        same clear ValueError, not an incidental
+        AttributeError/TypeError — for EVERY non-dict type, not just
+        ones where `in` happens to work (review-found: a bare `not in`
+        guard passes for [] but TypeErrors for None/int)."""
+        for body in ([], None, 42):
+            mock_client.get.return_value = body
+
+            with pytest.raises(ValueError, match="candlesticks"):
+                await get_candlesticks(
+                    mock_client, "KXTEST",
+                    start_ts=1700000000, end_ts=1700100000,
+                )
+
+    @pytest.mark.asyncio
+    async def test_null_candlesticks_value_raises(
+        self, mock_client: AsyncMock,
+    ) -> None:
+        """#704: key present but not a list (null value) is the same
+        shape anomaly — documented ValueError, not a TypeError from
+        iterating None."""
+        mock_client.get.return_value = {"candlesticks": None}
+
+        with pytest.raises(ValueError, match="candlesticks"):
+            await get_candlesticks(
+                mock_client, "KXTEST",
+                start_ts=1700000000, end_ts=1700100000,
+            )
+
+
+class TestParseCandleRenameDetection:
+    """#704 (root cause of #655): key ABSENCE, not zero value, is the
+    rename signal — a real 0.00 bid still carries a close key, so the
+    guard has no false-positive overlap with legal zero quotes."""
+
+    def test_renamed_close_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="close"):
+            _parse_candle({
+                "end_period_ts": 1,
+                "yes_bid": {"close_usd": "0.34"},
+                "yes_ask": {"close_usd": "0.36"},
+                "price": {},
+            })
+
+    def test_zero_close_key_present_is_legal(self) -> None:
+        candle = _parse_candle({
+            "end_period_ts": 1,
+            "yes_bid": {"close_dollars": "0.0000"},
+            "yes_ask": {"close_dollars": "0.0100"},
+            "price": {},
+        })
+        assert candle.yes_bid_close == 0.0
+        assert candle.yes_ask_close == 0.01
+
+    def test_partial_price_group_still_allowed(self) -> None:
+        """The live price group is verifiably partial (open/close
+        only) — the guard is scoped to yes_bid/yes_ask."""
+        candle = _parse_candle({
+            "end_period_ts": 1,
+            "yes_bid": {"close_dollars": "0.3000"},
+            "yes_ask": {"close_dollars": "0.4000"},
+            "price": {"open_dollars": "0.3500"},
+        })
+        assert candle.price_close == 0.0
+
+    def test_empty_groups_keep_zero_defaults(self) -> None:
+        """Wholly absent/empty groups keep the legacy zero-default
+        path — group-level omission is legal in quiet periods."""
+        candle = _parse_candle({"end_period_ts": 1})
+        assert candle.yes_bid_close == 0.0
+        assert candle.yes_ask_close == 0.0
+
+    def test_non_numeric_close_value_raises(self) -> None:
+        """A close key that is PRESENT but not coercible to float
+        (null, nested object) is the same rename-class anomaly via a
+        value-shape change — the _ohlc zero-default would otherwise
+        mint a cacheable all-zero candle (review-found)."""
+        with pytest.raises(ValueError, match="close is not numeric"):
+            _parse_candle({
+                "end_period_ts": 1,
+                "yes_bid": {"close_dollars": None},
+                "yes_ask": {"close_dollars": "0.3600"},
+            })
+
+    def test_non_dict_group_raises(self) -> None:
+        """A scalar group value raises the documented ValueError, not
+        garbled substring-membership semantics."""
+        with pytest.raises(ValueError, match="yes_bid"):
+            _parse_candle({
+                "end_period_ts": 1,
+                "yes_bid": "0.34",
+                "yes_ask": {"close_dollars": "0.3600"},
+            })
+
+    def test_missing_end_period_ts_raises(self) -> None:
+        """#704: a renamed timestamp key would zero-default and make
+        the engine price every market from an arbitrary candle — and
+        disk-cache it. Key absence must raise."""
+        with pytest.raises(ValueError, match="end_period_ts"):
+            _parse_candle({
+                "yes_bid": {"close_dollars": "0.3400"},
+                "yes_ask": {"close_dollars": "0.3600"},
+            })
+
 
 class TestListAllHistoricalMarketsFiltering:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A 200 response missing the `candlesticks` key (API rename, error-in-200 body) parsed as genuinely empty history via `data.get(..., [])` — and with the #696 disk cache, that anomaly would be **negative-cached permanently**, counting `skipped_no_candle` instead of `fetch_failures` until the operator deleted `$GIMMES_HOME/backtest_cache.db`.

**Envelope guard**: `get_candlesticks` now raises `ValueError` (house convention for shape anomalies, matching `client._request`'s "Unexpected response") whenever the body is not a dict whose `candlesticks` value is a **list** — missing key, `null` value, and non-dict bodies (`None`, numbers, arrays) all get the documented error instead of an incidental `TypeError`/`AttributeError`. The engine's existing except-branch routes the raise into `failed` → `fetch_failures`: loud, retried every run, structurally unreachable by `disk.put`.

**Value-layer guards** in `_parse_candle`, scoped to exactly what the backtest consumes:
- `end_period_ts` must be present (review-found at 90): a renamed key would zero-default and make the engine price every market from an arbitrary candle — then cache it.
- `_require_close`: a non-empty `yes_bid`/`yes_ask` group must carry `close_dollars` or `close` — **key absence is the #655 rename signal**; a real 0.00 quote still carries its key, so there is zero false-positive overlap with legal zero quotes — and the value must coerce to float (review-found: `close_dollars: null` would zero-default into a cacheable all-zero candle). Empty/missing groups keep legacy zero-defaults (legal in quiet periods); the live `price` group is verifiably partial (open/close only, verified 2026-07-03) and stays unguarded.

**Deliberately out of scope** (residuals, named per review): wholesale group renames are by-construction indistinguishable from legal quiet-period omission; `volume_fp` renames zero-default into scanner-filter rejections (visible in funnel counts); `list_historical_markets`' missing-key default yields a loud `markets_scanned=0` and is never disk-cached. Pre-fix poisoned cache entries (if any anomaly window ever occurred) are not purged — the #696 cache shipped hours before this fix, so real-world exposure is nil; deleting the cache DB remains the remedy.

Review pipeline: three review agents + simplifier. All ≥80 findings fixed (mutation-surviving test body, `candlesticks: null` contract violation, `end_period_ts` residual); test analyzer verified the unit-layer raises compose soundly with the pre-existing engine pins (`fetch_failures` counting, failures-never-cached warm retry).

Closes #704

## Test plan

- 9 new tests in `tests/unit/test_historical.py`: missing key raises (ticker pinned in message), non-dict bodies (`[]`, `None`, `42`) raise the documented ValueError, `{"candlesticks": None}` raises, renamed close raises, present-but-zero close is legal (the false-positive boundary), partial `price` group allowed, empty groups keep zero-defaults, non-numeric close raises, scalar group raises, missing `end_period_ts` raises.
- Engine pins unchanged and still green: any raise → `fetch_failures`, never cached, retried warm (`test_fetch_error_dropped_not_crashed`, `test_failures_never_cached`).
- Full suite: **2008 passed** (16:11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB