### PR TITLE
Hourly ladders B: calendar hourly windows, third cycle type, cadence and budget guardrails

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -8,7 +8,10 @@ import re
 import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 import click
 import typer
@@ -38,6 +41,12 @@ pause + 3600s monitor interval (~390 in-window cycles + ~17 monitor cycles).
 Pass `--cycles 0` (or `--max-cycles 0`) to opt into unbounded runs; the loop
 prints a startup warning when it does.
 """
+
+HOURLY_MIN_CYCLE_SECONDS = 120
+"""Skip an hourly dispatch when less than this remains before settlement.
+
+A cycle that can't finish Scout -> Caddie -> Closer before the market
+settles would only burn a session (#723)."""
 
 
 def _api_error_detail(e) -> str:  # type: ignore[no-untyped-def]
@@ -5436,6 +5445,30 @@ def _detect_api_error(output: bytes) -> tuple[bool, bool, str]:
     return True, is_transient, detail
 
 
+def _position_window_hit(
+    close_times: list[tuple[str, datetime]],
+    config: GimmesConfig,
+    now: datetime,
+) -> tuple[bool, str | None]:
+    """Return (True, ticker) if any held position is inside its ad-hoc
+    settlement window.
+
+    Hourly-series tickers are EXCLUDED (#723): a held sub-hour position
+    must not trigger full cycles every 60s until settlement (~600
+    sessions/day); its settlement reconciles on the next hourly cycle's
+    Step 1 (<=1h lag, matching pull-based paper semantics).
+    """
+    from gimmes.strategy.calendar import position_window
+
+    for ticker, ct in close_times:
+        if config.is_hourly_ticker(ticker):
+            continue
+        pw_open, pw_close = position_window(ct)
+        if pw_open <= now < pw_close:
+            return True, ticker
+    return False, None
+
+
 def _resilient_sleep(seconds: float) -> None:
     """Sleep that survives macOS system sleep/wake.
 
@@ -5810,6 +5843,29 @@ def _autonomous_loop(
     consecutive_failures = 0
     session_status = "stopped"
 
+    # Hourly-ladder state (#723): track the single active window only —
+    # two scalars, bounded memory, no pruning needed. The key is the
+    # settlement instant in UTC, NOT an ET wall-clock stamp: on the DST
+    # fall-back day both 1 AM ET hours must get their own window.
+    hourly_enabled = bool(config.scanner.hourly_series)
+    hourly_lead = config.scanner.hourly_lead_minutes
+    _hourly_window_key: str | None = None
+    _hourly_window_count = 0
+    if hourly_enabled and hourly_lead * 60 <= HOURLY_MIN_CYCLE_SECONDS:
+        console.print(
+            f"[red bold]scanner.hourly_lead_minutes={hourly_lead} leaves"
+            f" <={HOURLY_MIN_CYCLE_SECONDS}s per window — the hourly lane"
+            " can NEVER fire (it still wakes the loop every hour)."
+            " Raise the lead or clear scanner.hourly_series.[/red bold]"
+        )
+    elif hourly_enabled and hourly_lead < 10:
+        console.print(
+            f"[yellow]scanner.hourly_lead_minutes={hourly_lead} clamps"
+            f" every hourly cycle to ~{hourly_lead * 60}s — expect"
+            " chronic timeouts. Leads under 10 minutes are untested"
+            " territory (#723).[/yellow]"
+        )
+
     # Code staleness detection
     _startup_commit: str | None = None
     _last_remote_check: float = 0.0
@@ -5838,11 +5894,15 @@ def _autonomous_loop(
     proc = None
     old_handler = signal.signal(signal.SIGINT, _sigint_handler)
     try:
+        from datetime import UTC, datetime
+
         from gimmes.strategy.calendar import (
             ET,
+            hourly_window,
+            is_in_hourly_window,
             is_in_trade_window,
             next_trade_window,
-            position_window,
+            seconds_until_next_hourly_open,
             seconds_until_next_window,
         )
 
@@ -5913,11 +5973,7 @@ def _autonomous_loop(
                         exc_info=True,
                     )
 
-            for ticker, ct in close_times:
-                pw_open, pw_close = position_window(ct)
-                if pw_open <= now < pw_close:
-                    return True, ticker
-            return False, None
+            return _position_window_hit(close_times, config, now)
 
         while max_cycles == 0 or cycles_run < max_cycles:
             # --- Daily budget guardrail (#545) ---
@@ -6019,8 +6075,40 @@ def _autonomous_loop(
                             )
                             _staleness_warned = True
 
-            # Determine cycle type based on trade window calendar
+            # Determine cycle type based on trade window calendar.
+            # Precedence: release > position > hourly > monitor.
+            # Position outranks hourly (#723 review): the post-hourly
+            # sleep lands exactly at the next hourly open, so anything
+            # below hourly is unreachable in steady state — a held
+            # NON-hourly position nearing settlement must keep its full
+            # cycles (hourly-series positions are excluded from position
+            # windows by _position_window_hit, so they can't preempt).
+            # Release windows fully mask any hourly window they cover
+            # (full cycles don't scan the hourly series) — e.g. the
+            # 14:00-16:00 ET index window masks 2 of 24 hourly windows
+            # every weekday. Accepted miss per #723.
+            effective_timeout = config.strategy.cycle_timeout
             in_window, release_name, _secs_to_close = is_in_trade_window()
+            in_pos_window, pos_ticker = False, None
+            if not in_window:
+                _pw_result = asyncio.run(_check_position_windows())
+                in_pos_window, pos_ticker = _pw_result or (False, None)
+            hourly_fire = False
+            if not in_window and not in_pos_window and hourly_enabled:
+                _now_et = datetime.now(ET)
+                if is_in_hourly_window(_now_et, lead_minutes=hourly_lead):
+                    _, h_close = hourly_window(_now_et, lead_minutes=hourly_lead)
+                    _key = h_close.astimezone(UTC).isoformat()
+                    if _key != _hourly_window_key:
+                        _hourly_window_key = _key
+                        _hourly_window_count = 0
+                    _remaining = int((h_close - _now_et).total_seconds())
+                    if (
+                        _hourly_window_count
+                        < config.scanner.hourly_max_cycles_per_window
+                        and _remaining >= HOURLY_MIN_CYCLE_SECONDS
+                    ):
+                        hourly_fire = True
             if in_window:
                 cycle_type = "full"
                 cycle_prompt = "Run one trading cycle."
@@ -6029,38 +6117,56 @@ def _autonomous_loop(
                     f"[cyan]--- Cycle {cycle} ---[/cyan]"
                     f" [green bold][TRADE WINDOW: {release_name}][/green bold]"
                 )
-            else:
-                # Check if any held position is near settlement
-                _pw_result = asyncio.run(
-                    _check_position_windows()
+            elif in_pos_window:
+                cycle_type = "full"
+                cycle_prompt = "Run one trading cycle."
+                post_sleep = pause_seconds
+                console.print(
+                    f"[cyan]--- Cycle {cycle} ---[/cyan]"
+                    f" [magenta bold][POSITION WINDOW:"
+                    f" {pos_ticker}][/magenta bold]"
                 )
-                in_pos_window, pos_ticker = _pw_result or (False, None)
-                if in_pos_window:
-                    cycle_type = "full"
-                    cycle_prompt = "Run one trading cycle."
-                    post_sleep = pause_seconds
-                    console.print(
-                        f"[cyan]--- Cycle {cycle} ---[/cyan]"
-                        f" [magenta bold][POSITION WINDOW:"
-                        f" {pos_ticker}][/magenta bold]"
-                    )
-                else:
-                    cycle_type = "monitor"
-                    _, next_name = next_trade_window()
-                    secs_to_next = seconds_until_next_window()
-                    post_sleep = min(secs_to_next, monitor_interval)
-                    h, remainder = divmod(secs_to_next, 3600)
-                    m, _ = divmod(remainder, 60)
-                    console.print(
-                        f"[cyan]--- Cycle {cycle} ---[/cyan]"
-                        f" [yellow][MONITOR ONLY — next window:"
-                        f" {next_name} in {h}h {m:02d}m][/yellow]"
-                    )
-                    cycle_prompt = (
-                        "Run a MONITOR-ONLY cycle. Only run Steps 0, 0.5, 1, 2,"
-                        " 6.5, and 8. Skip Scout, Caddie, Closer, Scorecard,"
-                        " and Pro."
-                    )
+            elif hourly_fire:
+                _hourly_window_count += 1
+                cycle_type = "hourly"
+                # A straggler cycle must not order into a settled
+                # market — clamp the subprocess to the window close.
+                effective_timeout = min(config.strategy.cycle_timeout, _remaining)
+                post_sleep = pause_seconds  # recomputed post-cycle
+                _series = ", ".join(config.scanner.hourly_series)
+                console.print(
+                    f"[cyan]--- Cycle {cycle} ---[/cyan]"
+                    f" [blue bold][HOURLY WINDOW: {_series} —"
+                    f" settles {h_close.strftime('%H:%M')} ET][/blue bold]"
+                )
+                cycle_prompt = (
+                    "Run an HOURLY-LADDER cycle. Only run Steps 0, 0.5, 1,"
+                    " 3, 4, 4c, 5, and 8. In Step 3, instruct Scout to scan"
+                    " ONLY the hourly series (run 'gimmes scan -s <series>'"
+                    f" for each of: {_series}). Skip Monitor, Scorecard,"
+                    " and Pro."
+                )
+            else:
+                cycle_type = "monitor"
+                _, next_name = next_trade_window()
+                secs_to_next = seconds_until_next_window()
+                if hourly_enabled:
+                    h_secs = seconds_until_next_hourly_open(lead_minutes=hourly_lead)
+                    if h_secs < secs_to_next:
+                        secs_to_next, next_name = h_secs, "Hourly ladder"
+                post_sleep = min(secs_to_next, monitor_interval)
+                h, remainder = divmod(secs_to_next, 3600)
+                m, _ = divmod(remainder, 60)
+                console.print(
+                    f"[cyan]--- Cycle {cycle} ---[/cyan]"
+                    f" [yellow][MONITOR ONLY — next window:"
+                    f" {next_name} in {h}h {m:02d}m][/yellow]"
+                )
+                cycle_prompt = (
+                    "Run a MONITOR-ONLY cycle. Only run Steps 0, 0.5, 1, 2,"
+                    " 6.5, and 8. Skip Scout, Caddie, Closer, Scorecard,"
+                    " and Pro."
+                )
 
             update_session_cycle(config.db_path, session_id, cycle)
 
@@ -6094,7 +6200,7 @@ def _autonomous_loop(
                 _active_proc = proc
                 try:
                     stdout_bytes = _communicate_interruptible(
-                        proc, timeout=config.strategy.cycle_timeout,
+                        proc, timeout=effective_timeout,
                     )
                 finally:
                     _active_proc = None
@@ -6180,10 +6286,14 @@ def _autonomous_loop(
 
             except subprocess.TimeoutExpired:
                 _kill_process_group(proc)
+                # Anthropic charged for the killed subprocess's tokens —
+                # count the session (#545 intent; the hourly clamp makes
+                # timeouts a routine outcome rather than an anomaly, #723)
+                budget_tracker.record_session_no_usage()
                 consecutive_failures += 1
                 console.print(
                     f"[yellow]Cycle {cycle} timed out after"
-                    f" {config.strategy.cycle_timeout}s"
+                    f" {effective_timeout}s"
                     f" (failure {consecutive_failures}"
                     f"/{max_consecutive_failures})[/yellow]"
                 )
@@ -6218,7 +6328,25 @@ def _autonomous_loop(
             # may have opened during the cycle execution.
             if cycle_type == "monitor":
                 fresh_secs = seconds_until_next_window()
+                if hourly_enabled:
+                    fresh_secs = min(
+                        fresh_secs,
+                        seconds_until_next_hourly_open(lead_minutes=hourly_lead),
+                    )
                 post_sleep = min(fresh_secs, monitor_interval)
+            elif cycle_type == "hourly":
+                if _hourly_window_count < config.scanner.hourly_max_cycles_per_window:
+                    post_sleep = pause_seconds  # more cycles this window
+                else:
+                    # Land exactly at the next open (hourly or release) —
+                    # zero intermediate monitor sessions. NOT clamped by
+                    # monitor_interval: the hourly gap is <= ~61 min, so a
+                    # release window opening mid-gap is picked up within
+                    # the same bound as the monitor_interval path.
+                    post_sleep = min(
+                        seconds_until_next_window(),
+                        seconds_until_next_hourly_open(lead_minutes=hourly_lead),
+                    )
             console.print(f"[dim]Next cycle in {post_sleep}s...[/dim]")
             _resilient_sleep(post_sleep)
     except KeyboardInterrupt:

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -1130,7 +1130,13 @@ class BudgetConfig(BaseModel):
             "display_name": "Max Claude sessions per day",
             "description": (
                 "Hard cap on Claude Code sessions started per UTC"
-                " day. None = hardcoded default (80). 0 = unlimited."
+                " day. None = hardcoded default (80). 0 = unlimited.\n"
+                "\n"
+                "Enabling scanner.hourly_series adds up to 24 hourly"
+                " sessions per day (one per window at the default"
+                " hourly_max_cycles_per_window=1) on top of the"
+                " release/monitor load — raise this cap if the default"
+                " leaves insufficient headroom (#723)."
             ),
             "min_val": 0,
         },

--- a/src/gimmes/strategy/calendar.py
+++ b/src/gimmes/strategy/calendar.py
@@ -6,7 +6,7 @@ import calendar as _cal
 import math
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, time, timedelta
+from datetime import UTC, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 ET = ZoneInfo("America/New_York")
@@ -329,3 +329,55 @@ def position_window(
     close_et = close_time.astimezone(ET)
     open_et = close_et - timedelta(hours=hours_before)
     return open_et, close_et
+
+
+def hourly_window(
+    dt: datetime | None = None,
+    *,
+    lead_minutes: int,
+) -> tuple[datetime, datetime]:
+    """Ad-hoc scan window for hourly-settled series (#723).
+
+    Hourly series (e.g. KXBTCD) settle at the top of every hour ET.
+    Returns [next_hour_top - lead_minutes, next_hour_top) as ET-aware
+    datetimes. Top-of-hour is computed in UTC (ET is always a
+    whole-hour offset), so the helper is DST-immune: fall-back's
+    repeated 1 AM ET hour yields two distinct windows, and
+    spring-forward's nonexistent 2 AM wall hour is naturally absent.
+    A *dt* exactly at a top of hour belongs to the NEXT settlement:
+    hourly_window(14:00) opens at 15:00 - lead. The caller passes
+    config.scanner.hourly_lead_minutes (keyword-only, no default —
+    the value is config-owned); WINDOWS stays config-blind.
+    """
+    if dt is None:
+        dt = datetime.now(ET)
+    dt_utc = dt.astimezone(UTC)
+    next_top = (dt_utc + timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
+    open_dt = next_top - timedelta(minutes=lead_minutes)
+    return open_dt.astimezone(ET), next_top.astimezone(ET)
+
+
+def is_in_hourly_window(
+    dt: datetime | None = None, *, lead_minutes: int,
+) -> bool:
+    """True when *dt* falls inside the current hourly scan window."""
+    if dt is None:
+        dt = datetime.now(ET)
+    open_dt, close_dt = hourly_window(dt, lead_minutes=lead_minutes)
+    return open_dt <= dt < close_dt
+
+
+def seconds_until_next_hourly_open(
+    dt: datetime | None = None, *, lead_minutes: int,
+) -> int:
+    """Seconds from *dt* until the next hourly window opens (minimum 1).
+
+    If *dt* is already inside a window, returns seconds to the
+    FOLLOWING window's open. Same contract as
+    seconds_until_next_window: int, math.ceil, floor of 1.
+    """
+    if dt is None:
+        dt = datetime.now(ET)
+    open_dt, _close = hourly_window(dt, lead_minutes=lead_minutes)
+    target = open_dt if dt < open_dt else open_dt + timedelta(hours=1)
+    return max(1, math.ceil((target - dt).total_seconds()))

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -20,11 +20,12 @@ from gimmes.cli import (
     _detect_api_error,
     _detect_rate_limit,
     _extract_terminal_text,
+    _position_window_hit,
     _set_mode,
     _wrap_stream_json,
     app,
 )
-from gimmes.config import GimmesConfig, Mode, RiskConfig
+from gimmes.config import GimmesConfig, Mode, RiskConfig, ScannerConfig
 
 runner = CliRunner()
 
@@ -1950,3 +1951,666 @@ class TestCheckRemoteStaleness:
             )
             msg = _check_remote_staleness(tmp_path, "abc")
             assert msg is None
+
+
+class TestPositionWindowHit:
+    """#723: the pure position-window seam — hourly tickers are excluded
+    so a held sub-hour position can't trigger full cycles every 60s."""
+
+    @staticmethod
+    def _config(hourly_series: list[str]) -> GimmesConfig:
+        return GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            scanner=ScannerConfig(hourly_series=hourly_series),
+        )
+
+    def test_excludes_hourly_ticker(self) -> None:
+        now = datetime.now(UTC)
+        close_times = [
+            ("KXBTCD-26JUN23H14-T119999.99", now + timedelta(minutes=30)),
+            ("KXINX-26JUN23-B5000", now + timedelta(hours=2)),
+        ]
+        hit, ticker = _position_window_hit(
+            close_times, self._config(["KXBTCD"]), now,
+        )
+        assert hit is True
+        assert ticker == "KXINX-26JUN23-B5000"
+
+    def test_only_hourly_positions_no_hit(self) -> None:
+        now = datetime.now(UTC)
+        close_times = [
+            ("KXBTCD-26JUN23H14-T119999.99", now + timedelta(minutes=30)),
+        ]
+        assert _position_window_hit(
+            close_times, self._config(["KXBTCD"]), now,
+        ) == (False, None)
+
+    def test_inert_when_hourly_series_empty(self) -> None:
+        # Without the hourly opt-in the old behavior is unchanged: a
+        # KXBTCD position inside its 18h window IS a hit
+        now = datetime.now(UTC)
+        close_times = [
+            ("KXBTCD-26JUN23H14-T119999.99", now + timedelta(minutes=30)),
+        ]
+        hit, ticker = _position_window_hit(
+            close_times, self._config([]), now,
+        )
+        assert hit is True
+        assert ticker == "KXBTCD-26JUN23H14-T119999.99"
+
+    def test_outside_window_no_hit(self) -> None:
+        now = datetime.now(UTC)
+        close_times = [("KXINX-26JUN23-B5000", now + timedelta(hours=30))]
+        assert _position_window_hit(
+            close_times, self._config([]), now,
+        ) == (False, None)
+
+
+class TestHourlyLadder:
+    """#723: the third 'hourly' cycle type — window gating, one cycle
+    per window, timeout clamp, sleep integration, 24h cadence."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_session_funcs(self, tmp_path, monkeypatch):
+        """Same isolation as TestAutonomousLoop, but OUTSIDE any release
+        window by default — the fixture's is_in_trade_window=True would
+        mask every hourly path (release wins the precedence ladder)."""
+        monkeypatch.setenv("GIMMES_MODE", "driving_range")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+        with (
+            patch("gimmes.store.session.create_session", return_value=1),
+            patch("gimmes.store.session.end_session"),
+            patch("gimmes.store.session.mark_stale_sessions", return_value=0),
+            patch("gimmes.store.session.update_session_cycle"),
+            patch("asyncio.run", side_effect=lambda coro: coro.close()),
+            patch(
+                "gimmes.strategy.calendar.is_in_trade_window",
+                return_value=(False, None, None),
+            ),
+            patch(
+                "gimmes.strategy.calendar.next_trade_window",
+                return_value=(_make_future_dt(), "Index contracts"),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=3600,
+            ),
+            patch(
+                "gimmes.cli._check_code_staleness",
+                return_value=("abc123", False, None),
+            ),
+            patch(
+                "gimmes.cli._check_remote_staleness",
+                return_value=None,
+            ),
+        ):
+            yield
+
+    @staticmethod
+    def _hourly_load_config(**scanner_overrides):
+        """load_config side_effect injecting hourly_series=['KXBTCD']."""
+        from gimmes import cli as gimmes_cli
+
+        original = gimmes_cli.load_config
+        scanner_overrides.setdefault("hourly_series", ["KXBTCD"])
+
+        def patched(*args, **kwargs):  # type: ignore[no-untyped-def]
+            cfg = original(*args, **kwargs)
+            return cfg.model_copy(update={
+                "scanner": cfg.scanner.model_copy(update=scanner_overrides),
+            })
+
+        return patched
+
+    @staticmethod
+    def _dt_relative_window(remaining_seconds: int):
+        """hourly_window stub: close at dt + remaining — cli computes
+        _remaining from the same dt it passes, so the clamp is exact."""
+        def _hw(dt=None, *, lead_minutes):  # type: ignore[no-untyped-def]
+            return (
+                dt - timedelta(minutes=4),
+                dt + timedelta(seconds=remaining_seconds),
+            )
+        return _hw
+
+    def test_hourly_prompt_and_env(self) -> None:
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(1500),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "hourly"
+        cmd = mock_popen.call_args.args[0]
+        prompt = cmd[cmd.index("-p") + 1]
+        assert "HOURLY-LADDER" in prompt
+        assert "KXBTCD" in prompt
+        assert "0, 0.5, 1, 3, 4, 4c, 5, and 8" in prompt
+        assert "Skip Monitor, Scorecard, and Pro" in prompt
+
+    def test_hourly_disabled_when_series_empty(self) -> None:
+        # Default config: the hourly gate is bool(hourly_series) — the
+        # calendar helpers must never even be consulted. max_cycles=2 so
+        # the post-cycle monitor recompute (which has its own
+        # hourly_enabled guard) is also exercised: the loop breaks
+        # BEFORE the sleep on the final cycle, so a single cycle would
+        # never reach that block. The real seconds_until_next_hourly_open
+        # delegates to the patched module-global hourly_window, so the
+        # spies catch a dropped guard at either site transitively.
+        hw_spy = MagicMock()
+        in_hw_spy = MagicMock()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ) as mock_popen,
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("gimmes.strategy.calendar.is_in_hourly_window", in_hw_spy),
+            patch("gimmes.strategy.calendar.hourly_window", hw_spy),
+        ):
+            _autonomous_loop("driving_range", max_cycles=2, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "monitor"
+        in_hw_spy.assert_not_called()
+        hw_spy.assert_not_called()
+
+    def test_one_cycle_per_window(self) -> None:
+        # A FIXED absolute window (same close instant every call → same
+        # key): the second and third iterations must fall to monitor
+        close = datetime.now(UTC) + timedelta(seconds=1500)
+        window = (close - timedelta(minutes=29), close)
+        types: list[str] = []
+
+        def popen_side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            types.append(kwargs["env"]["GIMMES_CYCLE_TYPE"])
+            return _mock_popen()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=popen_side_effect),
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ) as mock_comm,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                lambda dt=None, *, lead_minutes: window,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 1860,
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=3, pause_seconds=0)
+
+        assert types == ["hourly", "monitor", "monitor"]
+        # The clamp must not leak into later cycles: cycle 1 is clamped
+        # to the window remainder, cycles 2-3 (monitor) run unclamped
+        timeouts = [c.kwargs["timeout"] for c in mock_comm.call_args_list]
+        assert timeouts[0] <= 1500
+        assert timeouts[1:] == [2700, 2700]
+
+    def test_max_cycles_per_window_gt_one(self) -> None:
+        close = datetime.now(UTC) + timedelta(seconds=1500)
+        window = (close - timedelta(minutes=29), close)
+        types: list[str] = []
+
+        def popen_side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            types.append(kwargs["env"]["GIMMES_CYCLE_TYPE"])
+            return _mock_popen()
+
+        sleep_spy = MagicMock()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=popen_side_effect),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep", sleep_spy),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=self._hourly_load_config(
+                    hourly_max_cycles_per_window=2,
+                ),
+            ),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                lambda dt=None, *, lead_minutes: window,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 1860,
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=3, pause_seconds=0)
+
+        assert types == ["hourly", "hourly", "monitor"]
+        # Post-hourly with count < max sleeps pause_seconds (0), NOT the
+        # to-next-open path — otherwise max>1 silently degrades to 1
+        # effective cycle per window
+        assert sleep_spy.call_args_list[0].args[0] == 0
+
+    def test_release_precedence_over_hourly(self) -> None:
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_trade_window",
+                return_value=(True, "Index contracts", 3600),
+            ),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(1500),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "full"
+        cmd = mock_popen.call_args.args[0]
+        assert cmd[cmd.index("-p") + 1] == "Run one trading cycle."
+
+    def test_hourly_timeout_clamped(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=_mock_popen()),
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ) as mock_comm,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(1500),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        assert mock_comm.call_args.kwargs["timeout"] == 1500
+
+    def test_hourly_timeout_not_clamped_when_window_long(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=_mock_popen()),
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ) as mock_comm,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(5000),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        assert mock_comm.call_args.kwargs["timeout"] == 2700
+
+    def test_hourly_skipped_when_too_late(self) -> None:
+        # 60s remaining < HOURLY_MIN_CYCLE_SECONDS: fall through to
+        # monitor, full timeout — no straggler cycle can order into a
+        # settled market
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ) as mock_comm,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(60),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 3600,
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "monitor"
+        assert mock_comm.call_args.kwargs["timeout"] == 2700
+
+    def test_monitor_sleep_and_display_consider_hourly(self, capsys) -> None:
+        sleep_spy = MagicMock()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep", sleep_spy),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: False,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=7200,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 900,
+            ),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=2, pause_seconds=0,
+                monitor_interval=3600,
+            )
+
+        # Both the decision-time sleep and the post-cycle recompute must
+        # take the sooner hourly open (900 < 7200 release, < 3600 interval)
+        assert sleep_spy.call_args_list[0].args[0] == 900
+        assert "Hourly ladder" in capsys.readouterr().out
+
+    def test_post_hourly_sleep_lands_at_next_open(self) -> None:
+        # After an exhausted hourly window, sleep to the next open —
+        # NOT clamped by monitor_interval, no intermediate monitor cycle
+        sleep_spy = MagicMock()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep", sleep_spy),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(1500),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=7200,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 1860,
+            ),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=2, pause_seconds=0,
+                monitor_interval=120,
+            )
+
+        assert sleep_spy.call_args_list[0].args[0] == 1860
+
+    def test_24h_cadence_simulation(self) -> None:
+        """The budget guardrail as a test: a full simulated day with
+        hourly enabled and no release windows runs exactly 24 hourly
+        cycles + 1 leading monitor cycle — no window slept through, no
+        intermediate monitor sessions, sessions/day bounded at 25."""
+        from zoneinfo import ZoneInfo
+
+        from gimmes.strategy.calendar import (
+            hourly_window as real_hw,
+        )
+        from gimmes.strategy.calendar import (
+            is_in_hourly_window as real_in_hw,
+        )
+        from gimmes.strategy.calendar import (
+            seconds_until_next_hourly_open as real_snho,
+        )
+
+        et = ZoneInfo("America/New_York")
+        clock = {"now": datetime(2026, 4, 7, 0, 0, tzinfo=et)}  # a Tuesday
+        end = clock["now"] + timedelta(hours=24)
+        types: list[str] = []
+
+        def fake_in_hw(dt=None, *, lead_minutes):  # type: ignore[no-untyped-def]
+            return real_in_hw(clock["now"], lead_minutes=lead_minutes)
+
+        def fake_hw(dt=None, *, lead_minutes):  # type: ignore[no-untyped-def]
+            # Delegate to the real impl at the simulated instant, then
+            # re-anchor to the caller's dt (the loop's real now) so its
+            # `_remaining = close - now` arithmetic stays exact
+            o, c = real_hw(clock["now"], lead_minutes=lead_minutes)
+            rem_open = (o - clock["now"]).total_seconds()
+            rem_close = (c - clock["now"]).total_seconds()
+            base = dt if dt is not None else clock["now"]
+            return (
+                base + timedelta(seconds=rem_open),
+                base + timedelta(seconds=rem_close),
+            )
+
+        def fake_snho(dt=None, *, lead_minutes):  # type: ignore[no-untyped-def]
+            return real_snho(clock["now"], lead_minutes=lead_minutes)
+
+        def fake_sleep(secs):  # type: ignore[no-untyped-def]
+            clock["now"] += timedelta(seconds=secs)
+            if clock["now"] >= end:
+                raise KeyboardInterrupt
+
+        def popen_side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            types.append(kwargs["env"]["GIMMES_CYCLE_TYPE"])
+            return _mock_popen()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=popen_side_effect),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep", side_effect=fake_sleep),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch("gimmes.strategy.calendar.is_in_hourly_window", fake_in_hw),
+            patch("gimmes.strategy.calendar.hourly_window", fake_hw),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                fake_snho,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=10**6,  # no release windows all day
+            ),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=100, pause_seconds=0,
+                monitor_interval=3600,
+            )
+
+        assert types.count("hourly") == 24
+        assert types.count("monitor") == 1
+        assert len(types) == 25
+
+    def test_position_precedence_over_hourly(self, capsys) -> None:
+        # #723 review: a held NON-hourly position near settlement must
+        # keep its full cycles even when an hourly window is open —
+        # otherwise the steady-state hourly cadence starves position
+        # surveillance (overnight/weekends have no release windows)
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "asyncio.run",
+                side_effect=lambda coro: (
+                    coro.close(), (True, "KXINX-26JUN23-B5000"),
+                )[1],
+            ),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(1500),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "full"
+        assert "POSITION WINDOW" in capsys.readouterr().out
+
+    def test_post_hourly_sleep_takes_sooner_release_window(self) -> None:
+        # The post-hourly min must consider the release calendar too —
+        # a release window opening before the next hourly open wins
+        sleep_spy = MagicMock()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep", sleep_spy),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                self._dt_relative_window(1500),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=600,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 1860,
+            ),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=2, pause_seconds=0,
+                monitor_interval=3600,
+            )
+
+        assert sleep_spy.call_args_list[0].args[0] == 600
+
+    def test_startup_warning_lead_too_short_to_fire(self, capsys) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=self._hourly_load_config(hourly_lead_minutes=2),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        # Rich wraps long console lines — normalize before matching
+        out = " ".join(capsys.readouterr().out.split())
+        assert "can NEVER fire" in out
+
+    def test_startup_warning_lead_clamp_risk(self, capsys) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=self._hourly_load_config(hourly_lead_minutes=5),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "chronic timeouts" in out
+
+    def test_no_startup_warning_at_default_lead(self, capsys) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: False,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda dt=None, *, lead_minutes: 1860,
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "can NEVER fire" not in out
+        assert "chronic timeouts" not in out
+
+    def test_timeout_records_session_in_budget(self) -> None:
+        # #545 intent: Anthropic charged for the killed subprocess — a
+        # clamp-killed hourly straggler must still count a session
+        _frozen = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        from gimmes.config import GIMMES_HOME
+        budget_path = GIMMES_HOME / "budget.json"
+
+        def comm_side_effect(proc, timeout):  # type: ignore[no-untyped-def]
+            raise _subprocess.TimeoutExpired(cmd=proc.args, timeout=timeout)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", side_effect=lambda *a, **kw: _mock_popen()),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=comm_side_effect,
+            ),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("gimmes.budget._default_clock", lambda: _frozen),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        data = _json.loads(budget_path.read_text())
+        today = _frozen.date().isoformat()
+        assert data["days"][today]["sessions"] == 1

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from gimmes.strategy.calendar import (
     _cpi,
     _gdp_advance,
+    hourly_window,
+    is_in_hourly_window,
     is_in_trade_window,
     next_trade_window,
     position_window,
+    seconds_until_next_hourly_open,
     seconds_until_next_window,
 )
 
@@ -344,3 +347,100 @@ class TestPositionWindow:
         close = datetime(2026, 4, 15, 12, 0, tzinfo=ET)
         open_dt, _ = position_window(close, hours_before=6.0)
         assert open_dt == close.astimezone(ET) - timedelta(hours=6)
+
+
+class TestHourlyWindow:
+    """#723: ad-hoc scan windows for hourly-settled series."""
+
+    def test_basic(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 10, tzinfo=ET)
+        open_dt, close_dt = hourly_window(dt, lead_minutes=29)
+        assert open_dt == datetime(2026, 4, 7, 14, 31, tzinfo=ET)
+        assert close_dt == datetime(2026, 4, 7, 15, 0, tzinfo=ET)
+
+    def test_exact_top_of_hour_belongs_to_next(self) -> None:
+        at_top = datetime(2026, 4, 7, 14, 0, 0, tzinfo=ET)
+        open_dt, close_dt = hourly_window(at_top, lead_minutes=29)
+        assert close_dt == datetime(2026, 4, 7, 15, 0, tzinfo=ET)
+        assert open_dt == datetime(2026, 4, 7, 14, 31, tzinfo=ET)
+
+        just_before = datetime(2026, 4, 7, 13, 59, 59, 999999, tzinfo=ET)
+        _, close_dt = hourly_window(just_before, lead_minutes=29)
+        assert close_dt == datetime(2026, 4, 7, 14, 0, tzinfo=ET)
+
+    def test_day_boundary(self) -> None:
+        dt = datetime(2026, 4, 7, 23, 45, tzinfo=ET)
+        open_dt, close_dt = hourly_window(dt, lead_minutes=29)
+        assert close_dt == datetime(2026, 4, 8, 0, 0, tzinfo=ET)
+        assert open_dt == datetime(2026, 4, 7, 23, 31, tzinfo=ET)
+
+    def test_custom_lead(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 55, tzinfo=ET)
+        open_dt, close_dt = hourly_window(dt, lead_minutes=10)
+        assert close_dt - open_dt == timedelta(minutes=10)
+
+    def test_spring_forward_no_2am_window(self) -> None:
+        # 2026-03-08: 2 AM ET does not exist. From 01:45 EST the next
+        # real hour-top is 07:00 UTC (= 03:00 EDT); UTC arithmetic gets
+        # this right where wall-clock replace() would invent 02:00.
+        dt = datetime(2026, 3, 8, 1, 45, tzinfo=ET)
+        open_dt, close_dt = hourly_window(dt, lead_minutes=29)
+        assert close_dt.astimezone(UTC) == datetime(2026, 3, 8, 7, 0, tzinfo=UTC)
+        assert is_in_hourly_window(dt, lead_minutes=29) is True
+
+    def test_fall_back_repeated_hour_gets_two_windows(self) -> None:
+        # 2026-11-01: the 1 AM ET wall hour repeats. Both instants must
+        # get their own settlement window (KXBTCD settles every real
+        # hour) — pins the UTC-arithmetic design via ZoneInfo fold.
+        first = datetime(2026, 11, 1, 1, 30, tzinfo=ET)  # fold=0, EDT
+        second = datetime(2026, 11, 1, 1, 30, fold=1, tzinfo=ET)  # EST
+        _, close1 = hourly_window(first, lead_minutes=29)
+        _, close2 = hourly_window(second, lead_minutes=29)
+        assert close1.astimezone(UTC) == datetime(2026, 11, 1, 6, 0, tzinfo=UTC)
+        assert close2.astimezone(UTC) == datetime(2026, 11, 1, 7, 0, tzinfo=UTC)
+        assert close2.astimezone(UTC) - close1.astimezone(UTC) == timedelta(hours=1)
+
+
+class TestIsInHourlyWindow:
+    def test_open_boundary_inclusive(self) -> None:
+        at_open = datetime(2026, 4, 7, 14, 31, tzinfo=ET)
+        assert is_in_hourly_window(at_open, lead_minutes=29) is True
+
+    def test_just_before_open(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 30, 59, tzinfo=ET)
+        assert is_in_hourly_window(dt, lead_minutes=29) is False
+
+    def test_top_of_hour_not_in_window(self) -> None:
+        # At exactly 14:00 the relevant window is the 15:00 one, whose
+        # open is 14:31 — close-exclusivity via the next-window rule
+        dt = datetime(2026, 4, 7, 14, 0, tzinfo=ET)
+        assert is_in_hourly_window(dt, lead_minutes=29) is False
+
+
+class TestSecondsUntilNextHourlyOpen:
+    def test_before_open(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 10, tzinfo=ET)
+        assert seconds_until_next_hourly_open(dt, lead_minutes=29) == 1260
+
+    def test_exactly_at_open_returns_following(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 31, tzinfo=ET)
+        assert seconds_until_next_hourly_open(dt, lead_minutes=29) == 3600
+
+    def test_inside_window(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 45, tzinfo=ET)
+        assert seconds_until_next_hourly_open(dt, lead_minutes=29) == 2760
+
+    def test_ceil_and_minimum(self) -> None:
+        dt = datetime(2026, 4, 7, 14, 30, 59, 900000, tzinfo=ET)
+        assert seconds_until_next_hourly_open(dt, lead_minutes=29) == 1
+
+    def test_ceil_not_truncation(self) -> None:
+        # 60.5s to the open must round UP (61) — int() truncation (60)
+        # would wake the loop a second early, outside the window
+        dt = datetime(2026, 4, 7, 14, 29, 59, 500000, tzinfo=ET)
+        assert seconds_until_next_hourly_open(dt, lead_minutes=29) == 61
+
+    def test_fall_back_counts_toward_first_settlement(self) -> None:
+        dt = datetime(2026, 11, 1, 1, 15, tzinfo=ET)  # fold=0, EDT
+        # Next open is 01:31 EDT (toward the 06:00 UTC settlement)
+        assert seconds_until_next_hourly_open(dt, lead_minutes=29) == 960


### PR DESCRIPTION
## Summary

Part B of the #721 hourly strike-ladder feature: the autonomous loop can now wake for the ~29 minutes before each top-of-hour settlement and run a scoped hourly cycle. Default-inert while `scanner.hourly_series` is empty — with the feature off, the calendar helpers are never consulted and every existing path is byte-identical.

- **Calendar** (`calendar.py`): `hourly_window`, `is_in_hourly_window`, `seconds_until_next_hourly_open` — pure helpers, keyword-only `lead_minutes` (config-owned, no default). Hour-tops are computed in **UTC arithmetic**, making them DST-immune: the fall-back day genuinely yields 25 windows (both 1 AM ET hours settle), spring-forward's phantom 2 AM never exists. Pinned by fold-aware tests.
- **Precedence: release > position > hourly > monitor.** Position outranks hourly — a review finding, not the original plan: the post-hourly sleep lands exactly at the next hourly open, so anything ranked below hourly is unreachable in steady state, and a held **non-hourly** position would get zero surveillance cycles overnight/weekends. Hourly-series positions are excluded from position windows via the new pure `_position_window_hit` seam (a held sub-hour position must not trigger 60-second full cycles — ~600 sessions/day).
- **Hourly cycle**: steps-scoped prompt (Scout scans only the hourly series; skips Monitor/Scorecard/Pro), `GIMMES_CYCLE_TYPE=hourly`, one cycle per window (window key = UTC settlement instant — an ET wall-stamp would collide the fall-back day's two 1 AM windows), subprocess timeout clamped to the window close, dispatch skipped when <120s remain (`HOURLY_MIN_CYCLE_SECONDS`).
- **Sleep integration** at all three sites; the post-hourly sleep lands exactly at the next open (hourly or release, whichever is sooner) with zero intermediate monitor sessions.
- **Guardrails**: startup warning when `hourly_lead_minutes` ≤ 2 (lane can never fire) or < 10 (chronic clamp timeouts); timed-out cycles now count toward the session budget (#545 intent — the clamp makes timeouts routine); budget docs note +24 sessions/day (defaults untouched).

## Review findings deferred with tracking

- Monitor/stop-loss/Groundskeeper coverage inside the hourly lane + the zero-candidate prompt contradiction → commented on #724 (prompt scope).
- Hourly cycle wall-clock vs the ≤1740s clamp (chronic-timeout burn scenario) → commented on #725 (e2e timing budget deliverable).
- Restart-mid-window double-fire: bounded (scan excludes held tickers; Step 1 reconciles; budget.json persists across restarts) — accepted.

Closes #723

## Test plan

- 30 new tests: calendar helpers (incl. DST fold, day boundary, exact-top-of-hour, ceil-not-truncation), `_position_window_hit` seam (exclusion + inertness), loop behavior (prompt/env, one-cycle-per-window, max>1, release AND position precedence, timeout clamp + no-leak across cycles, skip-when-too-late, sleep at all three sites, startup warnings, timeout budget accounting), and a deterministic **24h cadence simulation** asserting exactly 24 hourly + 1 monitor session per day — the budget guardrail as a test.
- Full unit suite: **2158 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB