### PR TITLE
Fix #710: liquidity skips carry --reason liquidity; CLI warns on unclassified entry skips

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -261,6 +261,16 @@ gimmes log-trade TICKER --action skip \
 rm -f "$RATIONALE_FILE"
 ```
 
+**Liquidity skips MUST carry `--reason liquidity`** (#710). When the skip is because the order book is empty or one-sided — `market-info` shows YES Bid $0.00 / YES Ask $0.00, or the tradeable side has no resting orders — add `--reason liquidity` to the command:
+
+```bash
+gimmes log-trade TICKER --action skip --reason liquidity \
+  --price 0.XX --prob 0.XX --score NN \
+  --rationale-file "$RATIONALE_FILE" --agent caddie
+```
+
+For all other skips (PASS on research grounds, NEEDS MORE RESEARCH after re-scoring), omit `--reason` — the rationale prose carries the cause. A thin-but-two-sided book that merely lowers the liquidity-depth score is a research-grounds PASS, not a `liquidity` skip. Never invent a reason value: unknown values are rejected and the skip row is lost. A reason-less skip prints a yellow #710 warning — this is EXPECTED for non-liquidity skips; do not add `--reason` just to silence it and do not re-log.
+
 If a `log-trade` skip command fails, note the failure in your output and continue. Do not retry failed log commands.
 
 If `market-info` fails for a candidate, log the candidate with `--price 0 --prob 0` and log the skip with the failure in the rationale.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -55,6 +55,16 @@ gimmes log-trade TICKER --action skip \
 rm -f "$RATIONALE_FILE"
 ```
 
+**Liquidity skips MUST carry `--reason liquidity`** (#710). When the skip is because the order book is empty or one-sided — Best YES Bid = None, no resting offers, zero depth on the tradeable side — add `--reason liquidity` to the command:
+
+```bash
+gimmes log-trade TICKER --action skip --reason liquidity \
+  --price 0.XX --prob 0.XX --score NN \
+  --rationale-file "$RATIONALE_FILE" --agent scout
+```
+
+For all other skips (score below `gimme_threshold`, price out of range, sibling-strike), omit `--reason` — the rationale prose carries the cause. Never invent a reason value: unknown values are rejected and the skip row is lost. A reason-less skip prints a yellow #710 warning — this is EXPECTED for non-liquidity skips; do not add `--reason` just to silence it and do not re-log.
+
 MUST include `--price` (market price), `--prob` (estimated probability if available, else 0), and `--score` (quick score). This data feeds the Missed Opportunity Audit analysis.
 
 If a `log-trade` skip command fails, note the failure in the Scout output and continue with the remaining candidates. Do not retry failed log commands.

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2860,6 +2860,19 @@ def log_trade(
                 )
             row_id = await insert_trade(db, trade)
             console.print(f"[green]Logged trade #{row_id}: {action} {ticker}[/green]")
+            if action == "skip" and not reason:
+                # #710: entry-type skip with no structured cause — the
+                # #657 skip analytics and #707 EV audit can't classify
+                # it. Warn AFTER the insert (a pre-insert warning would
+                # claim "logged" on failure paths), and never reject:
+                # agents are told not to retry failed log commands, so
+                # rejection would silently drop the row.
+                console.print(
+                    "[yellow]Warning: skip logged without --reason"
+                    " (#710) — if the order book was empty/one-sided,"
+                    " this should carry --reason liquidity. The row"
+                    " was logged; do not re-log.[/yellow]"
+                )
 
     _run(_log())
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -15,6 +15,12 @@ CADDIE_MASTER = AGENTS_DIR / "caddie-master.md"
 CADDIE = AGENTS_DIR / "caddie.md"
 MONITOR = AGENTS_DIR / "monitor.md"
 GROUNDSKEEPER = AGENTS_DIR / "groundskeeper.md"
+SCOUT = AGENTS_DIR / "scout.md"
+
+
+@pytest.fixture(scope="module")
+def scout_text() -> str:
+    return SCOUT.read_text()
 
 
 @pytest.fixture(scope="module")
@@ -1831,7 +1837,6 @@ def test_no_agent_uses_inline_memo_body_rationale_for_prose() -> None:
 # ---------------------------------------------------------------------------
 
 _CLOSER = AGENTS_DIR / "closer.md"
-_SCOUT = AGENTS_DIR / "scout.md"
 
 
 def test_no_zeroed_skip_analytics_in_templates(
@@ -1891,12 +1896,11 @@ def test_skip_templates_carry_structured_reason(
 
 
 def test_scout_and_caddie_skip_templates_keep_real_analytics(
-    caddie_text: str,
+    scout_text: str, caddie_text: str,
 ) -> None:
     """Scout/Caddie skips happen at scan/research time when the agent
     HAS the real values — their templates must keep passing them
     (the CLI backfill is the fallback, not the primary path)."""
-    scout_text = _SCOUT.read_text()
     for text, name in ((scout_text, "scout.md"), (caddie_text, "caddie.md")):
         assert "--price 0.XX --prob 0.XX --score NN" in text, (
             f"{name} skip template no longer passes real analytics"
@@ -2262,3 +2266,46 @@ def test_caddie_master_stale_close_precedes_score_rules(
     stale = caddie_master_text.index("Prior research flagged STALE-CLOSE")
     first_rule = caddie_master_text.index("1. **No prior research**")
     assert stale < first_rule
+
+
+def test_scout_and_caddie_mandate_liquidity_reason(
+    scout_text: str, caddie_text: str,
+) -> None:
+    """#710: empty-reason liquidity skips degrade the #657 skip
+    analytics and the #707 EV audit — both skip-logging agents must
+    mandate --reason liquidity for book-emptiness skips and say what
+    to do otherwise (omit, never invent)."""
+    for name, text in (("scout.md", scout_text), ("caddie.md", caddie_text)):
+        assert "--action skip --reason liquidity" in text, (
+            f"{name} lost the --reason liquidity template (#710)"
+        )
+        assert "order book is empty or one-sided" in text, (
+            f"{name} lost the liquidity-skip mandate prose (#710)"
+        )
+        assert "Never invent a reason value" in text, (
+            f"{name} lost the invalid-reason warning (#710) — agents"
+            " guessing values hit BadParameter and the row is lost"
+        )
+
+
+def test_prompt_skip_reasons_exist_in_cli_vocabulary() -> None:
+    """#710 sync guard: every --reason value in any agent prompt must
+    exist in the CLI's _SKIP_REASONS — an unknown value is rejected
+    at log time and, combined with the no-retry rule, loses the row."""
+    import re
+
+    from gimmes.cli import _SKIP_REASONS
+
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        # [= ] + optional quote: the bare form is the template norm,
+        # but --reason=x and --reason 'x' must not slip past the
+        # guard (review-found extraction gap).
+        for value in re.findall(
+            r"--reason[= ]['\"]?(\w+)", path.read_text(),
+        ):
+            if value == "REASON":  # placeholder token, not a value
+                continue
+            assert value in _SKIP_REASONS, (
+                f"{path.name} references --reason {value!r} which is"
+                " not in cli._SKIP_REASONS (#710)"
+            )

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -100,6 +100,57 @@ def _invoke_skip(*extra: str) -> object:
     ])
 
 
+def test_empty_reason_skip_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#710: an entry-type skip with no --reason gets a yellow
+    warning naming the liquidity vocabulary — logged, exit 0."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip()
+    assert result.exit_code == 0, result.output
+    assert "#710" in result.output
+    assert "liquidity" in result.output
+    # The load-bearing instruction — an agent seeing the warning must
+    # not duplicate the row (review-found: was unpinned).
+    assert "re-log" in result.output
+    assert _skip_row(db_path)["reason"] == ""
+
+
+def test_reason_given_suppresses_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#710: a structured reason means no warning — and liquidity
+    persists (first persistence pin for the value)."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = _invoke_skip("--reason", "liquidity")
+    assert result.exit_code == 0, result.output
+    assert "#710" not in result.output
+    assert _skip_row(db_path)["reason"] == "liquidity"
+
+
+def test_non_skip_action_no_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#710: the warning is a skip-path concern only."""
+    db_path = tmp_path / "test.db"
+    _seed_candidate(db_path)
+    _patch_config(monkeypatch, db_path)
+
+    result = runner.invoke(app, [
+        "log-trade", TICKER, "--action", "open",
+        "--price", "0.5", "--prob", "0.8", "--score", "70",
+        "--count", "10", "--rationale", "test open",
+    ])
+    assert result.exit_code == 0, result.output
+    assert "#710" not in result.output
+
+
 def test_skip_without_args_inherits_candidate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Scout and Caddie were logging book-emptiness skips with prose-only rationales and `reason=''` (116+ rows since 2026-07-08), leaving the #657 skip analytics and the #707 EV audit unable to classify the skip class that dominates wide-band scanning.

**Agent prompts** (scout.md, caddie.md): mandate blocks after each skip template — book-emptiness skips MUST carry `--reason liquidity` (compact command variant included); all other skips OMIT `--reason` (never invent a value — unknown values are rejected and, under the no-retry rule, the row is lost). Each trigger is phrased in the vocabulary the agent actually observes (review-found): Scout reads `gimmes score`'s "Best YES Bid = None"; Caddie reads `market-info`'s "$0.00". Caddie's block also disambiguates the liquidity-depth *score* from a liquidity *skip*, and both prompts state the yellow warning is EXPECTED for non-liquidity skips — don't tag to silence it, don't re-log.

**CLI backstop** (`log-trade`): yellow warning when an entry-type skip arrives with no `--reason` — printed **after** the insert succeeds (review-found at 95: a pre-insert warning asserted "row was logged" on failure paths like the rationale mutex — a false audit trail). Warn, never reject: rejection would silently drop every scout/caddie skip in production (~15k rows of pipeline history came through this path) and break 15 existing tests.

**Guards**: drift tests pin both prompts' mandate template, trigger prose, and invent-warning; a vocabulary sync guard asserts every `--reason` value in any agent prompt exists in `cli._SKIP_REASONS` (regex covers bare/`=`/quoted forms — review-found extraction gap); the warning's load-bearing "re-log" phrase is pinned (review-found: a mutant could invert it to "please re-log" silently).

Review pipeline: three reviewers + simplifier; mutation analysis killed all seven briefed mutation classes.

Closes #710

## Test plan

- 5 new tests: empty-reason skip warns (with `#710`, `liquidity`, `re-log` pinned) and persists `reason=""`; `--reason liquidity` suppresses the warning and persists; non-skip actions never warn; both prompts pin the mandate; prompt→CLI vocabulary sync across all agent files.
- All pre-existing skip-analytics and prompt drift-guard tests pass unchanged (174 targeted incl. the rationale-mutex suite that exposed the premature-warning bug).
- Full suite: **2024 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB