### PR TITLE
Fix #716: sub-day candle granularity — --candle-period unlocks the short-lived-market universe

### DIFF
--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -30,7 +30,15 @@ from gimmes.strategy.scanner import effective_price, filter_markets
 from gimmes.strategy.scorer import quick_score
 
 ENTRY_OFFSET_DAYS = 1.0
+# The 3-day lookback fits the API cap at EVERY allowed period: worst
+# case is period 1 -> 3*1440 = 4320 (+1 inclusive endpoint) < 5000
+# (cap pinned by test; live-probed 2026-07-13, hard 400 beyond it).
 CANDLE_LOOKBACK_DAYS = 3
+ALLOWED_CANDLE_PERIODS = (1, 60, 1440)
+# Kalshi candlesticks: max 5000 periods per request — a hard 400
+# ("max candlesticks: 5000"), NOT truncation. Live-probed 2026-07-13
+# by bisection at periods 1/60/1440 (#716, settles the #714 TODO).
+MAX_CANDLES_PER_REQUEST = 5000
 
 
 logger = logging.getLogger(__name__)
@@ -64,10 +72,15 @@ class BacktestConfig:
     # legal threshold: every gate on these must use `is not None`.
     take_profit_pct: float | None = None
     stop_loss_pct: float | None = None
-    # #713: enter each market this many days before close. Daily
-    # candle granularity (period 1440) is unchanged — sub-day values
-    # warn; sub-day granularity is the v2 follow-up (#716).
+    # #713: enter each market this many days before close.
     entry_offset_days: float = ENTRY_OFFSET_DAYS
+    # #716: candle granularity in minutes (1, 60, or 1440) for entry
+    # pricing and the TP/SL walk. Sub-day periods make sub-day entry
+    # offsets meaningful (daily candles are midnight-US/Eastern
+    # aligned, so a <24h market has no daily candle before close) and
+    # compute volume_24h as a trailing-24h sum. Each period is a
+    # fresh cache namespace.
+    candle_period_minutes: int = 1440
 
 
 @dataclass
@@ -127,6 +140,10 @@ class BacktestResult:
     exited_take_profit: int = 0
     exited_stop_loss: int = 0
     walk_fetch_failures: int = 0
+    # #716: the period the walk actually used — coarser than the
+    # configured candle_period_minutes when the offset span would
+    # exceed the API's 5000-period cap; None when no walk ran.
+    walk_candle_period: int | None = None
 
 
 @dataclass
@@ -422,6 +439,7 @@ async def _fetch_entry_candle(
     cache: dict[str, list[Candle]],
     failed: set[str],
     disk: CandleCache | None = None,
+    period: int = 1440,
 ) -> Candle | None:
     """The ticker's entry-day candle, or None when no candle ends at
     or before entry_ts. The fetch window ends AT entry_ts, so future
@@ -442,7 +460,7 @@ async def _fetch_entry_candle(
         window = {
             "start_ts": entry_ts - CANDLE_LOOKBACK_DAYS * 86400,
             "end_ts": entry_ts,
-            "period_interval": 1440,
+            "period_interval": period,
         }
         cached = None
         if disk is not None:
@@ -470,11 +488,29 @@ async def _fetch_entry_candle(
     return entry_candle_at(cache[ticker], entry_ts)
 
 
+def _trailing_24h_volume(
+    candles: list[Candle], entry_ts: int,
+) -> int:
+    """Sum of per-period candle volumes in the trailing 24 hours
+    ``(entry_ts - 86400, entry_ts]`` (#716). Candle volume is
+    strictly per-period (live-verified: minute candles sum to the
+    market total), and quiet periods are simply omitted from the
+    series — omitted means zero volume, so the sum over present
+    candles is exact."""
+    return sum(
+        c.volume for c in candles
+        if entry_ts - 86_400 < c.end_period_ts <= entry_ts
+    )
+
+
 def _entry_day_view(
     market: Market, candle: Candle, close_time: datetime,
+    volume_24h: int | None = None,
 ) -> Market:
-    """A Market as it looked on ENTRY DAY, built from the entry-day
-    candle — the selection lens the scanner/scorer see (#666).
+    """A Market as it looked AT THE ENTRY TIMESTAMP, built from the
+    entry candle (daily at period 1440, hourly/minute at sub-day
+    periods, #716) — the selection lens the scanner/scorer see
+    (#666).
 
     Field mapping (all price/liquidity data comes from the candle so
     filter_markets and quick_score run unchanged with no settlement
@@ -484,10 +520,17 @@ def _entry_day_view(
       candle-derived spread with no new arithmetic.
     - last_price is 0.0: the midpoint must never fall back to stale
       trade prices (the same rationale candle_midpoint uses, #655).
-    - volume AND volume_24h from the daily candle's per-period volume
-      — for period_interval=1440 that IS the day's 24h volume, and
-      setting both makes the scanner/scorer's `volume_24h or volume`
-      branches read the candle value either way.
+    - volume AND volume_24h from the candle's per-period volume — for
+      period_interval=1440 that IS the day's 24h volume. At sub-day
+      periods the caller passes ``volume_24h`` = the trailing-24h sum
+      (#716); the single per-period candle volume would understate
+      24h volume up to 1440x and silently bias the scanner's
+      min_volume gate and quick_score's volume tiers. Both fields are
+      set to the same value so the scanner/scorer's
+      `volume_24h or volume` branches read it either way. The 1440
+      path deliberately keeps the SELECTED candle's volume (not the
+      trailing sum): a stale entry candle >1 day old would sum to 0
+      and silently drop markets the default path prices today.
     - open_interest at candle close.
     - status ACTIVE + close_time at now + the configured entry offset
       (``entry_offset_days``, default ENTRY_OFFSET_DAYS): the
@@ -496,13 +539,14 @@ def _entry_day_view(
       margin makes the min_days == entry_offset_days boundary
       deterministic).
     """
+    vol = candle.volume if volume_24h is None else volume_24h
     return market.model_copy(update={
         "status": MarketStatus.ACTIVE,
         "yes_bid": candle.yes_bid_close,
         "yes_ask": candle.yes_ask_close,
         "last_price": 0.0,
-        "volume": candle.volume,
-        "volume_24h": candle.volume,
+        "volume": vol,
+        "volume_24h": vol,
         "open_interest": candle.open_interest,
         "close_time": close_time,
         "expiration_time": close_time,
@@ -586,6 +630,14 @@ async def run_backtest(
         raise ValueError(
             f"entry_offset_days must be a positive finite number,"
             f" got {config.entry_offset_days!r}",
+        )
+    if config.candle_period_minutes not in ALLOWED_CANDLE_PERIODS:
+        # Same fail-fast doctrine (#713): a bad period would surface
+        # as a per-market API 400 deep in the entry pass.
+        raise ValueError(
+            f"candle_period_minutes must be one of"
+            f" {ALLOWED_CANDLE_PERIODS}, got"
+            f" {config.candle_period_minutes!r}",
         )
     ledger = BacktestLedger(config.starting_balance)
 
@@ -713,15 +765,17 @@ async def run_backtest(
             gc.scanner.min_days_to_resolution,
             gc.scanner.max_days_to_resolution, config.entry_offset_days,
         )
-    if config.entry_offset_days < 1:
-        # #713 v1: granularity is still DAILY — sub-day offsets mostly
-        # land in skipped_no_candle until #716.
+    if config.entry_offset_days < 1 and config.candle_period_minutes == 1440:
+        # #716: sub-day offsets are only meaningful with sub-day
+        # candles — daily candles are midnight-US/Eastern aligned, so
+        # a <24h market has no daily candle before close.
         logger.warning(
             "--entry-offset %g is sub-day, but candles are DAILY"
-            " (period 1440, midnight-UTC boundaries): entries still"
-            " price from the last candle ending at or before the"
-            " offset, and markets living under a day mostly have none"
-            " (skipped_no_candle). Sub-day granularity is #716 (#713)",
+            " (period 1440, midnight-US/Eastern boundaries): entries"
+            " still price from the last candle ending at or before"
+            " the offset, and markets living under a day mostly have"
+            " none (skipped_no_candle) — pass --candle-period 60 (or"
+            " 1) for sub-day granularity (#716)",
             config.entry_offset_days,
         )
         if (
@@ -729,11 +783,12 @@ async def run_backtest(
             or config.stop_loss_pct is not None
         ):
             logger.warning(
-                "TP/SL with a sub-day entry offset: the walk sees only"
-                " DAILY candles strictly between entry and settlement"
-                " — under a %g-day offset that is almost always ZERO"
-                " candles, so exits silently degrade to"
-                " hold-to-settlement (#713/#714)",
+                "TP/SL with a sub-day entry offset at DAILY"
+                " granularity: the walk sees only daily candles"
+                " strictly between entry and settlement — under a"
+                " %g-day offset that is almost always ZERO candles,"
+                " so exits silently degrade to hold-to-settlement;"
+                " pass --candle-period 60 (or 1) (#714/#716)",
                 config.entry_offset_days,
             )
     logger.info(
@@ -756,6 +811,7 @@ async def run_backtest(
         candle = await _fetch_entry_candle(
             client, m.ticker, entry_ts, memory_cache,
             failed=failed_fetches, disk=candle_cache,
+            period=config.candle_period_minutes,
         )
         if candle is None and m.ticker in failed_fetches:
             # Distinguish a FAILED fetch from genuinely-empty history:
@@ -827,6 +883,13 @@ async def run_backtest(
     entry_views: dict[str, Market] = {
         ticker: _entry_day_view(
             original_by_ticker[ticker], candle, synthetic_close,
+            volume_24h=(
+                _trailing_24h_volume(
+                    memory_cache[ticker],
+                    int(entry_times[ticker].timestamp()),
+                )
+                if config.candle_period_minutes < 1440 else None
+            ),
         )
         for ticker, candle in entry_candles.items()
     }
@@ -967,14 +1030,36 @@ async def run_backtest(
     # and must not be reused. Walk fetch failures hold to settlement
     # (debug-logged) and deliberately do NOT count in fetch_failures —
     # that counter's funnel arithmetic is entry-pass semantics.
-    # TODO(#714): verify Kalshi's candlesticks period cap (~5000 per
-    # request, unpinned) — one request per market is safe for daily
-    # candles over any realistic backtest window.
+    # Cap fact (settles the #714 TODO): Kalshi hard-400s beyond 5000
+    # periods per request (live-probed 2026-07-13) — see
+    # MAX_CANDLES_PER_REQUEST. The walk span is exactly the entry
+    # offset (entry -> settle), so the cap condition is config-derived
+    # and computed ONCE: fall back to the next coarser period until
+    # the span fits (#716). Coarser exit resolution beats a hard 400,
+    # and 1440 always fits (a 5000-day offset would be absurd).
     walk_fetch_failures = 0
+    walk_candle_period: int | None = None
     if (
         config.take_profit_pct is not None
         or config.stop_loss_pct is not None
     ):
+        walk_candle_period = config.candle_period_minutes
+        while (
+            walk_candle_period != 1440
+            and config.entry_offset_days * 1440 / walk_candle_period
+            >= MAX_CANDLES_PER_REQUEST
+        ):
+            coarser = 60 if walk_candle_period == 1 else 1440
+            logger.warning(
+                "--entry-offset %g spans %d candles at period %d —"
+                " over the API's hard cap of %d per request; walking"
+                " exits at period %d instead (coarser exit"
+                " resolution) (#716)",
+                config.entry_offset_days,
+                int(config.entry_offset_days * 1440 / walk_candle_period),
+                walk_candle_period, MAX_CANDLES_PER_REQUEST, coarser,
+            )
+            walk_candle_period = coarser
         for trade in pending:
             entry_ts = int(trade.entry_time.timestamp())
             settle_time = (
@@ -985,7 +1070,7 @@ async def run_backtest(
             walk_window = {
                 "start_ts": entry_ts,
                 "end_ts": settle_ts,
-                "period_interval": 1440,
+                "period_interval": walk_candle_period,
             }
             walk_candles = None
             if candle_cache is not None:
@@ -1168,4 +1253,5 @@ async def run_backtest(
         exited_take_profit=exited_take_profit,
         exited_stop_loss=exited_stop_loss,
         walk_fetch_failures=walk_fetch_failures,
+        walk_candle_period=walk_candle_period,
     )

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -520,10 +520,11 @@ def _entry_day_view(
       candle-derived spread with no new arithmetic.
     - last_price is 0.0: the midpoint must never fall back to stale
       trade prices (the same rationale candle_midpoint uses, #655).
-    - volume AND volume_24h from the candle's per-period volume — for
-      period_interval=1440 that IS the day's 24h volume. At sub-day
-      periods the caller passes ``volume_24h`` = the trailing-24h sum
-      (#716); the single per-period candle volume would understate
+    - volume AND volume_24h: at period 1440 both come from the
+      candle's per-period volume — that IS the day's 24h volume. At
+      sub-day periods the caller passes ``volume_24h`` = the
+      trailing-24h SUM of per-period volumes, and both fields carry
+      it (#716); the single per-period candle volume would understate
       24h volume up to 1440x and silently bias the scanner's
       min_volume gate and quick_score's volume tiers. Both fields are
       set to the same value so the scanner/scorer's
@@ -1051,10 +1052,10 @@ async def run_backtest(
         ):
             coarser = 60 if walk_candle_period == 1 else 1440
             logger.warning(
-                "--entry-offset %g spans %d candles at period %d —"
-                " over the API's hard cap of %d per request; walking"
-                " exits at period %d instead (coarser exit"
-                " resolution) (#716)",
+                "--entry-offset %g spans %d periods at %d-min"
+                " granularity — over the API's hard cap of %d periods"
+                " per request; walking exits at period %d instead"
+                " (coarser exit resolution) (#716)",
                 config.entry_offset_days,
                 int(config.entry_offset_days * 1440 / walk_candle_period),
                 walk_candle_period, MAX_CANDLES_PER_REQUEST, coarser,

--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -87,6 +87,13 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         f"Gimme threshold: {cfg.gimmes_config.strategy.gimme_threshold:.0f}",
         f"Assumed edge: {cfg.assumed_edge:.0%}",
         f"Entry offset: {cfg.entry_offset_days:g} day(s) before close",
+        f"Candle period: {cfg.candle_period_minutes} min" + (
+            f" (exits walked at {result.walk_candle_period} min —"
+            f" capped fallback)"
+            if result.walk_candle_period is not None
+            and result.walk_candle_period != cfg.candle_period_minutes
+            else ""
+        ),
         "Fill model: "
         + ("taker (pays the ask)" if cfg.taker_fill else "maker (midpoint)"),
         "Exits: "
@@ -303,6 +310,8 @@ def backtest_result_to_json(result: BacktestResult) -> dict:  # type: ignore[typ
             "take_profit_pct": result.config.take_profit_pct,
             "stop_loss_pct": result.config.stop_loss_pct,
             "entry_offset_days": result.config.entry_offset_days,
+            "candle_period_minutes": result.config.candle_period_minutes,
+            "walk_candle_period": result.walk_candle_period,
         },
         "funnel": {
             "markets_scanned": result.markets_scanned,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4413,8 +4413,17 @@ def backtest(
     entry_offset: float = typer.Option(
         1.0, "--entry-offset",
         help="Enter each market this many days before close (default"
-             " 1). Candles are daily — sub-day values mostly skip;"
-             " each offset value is a fresh cache namespace (#713)",
+             " 1). Sub-day offsets need --candle-period 60 (or 1);"
+             " each offset value is a fresh cache namespace"
+             " (#713/#716)",
+    ),
+    candle_period: int = typer.Option(
+        1440, "--candle-period",
+        help="Candle granularity in minutes for entry pricing and the"
+             " TP/SL walk: 1, 60, or 1440 (default: daily). Sub-day"
+             " periods compute volume_24h as a trailing-24h sum; each"
+             " period is a fresh cache namespace, and period 1 grows"
+             " the cache fast (#716)",
     ),
 ) -> None:
     """Backtest the gimme strategy on historical settled markets."""
@@ -4424,7 +4433,11 @@ def backtest(
         import json
         from datetime import date
 
-        from gimmes.backtest.engine import BacktestConfig, run_backtest
+        from gimmes.backtest.engine import (
+            ALLOWED_CANDLE_PERIODS,
+            BacktestConfig,
+            run_backtest,
+        )
         from gimmes.backtest.report import backtest_result_to_json, format_backtest_report
         from gimmes.kalshi.client import KalshiClient
 
@@ -4457,6 +4470,11 @@ def backtest(
                 " number[/red]",
             )
             raise typer.Exit(1)
+        if candle_period not in ALLOWED_CANDLE_PERIODS:
+            console.print(
+                "[red]--candle-period must be 1, 60, or 1440[/red]",
+            )
+            raise typer.Exit(1)
         bt_config = BacktestConfig(
             start_date=start,
             end_date=end,
@@ -4467,6 +4485,7 @@ def backtest(
             take_profit_pct=take_profit,
             stop_loss_pct=stop_loss,
             entry_offset_days=entry_offset,
+            candle_period_minutes=candle_period,
         )
         console.print(
             f"[dim]Running backtest: {start} to {end}, "

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -7,8 +7,11 @@ from datetime import UTC, date, datetime, timedelta
 import pytest
 
 from gimmes.backtest.engine import (
+    ALLOWED_CANDLE_PERIODS,
+    CANDLE_LOOKBACK_DAYS,
     DEFAULT_FEE_MULTIPLIERS,
     ENTRY_OFFSET_DAYS,
+    MAX_CANDLES_PER_REQUEST,
     BacktestLedger,
     _walk_exit,
     candle_midpoint,
@@ -797,9 +800,13 @@ class _EntryDayHarness:
             m.ticker: int(m.close_time.timestamp()) for m in markets
         }
 
-        async def _fake_candles(client, ticker, *, start_ts, end_ts, **kw):
+        async def _fake_candles(
+            client, ticker, *, start_ts, end_ts,
+            period_interval=1440, **kw,
+        ):
             calls.append({"ticker": ticker, "start_ts": start_ts,
-                          "end_ts": end_ts})
+                          "end_ts": end_ts,
+                          "period_interval": period_interval})
             if end_ts == settle_ts[ticker] and start_ts != end_ts:
                 return walk_candles.get(ticker, [])
             return entry_candles.get(ticker, [])
@@ -1589,6 +1596,27 @@ def test_cli_entry_offset_wired(tmp_path) -> None:
     assert captured["config"].entry_offset_days == ENTRY_OFFSET_DAYS
 
 
+def test_cli_candle_period_wired(tmp_path) -> None:
+    """#716: --candle-period reaches BacktestConfig; default 1440."""
+    result, captured = _invoke_backtest_cli(
+        tmp_path, "--candle-period", "60",
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["config"].candle_period_minutes == 60
+
+    result, captured = _invoke_backtest_cli(tmp_path)
+    assert result.exit_code == 0, result.output
+    assert captured["config"].candle_period_minutes == 1440
+
+
+def test_cli_candle_period_invalid_rejected(tmp_path) -> None:
+    for bad in ("30", "0", "720"):
+        result, _ = _invoke_backtest_cli(
+            tmp_path, "--candle-period", bad,
+        )
+        assert result.exit_code == 1, bad
+
+
 def test_cli_entry_offset_nonpositive_rejected(tmp_path) -> None:
     result, _ = _invoke_backtest_cli(tmp_path, "--entry-offset", "0")
     assert result.exit_code == 1
@@ -1728,7 +1756,22 @@ class TestEntryOffset(_EntryDayHarness):
             await run_backtest(client=None, config=config)
         warnings = [r.message for r in caplog.records]
         assert any("sub-day" in w for w in warnings)
+        assert any("--candle-period" in w for w in warnings)  # #716
         assert not any("hold-to-settlement" in w for w in warnings)
+
+        # #716 control arm: sub-day offset WITH sub-day candles is
+        # meaningful — no warning.
+        caplog.clear()
+        config = self._offset_config(0.5)
+        config.candle_period_minutes = 60
+        config.gimmes_config.scanner.min_days_to_resolution = 0.0
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            await run_backtest(client=None, config=config)
+        assert not any(
+            "sub-day" in r.message for r in caplog.records
+        )
 
         # Control arm (mutation pin: `< 1` must not become `<= 1`):
         # the default 1.0 offset never triggers the sub-day warning.
@@ -1771,6 +1814,20 @@ class TestEntryOffset(_EntryDayHarness):
         warnings = [r.message for r in caplog.records]
         assert any("sub-day" in w for w in warnings)
         assert any("hold-to-settlement" in w for w in warnings)
+
+        # #716 control arm: period 60 makes the sub-day walk real —
+        # neither warning fires.
+        caplog.clear()
+        config = self._offset_config(0.5, tp=0.8)
+        config.candle_period_minutes = 60
+        config.gimmes_config.scanner.min_days_to_resolution = 0.0
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            await run_backtest(client=None, config=config)
+        assert not any(
+            "hold-to-settlement" in r.message for r in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_days_filter_warning_keys_off_configured_offset(
@@ -1819,6 +1876,280 @@ class TestEntryOffset(_EntryDayHarness):
             "min_days_to_resolution" in r.message for r in caplog.records
         )
         assert result.trades == []
+
+
+class TestCandlePeriod(_EntryDayHarness):
+    """#716: configurable candle granularity — sub-day entry pricing,
+    sub-day exits, trailing-24h volume, the 5000-period cap fallback,
+    and fail-fast validation."""
+
+    def _period_config(self, period, offset=1.0, tp=None, sl=None):
+        cfg = self._exit_config(tp=tp, sl=sl)
+        cfg.entry_offset_days = offset
+        cfg.candle_period_minutes = period
+        cfg.gimmes_config.scanner.min_days_to_resolution = 0.0
+        return cfg
+
+    def test_trailing_24h_volume_boundary(self) -> None:
+        """Direct pin of the half-open interval (review-found: the
+        e2e min_volume gate can't see over-inclusion — 100 and 655
+        both pass min_volume=100). The boundary candle (exactly 24h
+        old) and the 25h-old candle are BOTH excluded."""
+        from gimmes.backtest.engine import _trailing_24h_volume
+
+        entry_ts = 1_700_000_000
+        candles = [
+            _make_candle(ts=entry_ts - 90_000, volume=999),
+            _make_candle(ts=entry_ts - 86_400, volume=555),
+            _make_candle(ts=entry_ts - 7_200, volume=30),
+            _make_candle(ts=entry_ts - 3_600, volume=30),
+            _make_candle(ts=entry_ts, volume=40),
+        ]
+        assert _trailing_24h_volume(candles, entry_ts) == 100
+
+    def test_lookback_fits_cap_at_every_period(self) -> None:
+        """Pure pin: the 3-day entry lookback must fit the API's
+        hard 5000-period cap at EVERY allowed period (worst case
+        period 1: 4320 + 1 inclusive endpoint)."""
+        for p in ALLOWED_CANDLE_PERIODS:
+            assert (
+                CANDLE_LOOKBACK_DAYS * 1440 / p + 1
+                <= MAX_CANDLES_PER_REQUEST
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_period_fails_fast(self, monkeypatch) -> None:
+        list_calls = []
+
+        async def _fake_list(*args, **kwargs):
+            list_calls.append(1)
+            return []
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+        for bad in (0, 30, 720, -1):
+            config = self._period_config(bad)
+            with pytest.raises(ValueError, match="candle_period"):
+                await run_backtest(client=None, config=config)
+        assert list_calls == []  # guard fired before any fetch
+
+    @pytest.mark.asyncio
+    async def test_period60_subday_entry_pricing(
+        self, monkeypatch,
+    ) -> None:
+        """A half-day offset with hourly candles prices the entry —
+        the combination #713 could only warn about."""
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        entry_ts = close_ts - 43_200  # offset 0.5
+        candles = {m.ticker: [_make_candle(
+            ts=entry_ts, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        calls = self._stub(monkeypatch, markets, candles)
+        config = self._period_config(60, offset=0.5)
+        result = await run_backtest(client=None, config=config)
+
+        assert len(result.trades) == 1
+        assert result.trades[0].entry_price == pytest.approx(0.65)
+        assert all(c["end_ts"] == entry_ts for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_period60_walk_finds_subday_exit(
+        self, monkeypatch,
+    ) -> None:
+        """Hourly walk candles let a half-day position exit intraday
+        — structurally impossible at period 1440."""
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        entry_ts = close_ts - 43_200
+        entry = {m.ticker: [_make_candle(
+            ts=entry_ts, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        walk = {m.ticker: [_make_candle(
+            ts=entry_ts + 3_600, yes_bid_close=0.02, yes_ask_close=0.06,
+        )]}
+        calls = self._stub_windowed(monkeypatch, markets, entry, walk)
+        config = self._period_config(60, offset=0.5, tp=0.8)
+        result = await run_backtest(client=None, config=config)
+
+        assert len(result.trades) == 1
+        t = result.trades[0]
+        assert t.exit_reason == "take_profit"
+        assert t.exit_time == datetime.fromtimestamp(
+            entry_ts + 3_600, tz=UTC,
+        )
+        assert result.walk_candle_period == 60
+        walk_calls = [c for c in calls if c["end_ts"] == close_ts]
+        assert walk_calls
+        # The FETCH itself carries the walk period (review-found:
+        # result.walk_candle_period is set independently of the
+        # window dict — both must agree).
+        assert all(c["period_interval"] == 60 for c in walk_calls)
+
+    @pytest.mark.asyncio
+    async def test_trailing_24h_volume_at_period60(
+        self, monkeypatch,
+    ) -> None:
+        """volume_24h = trailing-24h SUM of per-period volumes; the
+        25h-old candle is excluded (half-open lower bound). A
+        single-candle mapping (40) would fail min_volume=100."""
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        entry_ts = close_ts - 43_200
+        candles = {m.ticker: [
+            _make_candle(ts=entry_ts - 90_000, yes_bid_close=0.30,
+                         yes_ask_close=0.40, volume=999),
+            _make_candle(ts=entry_ts - 86_400, yes_bid_close=0.30,
+                         yes_ask_close=0.40, volume=555),  # boundary: excluded
+            _make_candle(ts=entry_ts - 7_200, yes_bid_close=0.30,
+                         yes_ask_close=0.40, volume=30),
+            _make_candle(ts=entry_ts - 3_600, yes_bid_close=0.30,
+                         yes_ask_close=0.40, volume=30),
+            _make_candle(ts=entry_ts, yes_bid_close=0.30,
+                         yes_ask_close=0.40, volume=40),
+        ]}
+        self._stub(monkeypatch, markets, candles)
+        config = self._period_config(60, offset=0.5)
+        config.gimmes_config.scanner.min_volume = 100
+        result = await run_backtest(client=None, config=config)
+        # 40 + 30 + 30 = 100 passes; single-candle 40 would not.
+        assert len(result.trades) == 1
+
+    @pytest.mark.asyncio
+    async def test_default_period_keeps_selected_candle_volume(
+        self, monkeypatch,
+    ) -> None:
+        """Period 1440 keeps the SELECTED candle's volume even when
+        stale — a trailing sum would be 0 and silently drop markets
+        the default path prices today (plan-found regression trap)."""
+        markets = self._markets()
+        m = markets[0]
+        entry_ts = self._entry_ts(m)
+        candles = {m.ticker: [_make_candle(
+            ts=entry_ts - 100_000,  # stale (>1 day old)
+            yes_bid_close=0.30, yes_ask_close=0.40, volume=500,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+        config = self._period_config(1440)
+        config.gimmes_config.scanner.min_volume = 100
+        result = await run_backtest(client=None, config=config)
+        assert len(result.trades) == 1
+        assert result.stale_candles == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_candle_at_period60_drops_on_volume(
+        self, monkeypatch,
+    ) -> None:
+        """At sub-day periods a stale entry candle (>24h old) means
+        the trailing 24h genuinely had zero volume — the market is
+        honestly dropped by min_volume (review-found: only the 1440
+        arm of this dichotomy was pinned)."""
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        entry_ts = close_ts - 43_200
+        candles = {m.ticker: [_make_candle(
+            ts=entry_ts - 100_000,  # >24h old
+            yes_bid_close=0.30, yes_ask_close=0.40, volume=500,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+        config = self._period_config(60, offset=0.5)
+        config.gimmes_config.scanner.min_volume = 100
+        result = await run_backtest(client=None, config=config)
+        assert result.trades == []
+        assert result.stale_candles == 1
+
+    @pytest.mark.asyncio
+    async def test_walk_period_fallback_ladder(
+        self, monkeypatch, caplog,
+    ) -> None:
+        """Offset spans over the 5000-period cap fall back to the
+        next coarser walk period; entries keep the configured
+        period."""
+        import logging
+
+        monkeypatch.setattr(
+            logging.getLogger("gimmes.backtest"), "propagate", True,
+        )
+        markets = self._markets()
+        m = markets[0]
+        close_ts = int(m.close_time.timestamp())
+        # offset 4.0 at period 1: 5760 >= 5000 -> walk at 60.
+        entry_ts = close_ts - 4 * 86_400
+        entry = {m.ticker: [_make_candle(
+            ts=entry_ts, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        walk = {m.ticker: []}
+        calls = self._stub_windowed(monkeypatch, markets, entry, walk)
+        config = self._period_config(1, offset=4.0, sl=0.15)
+        with caplog.at_level(
+            logging.WARNING, logger="gimmes.backtest.engine",
+        ):
+            result = await run_backtest(client=None, config=config)
+        assert result.walk_candle_period == 60
+        assert any("hard cap" in r.message for r in caplog.records)
+        entry_calls = [c for c in calls if c["end_ts"] == entry_ts]
+        assert entry_calls  # entries still fetched (at period 1)
+        assert all(c["period_interval"] == 1 for c in entry_calls)
+        fallback_walk = [c for c in calls if c["end_ts"] == close_ts]
+        assert fallback_walk
+        # The walk WINDOW uses the fallback period, not the config
+        # period (review-found: unpinned).
+        assert all(c["period_interval"] == 60 for c in fallback_walk)
+
+        # Control: offset 3.0 at period 1 = 4320 < 5000 -> no fallback.
+        caplog.clear()
+        entry_ts3 = close_ts - 3 * 86_400
+        entry3 = {m.ticker: [_make_candle(
+            ts=entry_ts3, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub_windowed(monkeypatch, markets, entry3, walk)
+        config = self._period_config(1, offset=3.0, sl=0.15)
+        result = await run_backtest(client=None, config=config)
+        assert result.walk_candle_period == 1
+
+        # Exact-cap boundary (mutation pin: `>=` must not become
+        # `>`): span of exactly 5000 periods needs 5001 inclusive
+        # candles -> fallback.
+        boundary_offset = 5000 / 1440
+        entry_tsb = close_ts - int(boundary_offset * 86_400)
+        entryb = {m.ticker: [_make_candle(
+            ts=entry_tsb, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub_windowed(monkeypatch, markets, entryb, walk)
+        config = self._period_config(1, offset=boundary_offset, sl=0.15)
+        result = await run_backtest(client=None, config=config)
+        assert result.walk_candle_period == 60
+
+        # Second rung: offset 209 at period 60 -> walk at 1440.
+        entry_ts209 = close_ts - 209 * 86_400
+        entry209 = {m.ticker: [_make_candle(
+            ts=entry_ts209, yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub_windowed(monkeypatch, markets, entry209, walk)
+        config = self._period_config(60, offset=209.0, sl=0.15)
+        config.gimmes_config.scanner.max_days_to_resolution = 400.0
+        result = await run_backtest(client=None, config=config)
+        assert result.walk_candle_period == 1440
+
+    @pytest.mark.asyncio
+    async def test_no_walk_means_no_walk_period(
+        self, monkeypatch,
+    ) -> None:
+        markets = self._markets()
+        m = markets[0]
+        candles = {m.ticker: [_make_candle(
+            ts=self._entry_ts(m), yes_bid_close=0.30, yes_ask_close=0.40,
+        )]}
+        self._stub(monkeypatch, markets, candles)
+        result = await run_backtest(
+            client=None, config=self._period_config(60),
+        )
+        assert result.walk_candle_period is None
 
 
 class TestPostEntryExits(_EntryDayHarness):
@@ -2331,15 +2662,14 @@ class TestDiskCandleCache(_EntryDayHarness):
         assert second.fetch_failures == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("period", [1, 60, 1440])
     async def test_engine_uses_the_documented_window_keys(
-        self, monkeypatch,
+        self, monkeypatch, period,
     ) -> None:
         """A recording fake pins the cache-key contract: the window
-        derives from close_time, making sweep keys stable."""
-        from gimmes.backtest.engine import (
-            CANDLE_LOOKBACK_DAYS,
-        )
-
+        derives from close_time and carries the configured period
+        (#716), making sweep keys stable. The lookback is deliberately
+        NOT scaled by period."""
         markets = self._markets()
         m = markets[0]
         entry_ts = self._entry_ts(m)
@@ -2360,8 +2690,10 @@ class TestDiskCandleCache(_EntryDayHarness):
             async def put(self, ticker, *, candles, **kw):
                 recorded.append({"op": "put", "ticker": ticker, **kw})
 
+        config = self._permissive_config()
+        config.candle_period_minutes = period
         await run_backtest(
-            client=None, config=self._permissive_config(),
+            client=None, config=config,
             candle_cache=_FakeCache(),
         )
         gets = [r for r in recorded if r["op"] == "get"]
@@ -2370,4 +2702,4 @@ class TestDiskCandleCache(_EntryDayHarness):
         for r in gets + puts:
             assert r["end_ts"] == entry_ts
             assert r["start_ts"] == entry_ts - CANDLE_LOOKBACK_DAYS * 86400
-            assert r["period_interval"] == 1440
+            assert r["period_interval"] == period

--- a/tests/unit/test_backtest_report.py
+++ b/tests/unit/test_backtest_report.py
@@ -468,3 +468,51 @@ class TestEntryOffsetInReport:
         buf = StringIO()
         format_backtest_report(result, Console(file=buf, width=120))
         assert "Entry offset: 2.5 day(s)" in buf.getvalue()
+
+
+class TestCandlePeriodInReport:
+    """#716: period and walk-period reach the JSON config."""
+
+    def test_json_carries_period_fields(self) -> None:
+        data = backtest_result_to_json(_make_result())
+        assert data["config"]["candle_period_minutes"] == 1440
+        assert data["config"]["walk_candle_period"] is None
+
+        result = _make_result()
+        result.config.candle_period_minutes = 60
+        result.walk_candle_period = 60
+        data = backtest_result_to_json(result)
+        assert data["config"]["candle_period_minutes"] == 60
+        assert data["config"]["walk_candle_period"] == 60
+
+    def test_header_shows_period(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "Candle period: 1440 min" in buf.getvalue()
+
+    def test_header_shows_walk_fallback(self) -> None:
+        """The capped-fallback walk period must be visible in the
+        HUMAN report, not just the JSON (review-found: a mid-run
+        warning scrolls away)."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        result = _make_result()
+        result.config.candle_period_minutes = 1
+        result.walk_candle_period = 60
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        out = buf.getvalue()
+        assert "exits walked at 60 min" in out
+
+        # No suffix when the walk ran at the configured period.
+        result.walk_candle_period = 1
+        buf = StringIO()
+        format_backtest_report(result, Console(file=buf, width=120))
+        assert "exits walked" not in buf.getvalue()


### PR DESCRIPTION
## Summary

Daily candles are **midnight-US/Eastern aligned** (live-probed 2026-07-13 — the #713 warning's "midnight-UTC" claim was wrong, now fixed), so a <24h market has no daily candle before close and sub-day entry offsets were structurally useless. `--candle-period {1,60,1440}` (default 1440, zero churn) threads granularity through the entry window and the #714 walk window — the candle machinery was already granularity-agnostic, and every cache key already carried the period.

**The two real problems this solves beyond plumbing:**

1. **`volume_24h` honesty**: at sub-day periods, the entry view's volume is now the trailing-24h *sum* of per-period candle volumes (live-verified: minute volumes sum exactly to market totals). The single candle's volume would understate 24h volume up to 1440× and silently bias the scanner's `min_volume` gate and `quick_score` tiers. The 1440 path deliberately keeps the selected candle's volume — a trailing sum over a stale entry candle is 0 and would silently drop markets the default path prices today (plan-found regression trap; both arms pinned).
2. **The API cap, settled**: live bisection pins **exactly 5000 periods/request, hard 400, uniform across granularities** (closes the #714 TODO). The 3-day lookback fits at every period (pure test pins the arithmetic). The walk span equals the entry offset exactly (plan-found structural simplification — no per-market chunking needed), so a config-time fallback ladder (1→60→1440) coarsens the walk period until the span fits, warns per rung, records `BacktestResult.walk_candle_period`, and the report header shows "exits walked at N min (capped fallback)" when it differs.

Review pipeline: three reviewers + simplifier (no changes). Mutation analysis drove four dedicated pins: a direct `_trailing_24h_volume` boundary test (the e2e `min_volume` gate can't see over-inclusion), the walk *fetch* period pinned independently of the result field, an exact-5000-span boundary fixture, and the stale-candle volume dichotomy in both directions.

With #713 + #714 + this, the full backtest pipeline for the 807k short-lived market universe is in place: `--entry-offset 0.05 --candle-period 60 --take-profit 0.8 --stop-loss 0.15` is now a meaningful invocation.

Closes #716

## Test plan

- 25 new/updated tests: TestCandlePeriod ×10 (cap-fit pure pin, fail-fast with zero fetches, sub-day entry pricing, sub-day walk exit with fetch-period pin, trailing-volume e2e + direct boundary unit, stale dichotomy both arms, fallback ladder with both rungs + exact-boundary + control, no-walk None); window-keys parametrized {1,60,1440}; #713 warning tests gain period-60 control arms; CLI wired/invalid; report JSON/header incl. the fallback suffix pin.
- Full suite: **2086 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB