### PR TITLE
Fix #707: missed-opportunity audit scores skips by EV after fees, cites only the admitted cohort

### DIFF
--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -10,6 +10,8 @@ from gimmes.models.recommendation import (
     Confidence,
     Recommendation,
 )
+from gimmes.strategy.fees import edge_after_fees
+from gimmes.strategy.scanner import effective_price, price_at_bound
 
 
 def _pair_closes(
@@ -581,7 +583,16 @@ def analyze_missed_opportunities(
     *,
     since: str | None = None,
 ) -> Recommendation | None:
-    """Check skipped candidates that resolved favorably.
+    """Audit skipped candidates by ex-ante EV AFTER FEES (#707).
+
+    A skip is a "missed win" when its expected value at the recorded
+    skip price — probability minus side-effective price minus maker
+    fee — was positive. This is deliberately NOT settlement-based:
+    ``resolved_outcome`` is sparse for skips by design (it is only
+    stamped when the ticker was also traded), and "would have won"
+    was the wrong bar anyway — a cheap long shot that happened to
+    settle favorably was still a bad bet at its price. The fee-free
+    raw ``edge`` column overstated missed wins by the fee margin.
 
     Requires skip logging to be in place (see issue #20).
     """
@@ -617,31 +628,57 @@ def analyze_missed_opportunities(
     if len(skips) < MIN_SKIPS_AUDIT:
         return None
 
-    # Count skips that had positive edge (would have won)
-    missed_wins = [s for s in skips if s.get("edge", 0) > 0]
+    # A missed win is a skip whose ex-ante EV AFTER FEES was positive
+    # at the recorded (YES-denominated) price. Guard-then-compute per
+    # the #658 scorer/validator pattern: a bound-priced skip has no
+    # tradeable edge and stays in the denominator as a correct skip.
+    missed_wins: list[tuple[dict, float]] = []  # type: ignore[type-arg]
+    for s in skips:
+        eff = effective_price(s["price"], s.get("side", "yes"))
+        ev = (
+            0.0 if price_at_bound(eff)
+            else edge_after_fees(eff, s["model_probability"])
+        )
+        if ev > 0:
+            missed_wins.append((s, ev))
     if not missed_wins:
         return None
 
     false_negative_rate = len(missed_wins) / len(skips)
+    correct_skip_rate = 1 - false_negative_rate
+    fn_cost = sum(ev for _, ev in missed_wins)
 
     if false_negative_rate < 0.20:  # Less than 20% false negatives — acceptable
         return None
 
-    # Check if missed wins had scores just below threshold
+    # Near-miss cohort: derive the recommendation once, then restrict
+    # the cited cohort to the score band the recommendation would
+    # actually admit (#707 — a threshold of 50 motivated by score-45
+    # skips it wouldn't admit is not evidence).
     threshold = config.strategy.gimme_threshold
-    near_misses = [
-        s for s in missed_wins
+    cohort = [
+        s for s, _ in missed_wins
         if 0 < s.get("gimme_score", 0) < threshold
     ]
-
-    if not near_misses:
+    if not cohort:
         return None
 
-    avg_missed_score = sum(s.get("gimme_score", 0) for s in near_misses) / len(near_misses)
-    recommended = max(int(avg_missed_score - 5), 50)
-
+    cohort_avg = sum(s.get("gimme_score", 0) for s in cohort) / len(cohort)
+    recommended = max(int(cohort_avg - 5), 50)
     if recommended >= threshold:
         return None
+
+    near_misses = [
+        s for s in cohort
+        if recommended <= s.get("gimme_score", 0) < threshold
+    ]
+    if not near_misses:
+        # The floor-50 recommendation admits nobody from the cohort
+        # that motivated it — not a recommendation.
+        return None
+    avg_missed_score = (
+        sum(s.get("gimme_score", 0) for s in near_misses) / len(near_misses)
+    )
 
     return Recommendation(
         parameter_path="strategy.gimme_threshold",
@@ -650,12 +687,19 @@ def analyze_missed_opportunities(
         confidence=Confidence.MEDIUM if len(skips) >= 50 else Confidence.LOW,
         analysis_type=AnalysisType.MISSED_OPPORTUNITY,
         rationale=(
-            f"False negative rate: {false_negative_rate:.0%} ({len(missed_wins)}/{len(skips)} "
-            f"skipped trades would have won). {len(near_misses)} near-misses averaged "
-            f"score {avg_missed_score:.0f} (threshold: {threshold})."
+            f"EV-based false negative rate: {false_negative_rate:.0%} "
+            f"({len(missed_wins)}/{len(skips)} skips had positive expected"
+            f" value after fees; correct-skip rate {correct_skip_rate:.0%})."
+            f" Estimated foregone EV: ${fn_cost:.2f} total at 1"
+            f" contract/skip."
+            f" {len(near_misses)} near-misses in the admitted band"
+            f" [{recommended}, {threshold}) averaged score"
+            f" {avg_missed_score:.0f}."
         ),
         supporting_data=json.dumps({
             "false_negative_rate": round(false_negative_rate, 3),
+            "correct_skip_rate": round(correct_skip_rate, 3),
+            "fn_cost_per_contract": round(fn_cost, 3),
             "missed_wins": len(missed_wins),
             "total_skips": len(skips),
             "excluded_degenerate": excluded_degenerate,

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -699,7 +699,7 @@ def analyze_missed_opportunities(
         supporting_data=json.dumps({
             "false_negative_rate": round(false_negative_rate, 3),
             "correct_skip_rate": round(correct_skip_rate, 3),
-            "fn_cost_per_contract": round(fn_cost, 3),
+            "fn_cost_total": round(fn_cost, 3),
             "missed_wins": len(missed_wins),
             "total_skips": len(skips),
             "excluded_degenerate": excluded_degenerate,

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -724,6 +724,151 @@ class TestMissedOpportunities:
         )
         assert rec is None
 
+    def test_ev_after_fees_flips_marginal_edge_out_of_numerator(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#707: a skip with a small POSITIVE raw edge but negative
+        EV after fees is a CORRECT skip. The old fee-free `edge > 0`
+        numerator counted these as missed wins — the maker fee margin
+        is exactly what the metric was overstating."""
+        trades = self._real_skips()
+        for i in range(10):
+            trades.append({
+                "ticker": f"SKIP-MARGINAL-{i}", "action": "skip",
+                "gimme_score": 72, "edge": 0.005, "price": 0.60,
+                "model_probability": 0.605,  # EV = 0.605-0.60-0.01 < 0
+                "timestamp": f"2026-04-{(i % 28) + 1:02d}T10:00:00",
+            })
+        rec = analyze_missed_opportunities(trades, config)
+        assert rec is not None
+        data = json.loads(rec.supporting_data)
+        assert data["missed_wins"] == 15  # marginal rows excluded
+        assert data["false_negative_rate"] == pytest.approx(15 / 35, abs=1e-3)
+        assert data["correct_skip_rate"] == pytest.approx(20 / 35, abs=1e-3)
+
+    def test_no_side_price_converted_before_fee_math(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#707: the price column is YES-denominated. A NO-side skip
+        at YES 0.30 has effective price 0.70 — EV 0.65-0.70-0.01 < 0,
+        a correct skip. Reading the raw YES price would fabricate a
+        +0.34 missed win."""
+        trades = self._real_skips()
+        for i in range(10):
+            trades.append({
+                # edge deliberately POSITIVE (review-found): with a
+                # negative edge these rows are excluded by an
+                # `edge > 0` revert too, making this test inert
+                # against that mutation — a positive edge keeps it
+                # load-bearing for BOTH the conversion and the
+                # EV-numerator itself.
+                "ticker": f"SKIP-NO-{i}", "action": "skip", "side": "no",
+                "gimme_score": 72, "edge": 0.05, "price": 0.30,
+                "model_probability": 0.65,
+                "timestamp": f"2026-04-{(i % 28) + 1:02d}T10:00:00",
+            })
+        rec = analyze_missed_opportunities(trades, config)
+        assert rec is not None
+        data = json.loads(rec.supporting_data)
+        assert data["missed_wins"] == 15
+        assert data["false_negative_rate"] == pytest.approx(15 / 35, abs=1e-3)
+
+    def test_recommendation_admits_its_cited_cohort(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#707: near-misses below the derived threshold must not be
+        cited — every cited near-miss clears the recommendation."""
+        trades = self._real_skips(n_wins=10, n_losses=10)  # 10 at 72
+        for i in range(5):
+            trades.append({
+                "ticker": f"SKIP-LOW-{i}", "action": "skip",
+                "gimme_score": 52, "edge": 0.15, "price": 0.65,
+                "model_probability": 0.85,
+                "timestamp": f"2026-04-{(i % 28) + 1:02d}T10:00:00",
+            })
+        rec = analyze_missed_opportunities(trades, config)
+        assert rec is not None
+        # cohort avg (10x72 + 5x52)/15 = 65.33 -> recommended 60;
+        # band [60, 75) drops the five 52s.
+        assert rec.recommended_value == "60"
+        data = json.loads(rec.supporting_data)
+        assert data["near_misses"] == 10
+        assert data["avg_missed_score"] == pytest.approx(72.0)
+        assert data["avg_missed_score"] >= int(rec.recommended_value)
+
+    def test_empty_admitted_band_returns_none(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#707: a floor-50 recommendation whose admitted band [50, 75)
+        contains none of the motivating cohort is not a
+        recommendation. The old code recommended 50 while citing
+        score-30 skips it wouldn't admit."""
+        trades = [{
+            "ticker": f"SKIP-DEEP-{i}", "action": "skip",
+            "gimme_score": 30, "edge": 0.15, "price": 0.65,
+            "model_probability": 0.85,
+            "timestamp": f"2026-01-{(i % 28) + 1:02d}T10:00:00",
+        } for i in range(15)]
+        trades += self._real_skips(n_wins=0, n_losses=10)
+        assert analyze_missed_opportunities(trades, config) is None
+
+    def test_rationale_surfaces_fn_cost_and_correct_skip_rate(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#707: the operator sees the EV-based cost AND the
+        correct-skip rate — the tradeoff, not just the loosening
+        pressure."""
+        rec = analyze_missed_opportunities(self._real_skips(), config)
+        assert rec is not None
+        data = json.loads(rec.supporting_data)
+        # 15 wins x EV(0.85 - 0.65 - 0.01) = 15 x 0.19 = 2.85
+        assert data["fn_cost_per_contract"] == pytest.approx(2.85)
+        assert data["correct_skip_rate"] == pytest.approx(0.4)
+        assert "$2.85" in rec.rationale
+        assert "40%" in rec.rationale
+        assert "[67, 75)" in rec.rationale
+        # 25 skips < 50 -> LOW (tiering was unpinned, review-found)
+        assert rec.confidence == Confidence.LOW
+
+    def test_confidence_medium_at_fifty_skips(
+        self, config: GimmesConfig,
+    ) -> None:
+        """The MEDIUM tier requires >= 50 audited skips."""
+        rec = analyze_missed_opportunities(
+            self._real_skips(n_wins=30, n_losses=20), config,
+        )
+        assert rec is not None
+        assert rec.confidence == Confidence.MEDIUM
+
+    def test_low_fnr_is_acceptable_no_recommendation(
+        self, config: GimmesConfig,
+    ) -> None:
+        """Below the 20% gate the skips are working as intended —
+        3/25 EV-positive skips (12%) must NOT produce loosening
+        pressure (gate was one-side-pinned, review-found)."""
+        rec = analyze_missed_opportunities(
+            self._real_skips(n_wins=3, n_losses=22), config,
+        )
+        assert rec is None
+
+    def test_bound_priced_skip_is_not_a_missed_win(
+        self, config: GimmesConfig,
+    ) -> None:
+        """#658 guard carries over: a bound-priced skip has no
+        tradeable edge — denominator yes, numerator no."""
+        trades = self._real_skips()
+        trades.append({
+            "ticker": "SKIP-BOUND", "action": "skip", "side": "no",
+            "gimme_score": 72, "edge": 0.0, "price": 0.995,
+            "model_probability": 0.9,
+            "timestamp": "2026-04-01T10:00:00",
+        })
+        rec = analyze_missed_opportunities(trades, config)
+        assert rec is not None
+        data = json.loads(rec.supporting_data)
+        assert data["missed_wins"] == 15
+        assert data["total_skips"] == 26
+
 
 class TestRunAllAnalyses:
     def test_returns_list(self, config: GimmesConfig) -> None:

--- a/tests/unit/test_advisor.py
+++ b/tests/unit/test_advisor.py
@@ -822,7 +822,7 @@ class TestMissedOpportunities:
         assert rec is not None
         data = json.loads(rec.supporting_data)
         # 15 wins x EV(0.85 - 0.65 - 0.01) = 15 x 0.19 = 2.85
-        assert data["fn_cost_per_contract"] == pytest.approx(2.85)
+        assert data["fn_cost_total"] == pytest.approx(2.85)
         assert data["correct_skip_rate"] == pytest.approx(0.4)
         assert "$2.85" in rec.rationale
         assert "40%" in rec.rationale


### PR DESCRIPTION
## Summary

The advisor's false-negative analysis recommended `gimme_threshold` reductions on two flawed legs:

1. **The numerator counted any skip with positive fee-free ex-ante edge as a "missed win."** The docstring claimed settlement-based classification ("resolved favorably") — the code never consulted settlements at all (and `resolved_outcome` is sparse for skips by design). Thin-edge skips *inside the fee margin* generated systematic loosening pressure.
2. **The cited near-miss cohort wasn't filtered to what the proposed threshold would admit** — a recommendation of 50 could be motivated entirely by score-45 skips it wouldn't take (exactly the live recommendation that prompted this issue).

Now:
- **EV after fees is the bar**: `effective_price(price, side)` (the skip `price` column is YES-denominated), the #658 `price_at_bound` guard (bound-priced skips stay in the denominator as correct skips), then `edge_after_fees` — the same helper and call shape as the scorer and validator.
- **The recommendation must admit its own evidence**: the threshold is derived once from the full sub-threshold cohort, then the cited near-misses are restricted to the admitted band `[recommended, threshold)` with their average recomputed; an empty band yields no recommendation.
- **The rationale surfaces the tradeoff**: EV-based FN rate, correct-skip rate, and total foregone EV at 1 contract/skip. `supporting_data` adds `correct_skip_rate` and `fn_cost_per_contract`; existing keys unchanged (nothing downstream parses the rationale — `gimmes tune` reads the structured `recommended_value`).

Review pipeline: three reviewers + simplifier (no changes). Mutation analysis verified all seven briefed mutation classes are killed; its two ≥80 gaps (confidence tiering unpinned, FNR gate one-side-pinned) are fixed with dedicated tests, and the NO-side test's raw edge was flipped positive so it stays load-bearing against an `edge > 0` revert.

**Deferred (review-found, pre-existing): #708** — `log-trade` skips fail entirely in dual-side mode (`resolved_side` passes `"both"` into `TradeDecision`'s yes/no Literal), silently starving this audit's input.

Closes #707

## Test plan

- 8 new tests in `TestMissedOpportunities`: marginal positive-raw-edge skips flip out of the numerator; NO-side price conversion; cohort admission (`recommended_value == "60"` cites only the [60, 75) band); empty admitted band → None; rationale surfaces `$2.85` / `40%` / `[67, 75)`; bound-priced skip counted in denominator only; MEDIUM/LOW confidence at the 50-skip boundary; 12% FNR → no recommendation.
- All 63 pre-existing advisor tests pass **unchanged** — the fixture arithmetic survives the fee margin, so the pinned 0.6 rates now double as EV-numerator pins.
- Full suite: **2019 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB