### PR TITLE
Fix #713: configurable backtest entry offset via --entry-offset

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -28,7 +28,7 @@ from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 from gimmes.strategy.scanner import effective_price, filter_markets
 from gimmes.strategy.scorer import quick_score
 
-ENTRY_OFFSET_DAYS = 1
+ENTRY_OFFSET_DAYS = 1.0
 CANDLE_LOOKBACK_DAYS = 3
 
 
@@ -63,6 +63,10 @@ class BacktestConfig:
     # legal threshold: every gate on these must use `is not None`.
     take_profit_pct: float | None = None
     stop_loss_pct: float | None = None
+    # #713: enter each market this many days before close. Daily
+    # candle granularity (period 1440) is unchanged — sub-day values
+    # warn; sub-day granularity is the v2 follow-up (#716).
+    entry_offset_days: float = ENTRY_OFFSET_DAYS
 
 
 @dataclass
@@ -484,10 +488,11 @@ def _entry_day_view(
       setting both makes the scanner/scorer's `volume_24h or volume`
       branches read the candle value either way.
     - open_interest at candle close.
-    - status ACTIVE + close_time at now + ENTRY_OFFSET_DAYS: the
+    - status ACTIVE + close_time at now + the configured entry offset
+      (``entry_offset_days``, default ENTRY_OFFSET_DAYS): the
       honest days-to-resolution at the backtest's fixed-offset entry
-      is exactly ENTRY_OFFSET_DAYS by construction (the +60s margin
-      makes the min_days == ENTRY_OFFSET_DAYS boundary
+      is exactly the configured offset by construction (the +60s
+      margin makes the min_days == entry_offset_days boundary
       deterministic).
     """
     return market.model_copy(update={
@@ -683,16 +688,44 @@ async def run_backtest(
     # otherwise see cumulative hits and negative "API fetches".
     disk_hits_before = candle_cache.hits if candle_cache is not None else 0
     if (
-        gc.scanner.min_days_to_resolution > ENTRY_OFFSET_DAYS
-        or gc.scanner.max_days_to_resolution <= ENTRY_OFFSET_DAYS
+        gc.scanner.min_days_to_resolution > config.entry_offset_days
+        or gc.scanner.max_days_to_resolution <= config.entry_offset_days
     ):
         logger.warning(
             "min_days_to_resolution (%.1f) / max_days_to_resolution"
-            " (%.1f) exclude the backtest's fixed %d-day entry offset"
-            " — the days filter will select NOTHING (#666)",
+            " (%.1f) exclude the backtest's %g-day entry offset"
+            " (--entry-offset) — the days filter will select NOTHING"
+            " (#666)",
             gc.scanner.min_days_to_resolution,
-            gc.scanner.max_days_to_resolution, ENTRY_OFFSET_DAYS,
+            gc.scanner.max_days_to_resolution, config.entry_offset_days,
         )
+    if config.entry_offset_days < 1:
+        # #713 v1: granularity is still DAILY — sub-day offsets mostly
+        # land in skipped_no_candle until #716.
+        logger.warning(
+            "--entry-offset %g is sub-day, but candles are DAILY"
+            " (period 1440, midnight-UTC boundaries): entries still"
+            " price from the last candle ending at or before the"
+            " offset, and markets living under a day mostly have none"
+            " (skipped_no_candle). Sub-day granularity is #716 (#713)",
+            config.entry_offset_days,
+        )
+        if (
+            config.take_profit_pct is not None
+            or config.stop_loss_pct is not None
+        ):
+            logger.warning(
+                "TP/SL with a sub-day entry offset: the walk sees only"
+                " DAILY candles strictly between entry and settlement"
+                " — under a %g-day offset that is almost always ZERO"
+                " candles, so exits silently degrade to"
+                " hold-to-settlement (#713/#714)",
+                config.entry_offset_days,
+            )
+    logger.info(
+        "entry-candle pass: %d markets to price — one candle fetch"
+        " each on a cold cache (#713)", len(settled),
+    )
     for i, m in enumerate(settled):
         if m.close_time is None:
             continue
@@ -704,7 +737,7 @@ async def run_backtest(
             m.close_time if m.close_time.tzinfo
             else m.close_time.replace(tzinfo=UTC)
         )
-        entry_time = close_time - timedelta(days=ENTRY_OFFSET_DAYS)
+        entry_time = close_time - timedelta(days=config.entry_offset_days)
         entry_ts = int(entry_time.timestamp())
         candle = await _fetch_entry_candle(
             client, m.ticker, entry_ts, memory_cache,
@@ -764,8 +797,8 @@ async def run_backtest(
     # Build the views AFTER the fetch pass: the synthetic close must
     # be honest RELATIVE TO FILTER TIME — computing it before a
     # multi-minute fetch pass would leave days-to-resolution just
-    # under ENTRY_OFFSET_DAYS and silently zero out configs with
-    # min_days_to_resolution == ENTRY_OFFSET_DAYS (review-found).
+    # under the configured entry offset and silently zero out configs
+    # with min_days_to_resolution == entry_offset_days (review-found).
     if candle_cache is not None:
         disk_hits = candle_cache.hits - disk_hits_before
         logger.info(
@@ -775,7 +808,7 @@ async def run_backtest(
             len(memory_cache) - disk_hits,
         )
     synthetic_close = datetime.now(UTC) + timedelta(
-        days=ENTRY_OFFSET_DAYS, seconds=60,
+        days=config.entry_offset_days, seconds=60,
     )
     entry_views: dict[str, Market] = {
         ticker: _entry_day_view(

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import calendar
 import logging
+import math
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 
@@ -573,6 +574,19 @@ async def run_backtest(
     5. Return aggregated results
     """
     gc = config.gimmes_config
+    if not (
+        math.isfinite(config.entry_offset_days)
+        and config.entry_offset_days > 0
+    ):
+        # Fail fast — BEFORE the minutes-long market fetch pass — with
+        # a clear message for programmatic callers: NaN/inf would
+        # otherwise surface as an obscure timedelta conversion error
+        # deep in the entry pass (Copilot, #713; placement
+        # review-found).
+        raise ValueError(
+            f"entry_offset_days must be a positive finite number,"
+            f" got {config.entry_offset_days!r}",
+        )
     ledger = BacktestLedger(config.starting_balance)
 
     # --- 1. Fetch settled markets per series via live API ---

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -86,6 +86,7 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         f" – {cfg.gimmes_config.strategy.max_market_price:.2f}",
         f"Gimme threshold: {cfg.gimmes_config.strategy.gimme_threshold:.0f}",
         f"Assumed edge: {cfg.assumed_edge:.0%}",
+        f"Entry offset: {cfg.entry_offset_days:g} day(s) before close",
         "Fill model: "
         + ("taker (pays the ask)" if cfg.taker_fill else "maker (midpoint)"),
         "Exits: "
@@ -301,6 +302,7 @@ def backtest_result_to_json(result: BacktestResult) -> dict:  # type: ignore[typ
             "taker_fill": result.config.taker_fill,
             "take_profit_pct": result.config.take_profit_pct,
             "stop_loss_pct": result.config.stop_loss_pct,
+            "entry_offset_days": result.config.entry_offset_days,
         },
         "funnel": {
             "markets_scanned": result.markets_scanned,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4410,6 +4410,12 @@ def backtest(
              " basis (e.g. 0.15 mirrors the live loop). Omit to hold"
              " to settlement (#714)",
     ),
+    entry_offset: float = typer.Option(
+        1.0, "--entry-offset",
+        help="Enter each market this many days before close (default"
+             " 1). Candles are daily — sub-day values mostly skip;"
+             " each offset value is a fresh cache namespace (#713)",
+    ),
 ) -> None:
     """Backtest the gimme strategy on historical settled markets."""
     config = load_config()
@@ -4441,6 +4447,9 @@ def backtest(
                     f"[red]{flag} must be between 0 and 1[/red]",
                 )
                 raise typer.Exit(1)
+        if not entry_offset > 0:  # `not >` also rejects NaN
+            console.print("[red]--entry-offset must be positive[/red]")
+            raise typer.Exit(1)
         bt_config = BacktestConfig(
             start_date=start,
             end_date=end,
@@ -4450,6 +4459,7 @@ def backtest(
             taker_fill=taker_fill,
             take_profit_pct=take_profit,
             stop_loss_pct=stop_loss,
+            entry_offset_days=entry_offset,
         )
         console.print(
             f"[dim]Running backtest: {start} to {end}, "

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4447,8 +4447,15 @@ def backtest(
                     f"[red]{flag} must be between 0 and 1[/red]",
                 )
                 raise typer.Exit(1)
-        if not entry_offset > 0:  # `not >` also rejects NaN
-            console.print("[red]--entry-offset must be positive[/red]")
+        import math
+
+        # `not >` also rejects NaN; isfinite rejects inf/1e309, which
+        # would otherwise crash obscurely in timedelta (Copilot).
+        if not (math.isfinite(entry_offset) and entry_offset > 0):
+            console.print(
+                "[red]--entry-offset must be a positive finite"
+                " number[/red]",
+            )
             raise typer.Exit(1)
         bt_config = BacktestConfig(
             start_date=start,

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -1594,6 +1594,10 @@ def test_cli_entry_offset_nonpositive_rejected(tmp_path) -> None:
     assert result.exit_code == 1
     result, _ = _invoke_backtest_cli(tmp_path, "--entry-offset", "-1")
     assert result.exit_code == 1
+    # Non-finite values would crash obscurely in timedelta (Copilot).
+    for bad in ("nan", "inf", "1e309"):
+        result, _ = _invoke_backtest_cli(tmp_path, "--entry-offset", bad)
+        assert result.exit_code == 1, bad
 
 
 class TestEntryOffset(_EntryDayHarness):
@@ -1674,6 +1678,28 @@ class TestEntryOffset(_EntryDayHarness):
         walk_calls = [c for c in calls if c["end_ts"] == close_ts]
         assert walk_calls
         assert all(c["start_ts"] == entry_ts3 for c in walk_calls)
+
+    @pytest.mark.asyncio
+    async def test_nonfinite_offset_fails_fast(
+        self, monkeypatch,
+    ) -> None:
+        """Programmatic callers get a clear ValueError BEFORE the
+        minutes-long market fetch pass (Copilot; placement
+        review-found — the stub records list calls to prove it)."""
+        list_calls = []
+
+        async def _fake_list(*args, **kwargs):
+            list_calls.append(1)
+            return []
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+        for bad in (float("nan"), float("inf"), 0.0, -1.0):
+            config = self._offset_config(bad)
+            with pytest.raises(ValueError, match="entry_offset_days"):
+                await run_backtest(client=None, config=config)
+        assert list_calls == []  # guard fired before any fetch
 
     @pytest.mark.asyncio
     async def test_subday_offset_warns(

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -725,9 +725,9 @@ class _EntryDayHarness:
         return [_settled_market("KXCPI-26MAR-T0.5",
                                 yes_bid=0.25, yes_ask=0.35)]
 
-    def _entry_ts(self, m) -> int:
+    def _entry_ts(self, m, offset: float = ENTRY_OFFSET_DAYS) -> int:
         return int(
-            (m.close_time - timedelta(days=ENTRY_OFFSET_DAYS)).timestamp(),
+            (m.close_time - timedelta(days=offset)).timestamp(),
         )
 
     def _stub(self, monkeypatch, markets, candles_by_ticker):
@@ -783,6 +783,40 @@ class _EntryDayHarness:
         return await run_backtest(
             client=None, config=config or self._permissive_config(),
         )
+
+    def _stub_windowed(
+        self, monkeypatch, markets, entry_candles, walk_candles,
+    ):
+        """Window-aware stub (#714): entry windows serve the entry
+        candle, walk windows (end_ts == settle_ts) the walk series."""
+        async def _fake_list(*args, **kwargs):
+            return markets
+
+        calls: list[dict] = []
+        settle_ts = {
+            m.ticker: int(m.close_time.timestamp()) for m in markets
+        }
+
+        async def _fake_candles(client, ticker, *, start_ts, end_ts, **kw):
+            calls.append({"ticker": ticker, "start_ts": start_ts,
+                          "end_ts": end_ts})
+            if end_ts == settle_ts[ticker] and start_ts != end_ts:
+                return walk_candles.get(ticker, [])
+            return entry_candles.get(ticker, [])
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.get_candlesticks", _fake_candles,
+        )
+        return calls
+
+    def _exit_config(self, tp=None, sl=None):
+        cfg = self._permissive_config()
+        cfg.take_profit_pct = tp
+        cfg.stop_loss_pct = sl
+        return cfg
 
 
 class TestEntryDayPricing(_EntryDayHarness):
@@ -1541,42 +1575,230 @@ def test_cli_tp_sl_out_of_range_rejected(tmp_path) -> None:
     assert result.exit_code == 1
 
 
+def test_cli_entry_offset_wired(tmp_path) -> None:
+    """#713: --entry-offset reaches BacktestConfig; the CLI default
+    equals the engine constant."""
+    result, captured = _invoke_backtest_cli(
+        tmp_path, "--entry-offset", "2.5",
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["config"].entry_offset_days == 2.5
+
+    result, captured = _invoke_backtest_cli(tmp_path)
+    assert result.exit_code == 0, result.output
+    assert captured["config"].entry_offset_days == ENTRY_OFFSET_DAYS
+
+
+def test_cli_entry_offset_nonpositive_rejected(tmp_path) -> None:
+    result, _ = _invoke_backtest_cli(tmp_path, "--entry-offset", "0")
+    assert result.exit_code == 1
+    result, _ = _invoke_backtest_cli(tmp_path, "--entry-offset", "-1")
+    assert result.exit_code == 1
+
+
+class TestEntryOffset(_EntryDayHarness):
+    """#713: the entry offset is configurable; the fetch window,
+    candle selection, synthetic close, walk boundary, and warnings
+    all key off the configured value."""
+
+    def _offset_config(self, offset, tp=None, sl=None):
+        cfg = self._exit_config(tp=tp, sl=sl)
+        cfg.entry_offset_days = offset
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_offset_shifts_entry_window_and_candle_selection(
+        self, monkeypatch,
+    ) -> None:
+        """The discriminating fixture: with offset 2.0 the window
+        ends at close-2d, so the close-1d candle (which the default
+        offset would price from) must be unreachable — both the
+        window bound AND the selected candle prove the offset
+        governs."""
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        candles = {m.ticker: [
+            _make_candle(ts=close_ts - 172_800,
+                         yes_bid_close=0.30, yes_ask_close=0.40),
+            _make_candle(ts=close_ts - 86_400,
+                         yes_bid_close=0.10, yes_ask_close=0.20),
+        ]}
+        calls = self._stub(monkeypatch, markets, candles)
+        config = self._offset_config(2.0)
+        result = await run_backtest(client=None, config=config)
+
+        assert len(result.trades) == 1
+        t = result.trades[0]
+        # NO eff of the -2d candle (mid 0.35 -> 0.65), NOT the -1d
+        # candle's 0.85.
+        assert t.entry_price == pytest.approx(0.65)
+        assert t.entry_time == m.close_time - timedelta(days=2)
+        assert all(c["end_ts"] == close_ts - 172_800 for c in calls)
+        assert all(
+            c["start_ts"] == close_ts - 172_800 - 3 * 86_400
+            for c in calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_larger_offset_walk_gains_candles(
+        self, monkeypatch,
+    ) -> None:
+        """#714 synergy: a 3-day offset gives the walk interior
+        candles the default offset never sees — the TP fires at
+        close-2d."""
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        entry_ts3 = close_ts - 259_200
+        entry = {m.ticker: [_make_candle(
+            ts=entry_ts3, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        walk = {m.ticker: [
+            _make_candle(ts=entry_ts3 + 86_400,
+                         yes_bid_close=0.02, yes_ask_close=0.06),
+            _make_candle(ts=entry_ts3 + 172_800,
+                         yes_bid_close=0.50, yes_ask_close=0.60),
+        ]}
+        calls = self._stub_windowed(monkeypatch, markets, entry, walk)
+        config = self._offset_config(3.0, tp=0.8)
+        result = await run_backtest(client=None, config=config)
+
+        assert len(result.trades) == 1
+        t = result.trades[0]
+        assert t.exit_reason == "take_profit"
+        assert t.exit_time == datetime.fromtimestamp(
+            entry_ts3 + 86_400, tz=UTC,
+        )
+        assert result.exited_take_profit == 1
+        walk_calls = [c for c in calls if c["end_ts"] == close_ts]
+        assert walk_calls
+        assert all(c["start_ts"] == entry_ts3 for c in walk_calls)
+
+    @pytest.mark.asyncio
+    async def test_subday_offset_warns(
+        self, monkeypatch, caplog,
+    ) -> None:
+        import logging
+
+        # CLI tests set propagate=False on gimmes.backtest (#696
+        # lesson) — caplog captures at root; restore for this test.
+        monkeypatch.setattr(
+            logging.getLogger("gimmes.backtest"), "propagate", True,
+        )
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        candles = {m.ticker: [_make_candle(
+            ts=close_ts - 43_200, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+        config = self._offset_config(0.5)
+        config.gimmes_config.scanner.min_days_to_resolution = 0.0
+
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            await run_backtest(client=None, config=config)
+        warnings = [r.message for r in caplog.records]
+        assert any("sub-day" in w for w in warnings)
+        assert not any("hold-to-settlement" in w for w in warnings)
+
+        # Control arm (mutation pin: `< 1` must not become `<= 1`):
+        # the default 1.0 offset never triggers the sub-day warning.
+        caplog.clear()
+        config = self._offset_config(1.0)
+        config.gimmes_config.scanner.min_days_to_resolution = 0.0
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            await run_backtest(client=None, config=config)
+        assert not any(
+            "sub-day" in r.message for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_subday_offset_with_tpsl_warns_walk_degradation(
+        self, monkeypatch, caplog,
+    ) -> None:
+        import logging
+
+        # CLI tests set propagate=False on gimmes.backtest (#696
+        # lesson) — caplog captures at root; restore for this test.
+        monkeypatch.setattr(
+            logging.getLogger("gimmes.backtest"), "propagate", True,
+        )
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        candles = {m.ticker: [_make_candle(
+            ts=close_ts - 43_200, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+        config = self._offset_config(0.5, tp=0.8)
+        config.gimmes_config.scanner.min_days_to_resolution = 0.0
+
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            await run_backtest(client=None, config=config)
+        warnings = [r.message for r in caplog.records]
+        assert any("sub-day" in w for w in warnings)
+        assert any("hold-to-settlement" in w for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_days_filter_warning_keys_off_configured_offset(
+        self, monkeypatch, caplog,
+    ) -> None:
+        """min_days 1.5: a 2.0 offset passes (and trades — proving
+        synthetic_close honors the offset); the default 1.0 offset
+        warns and selects nothing."""
+        import logging
+
+        monkeypatch.setattr(
+            logging.getLogger("gimmes.backtest"), "propagate", True,
+        )
+        markets = self._markets()
+        m = markets[0]
+
+        def _cfg(offset):
+            candles = {m.ticker: [_make_candle(
+                ts=int((m.close_time
+                        - timedelta(days=offset)).timestamp()),
+                yes_bid_close=0.30, yes_ask_close=0.40,
+            )]}
+            self._stub(monkeypatch, markets, candles)
+            config = self._offset_config(offset)
+            config.gimmes_config.scanner.min_days_to_resolution = 1.5
+            config.gimmes_config.scanner.max_days_to_resolution = 90.0
+            return config
+
+        config = _cfg(2.0)
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            result = await run_backtest(client=None, config=config)
+        assert not any(
+            "min_days_to_resolution" in r.message for r in caplog.records
+        )
+        assert len(result.trades) == 1
+
+        caplog.clear()
+        config = _cfg(1.0)
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            result = await run_backtest(client=None, config=config)
+        assert any(
+            "min_days_to_resolution" in r.message for r in caplog.records
+        )
+        assert result.trades == []
+
+
 class TestPostEntryExits(_EntryDayHarness):
     """#714: end-to-end TP/SL walk through run_backtest. The stub is
     window-aware: entry window (end_ts == entry_ts) serves the entry
     candle, walk window (end_ts == settle_ts) serves the walk series."""
-
-    def _stub_windowed(
-        self, monkeypatch, markets, entry_candles, walk_candles,
-    ):
-        async def _fake_list(*args, **kwargs):
-            return markets
-
-        calls: list[dict] = []
-        settle_ts = {
-            m.ticker: int(m.close_time.timestamp()) for m in markets
-        }
-
-        async def _fake_candles(client, ticker, *, start_ts, end_ts, **kw):
-            calls.append({"ticker": ticker, "start_ts": start_ts,
-                          "end_ts": end_ts})
-            if end_ts == settle_ts[ticker] and start_ts != end_ts:
-                return walk_candles.get(ticker, [])
-            return entry_candles.get(ticker, [])
-
-        monkeypatch.setattr(
-            "gimmes.backtest.engine.list_all_markets", _fake_list,
-        )
-        monkeypatch.setattr(
-            "gimmes.backtest.engine.get_candlesticks", _fake_candles,
-        )
-        return calls
-
-    def _exit_config(self, tp=None, sl=None):
-        cfg = self._permissive_config()
-        cfg.take_profit_pct = tp
-        cfg.stop_loss_pct = sl
-        return cfg
 
     def _entry_setup(self, monkeypatch, walk_bid, walk_ask):
         """One market, entry candle 0.30/0.40 (NO eff 0.65), one

--- a/tests/unit/test_backtest_report.py
+++ b/tests/unit/test_backtest_report.py
@@ -439,3 +439,32 @@ class TestExitFieldsInReport:
         assert "walk fetches" in out
         # The semantic point of the wording: only ENTERED positions.
         assert "entered" in out
+
+
+class TestEntryOffsetInReport:
+    """#713: the configured offset reaches the JSON config and the
+    header."""
+
+    def test_json_config_carries_entry_offset(self) -> None:
+        data = backtest_result_to_json(_make_result())
+        assert data["config"]["entry_offset_days"] == 1.0
+        result = _make_result()
+        result.config.entry_offset_days = 2.5
+        data = backtest_result_to_json(result)
+        assert data["config"]["entry_offset_days"] == 2.5
+
+    def test_header_shows_entry_offset(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        # %g pins: 1.0 renders "1", not "1.0" (mutation pin).
+        assert "Entry offset: 1 day(s)" in buf.getvalue()
+
+        result.config.entry_offset_days = 2.5
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "Entry offset: 2.5 day(s)" in buf.getvalue()


### PR DESCRIPTION
## Summary

The hard-coded `ENTRY_OFFSET_DAYS` (1 day — the issue's "3" was stale) structurally excluded any market living less than the offset: 804,946 of 807,146 daily-series markets in the 2026-07-10 probe hit `skipped_no_candle`, and the #714 walk was fixed at ~one interior candle per trade.

`BacktestConfig.entry_offset_days` (float, default = the constant — zero existing-test churn, zero cache invalidation) now governs the entry-time computation, the synthetic close, and the #666 days-filter warning. The #714 walk boundary moves automatically (single source of truth via `trade.entry_time`). CLI `--entry-offset` with NaN-rejecting validation (review-found: `<= 0` passes NaN); report header + JSON field for sweep tooling. Cross-offset cache-key collisions are provably harmless — key equality implies request equality implies response equality against immutable settled history (review-verified).

**v1 scope honesty**: research established Kalshi daily candles end on midnight-UTC boundaries, so sub-day offsets at daily granularity only help midnight-straddling markets. The short-lived universe needs sub-day granularity — filed as **#716** (needs `volume_24h` aggregation and walk-window changes). Sub-day offsets warn before the fetch pass, with a nested walk-degradation warning when TP/SL is set, and a fetch-count INFO line quantifies cold-run cost (~11–14h for the 807k universe at the observed ~17 req/s; warm reruns near-instant via #696).

**Immediate value even before #716**: larger offsets (2–7 days) give the #714 exit walk real candle density — exit-policy sweeps stop being single-candle approximations.

Review pipeline: three reviewers + simplifier; the mutation analysis ran 12 mutants empirically — 10 killed by the designed tests, and the 2 survivors (sub-day boundary, %g rendering) got dedicated pins.

Closes #713

## Test plan

- 9 new tests: the discriminating offset fixture (window bound AND candle selection independently lethal to a constant-revert); walk-gains-candles at offset 3 (TP at close−2d, unreachable at default); sub-day warnings incl. a default-offset control arm; days-filter warning keyed off the configured offset with a synthetic-close proof arm (trades==1 at offset 2/min_days 1.5 — a constant revert selects nothing); CLI wiring + nonpositive rejection; JSON + `%g` header pins.
- Full suite: **2068 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB