### PR TITLE
Hourly ladders D: end-to-end paper validation + operator enablement docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ CPI and GDP windows use actual BLS/BEA release dates (lookup table for 2025-2026
 
 - **Full cycle** (inside a trade window or position settlement window): runs the complete pipeline — Monitor → Scout → Caddie → Closer → Scorecard. Pauses `--pause` seconds (default 60) between cycles.
 - **Monitor-only cycle** (outside all windows): runs only Monitor and Groundskeeper, then sleeps until the next trade window or `--monitor-interval` (default 1 hour). Sleep is recalculated after each cycle to catch windows that open mid-cycle.
+- **Hourly cycle** (inside an hourly-ladder window, when `scanner.hourly_series` is set): a trimmed pipeline — Scout scans only the hourly series, Caddie sanity-checks against the backtested base rate, Closer executes taker orders, with Monitor's stop-loss backstop and Groundskeeper riding along. Clamped to the window remainder so a straggler cycle can't order into a settled market. See [Hourly ladders](#hourly-ladders-kxbtcd-paper-experiment).
 
 This reduces token usage ~80-90% compared to continuous cycling while being *more* responsive during data releases. Code staleness detection warns when the installed code has changed or the remote has newer commits — restart to pick up fixes.
 
@@ -589,6 +590,24 @@ gimmes config set scanner.yes_series "KXINX,KXINXW,KXNASDAQ100,KXNASDAQ100W"
 ```
 
 When `side = "yes"` or `"no"`, the flat strategy fields are used directly. Per-side overrides only apply when `side = "both"`.
+
+### Hourly ladders (KXBTCD paper experiment)
+
+BTC hourly strike ladders (`KXBTCD`) settle at the top of every hour. When you list a series in `scanner.hourly_series`, the loop opens a scan window `scanner.hourly_lead_minutes` before each close (default 29), buys **NO** in the 0.30–0.85 band against the backtested 0.70 base rate, and **holds to settlement** — the strategy takes no discretionary exits (Monitor's stop-loss backstop still applies; only the time-decay trigger is exempted). A 10-week backtest returned **+466% maker / +171% taker**; the live experiment runs the **taker twin**, because paper-mode maker fills are optimistic (they fill at your limit without a real counterparty crossing) and honest fills are the point.
+
+```bash
+gimmes config get strategy.side                  # MUST be "no" — the backtest is NO-side only
+gimmes config add scanner.hourly_series KXBTCD   # the feature switch (empty = off)
+gimmes config set budget.max_sessions_per_day 120  # hourly adds up to ~24-25 sessions/day
+```
+
+The side prerequisite is load-bearing: the hourly band is applied in the configured side's effective terms and the 0.70 base rate only anchors NO-side sizing — with `side = "yes"` (or the YES pass of `"both"`) you would be running an **unbacktested hourly YES lane** under the relaxed gates while believing you're running the experiment.
+
+Raising the session cap matters — at the default 80, the hourly lane plus release windows can hit the cap mid-day, and a cap hit sleeps the loop until UTC midnight, missing every window in between.
+
+**The timing budget.** Each hourly cycle is clamped to the window remainder — at the default lead that's **at most 1,740 seconds** for the full Scout → Caddie → Closer pass. A cycle that outruns the clamp is killed, still burns a session, and does **not** trip the circuit breaker — chronic timeouts look like a quiet day, not a failure. Compare cycle start/end timestamps in `${GIMMES_HOME}/logs/cycle-NNN.json` against the clamp; `scanner.hourly_lead_minutes` is the tuning knob. The loop warns loudly at startup when the lead leaves ≤120 s per window (the lane will never fire, but the loop still wakes every hour — fix the config, don't ignore the red text) and warns below 10 minutes; at runtime the per-window remainder gate skips any dispatch with under 120 s left.
+
+**Know what you're testing.** This is a **Driving Range (paper) experiment** — Championship (real-money) hourly is explicitly out of scope. The backtest's one un-modeled risk is **book depth**: it fills full Kelly size at the touch, and whether real hourly books can absorb that size is precisely what this experiment exists to measure. Release windows outrank hourly windows, so the 2:00–4:00 PM ET equity window masks ~2 hourly windows every weekday.
 
 ---
 

--- a/tests/unit/test_pipeline_e2e.py
+++ b/tests/unit/test_pipeline_e2e.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -19,11 +20,13 @@ from gimmes.config import (
 )
 from gimmes.models.market import Market, MarketStatus, Orderbook, OrderbookLevel
 from gimmes.models.order import CreateOrderParams, OrderAction, OrderSide
+from gimmes.models.trade import TradeDecision
 from gimmes.paper.broker import PaperBroker
 from gimmes.risk.validator import validate_trade
 from gimmes.store.database import Database
-from gimmes.strategy.fees import edge_after_fees
-from gimmes.strategy.kelly import position_size
+from gimmes.store.queries import get_daily_pnl, insert_trade, sync_positions
+from gimmes.strategy.fees import edge_after_fees, fee_for_order
+from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 from gimmes.strategy.scanner import effective_price, filter_markets
 from gimmes.strategy.scorer import quick_score
 
@@ -320,3 +323,320 @@ class TestSettlement:
         assert len(positions) == 0
         balance = await broker_no.get_balance()
         assert balance > 10_000
+
+
+# ---------------------------------------------------------------------------
+# #725: hourly-ladder lifecycle (KXBTCD paper experiment, parts A-C of #721)
+# ---------------------------------------------------------------------------
+
+HOURLY_TICKER = "KXBTCD-26JUN23H14-T119999.99"
+
+
+def _hourly_config(series: list[str] | None = None) -> GimmesConfig:
+    return GimmesConfig(
+        mode=Mode.DRIVING_RANGE,
+        strategy=StrategyConfig(
+            side="no",
+            gimme_threshold=75,
+            min_true_probability=0.90,
+            min_edge_after_fees=0.05,
+        ),
+        # hourly_* stay at defaults: floor 0.70, band 0.30-0.85
+        sizing=SizingConfig(kelly_fraction=0.25, max_position_pct=0.05),
+        risk=RiskConfig(bankroll_paper=10_000.0),
+        scanner=ScannerConfig(
+            min_volume=100, min_open_interest=50,
+            hourly_series=series if series is not None else ["KXBTCD"],
+        ),
+        paper=PaperTradingConfig(starting_balance=10_000.0),
+    )
+
+
+def _hourly_market() -> Market:
+    return Market(
+        ticker=HOURLY_TICKER,
+        event_ticker="KXBTCD-26JUN23H14",
+        series_ticker="KXBTCD",
+        title="BTC above $119,999.99 at 2pm EDT?",
+        status=MarketStatus.ACTIVE,
+        yes_bid=0.53,
+        yes_ask=0.57,
+        last_price=0.55,  # YES mid 0.55 -> NO effective 0.45
+        volume=5000,
+        volume_24h=1200,
+        open_interest=800,
+        close_time=datetime.now(UTC) + timedelta(minutes=29),
+        rules_primary="Resolves YES if BTC price is above the strike at the hour close.",
+    )
+
+
+def _ob_hourly() -> Orderbook:
+    # Taker liquidity for BUY NO: implied NO ask = 1 - yes_bid = 0.47
+    return Orderbook(
+        ticker=HOURLY_TICKER,
+        yes_bids=[OrderbookLevel(price=0.53, quantity=2000)],
+        no_bids=[OrderbookLevel(price=0.43, quantity=2000)],
+    )
+
+
+def _ob_hourly_no_counterparty() -> Orderbook:
+    # Empty opposing side for a BUY NO — the #690 honest no-fill book
+    return Orderbook(
+        ticker=HOURLY_TICKER,
+        yes_bids=[],
+        no_bids=[OrderbookLevel(price=0.43, quantity=2000)],
+    )
+
+
+@pytest.fixture
+async def hourly_db_broker(
+    tmp_path: Path,
+) -> AsyncIterator[tuple[Database, PaperBroker]]:
+    cfg = _hourly_config()
+    db = Database(tmp_path / "hourly.db")
+    await db.connect()
+    broker = PaperBroker(db, cfg.paper)
+    await broker.initialize()
+    yield db, broker
+    await db.close()
+
+
+async def _enter_hourly_position(
+    db: Database, broker: PaperBroker,
+) -> int:
+    """Run the mechanical entry flow the live hourly cycle drives:
+    filter -> score -> base-rate floor -> size (taker) -> validate
+    (hourly floor) -> log open trade -> taker order. Returns count."""
+    cfg = _hourly_config()
+    market = _hourly_market()
+
+    # Scanner admission: min-days bypass + hourly band (NO 0.45 in
+    # 0.30-0.85; the flat 0.55 floor would reject it)
+    passed = filter_markets([market], cfg)
+    assert [m.ticker for m in passed] == [HOURLY_TICKER]
+
+    # quick_score under-scores hourly NO honestly (~55 < threshold 75):
+    # the price-position component is keyed to the classic 0.55-0.85
+    # band. Scanner admission is the assertion; the hourly-aware time
+    # branch lives in full_score (Caddie's rubric), not quick_score.
+    assert quick_score(market, cfg) > 0
+
+    # The KXBTCD base-rate floor promotes a low NO-side estimate to
+    # exactly the hourly gate (floor==gate by design, #722)
+    floored = apply_base_rate_floor(0.60, market.ticker, side="no")
+    assert floored == 0.70
+
+    # Production auto-sizing prices at the side-effective MID and
+    # passes the same floored prob to both position_size and
+    # validate_trade (cli.py order command); the ORDER then crosses at
+    # the NO ask
+    eff_mid = 0.45  # effective_price(0.55, "no")
+    no_price = 0.47  # the implied NO ask — takers pay the touch
+    contracts = position_size(
+        10_000, eff_mid, floored,
+        is_taker=True, fraction=0.25, max_position_pct=0.05,
+    )
+    assert contracts > 0
+
+    result = validate_trade(
+        market, contracts * eff_mid, floored, 10_000,
+        0.0, 0, [], cfg, is_taker=True,
+    )
+    assert result.approved
+    assert any("hourly floor" in c for c in result.checks)
+
+    # The open row the live Closer's order command writes — settle()
+    # clamps the settlement close to the ledger residual (#663), so the
+    # ledger must show the real opened count
+    await insert_trade(db, TradeDecision(
+        ticker=HOURLY_TICKER, action=TradeDecision.Action.OPEN,
+        side="no", count=contracts, price=no_price,
+        model_probability=0.72, agent="closer",
+    ))
+
+    # post_only=False is what `gimmes order --taker` wires (#722)
+    params = CreateOrderParams(
+        ticker=HOURLY_TICKER, action=OrderAction.BUY,
+        side=OrderSide.NO, count=contracts, no_price=no_price,
+        post_only=False,
+    )
+    order = await broker.create_order(params, _ob_hourly())
+    assert order.status == "executed"
+    fills = await broker.list_fills(HOURLY_TICKER)
+    assert fills and all(f.is_taker for f in fills)
+    return contracts
+
+
+async def _settlement_closes(db: Database) -> list:
+    """All close rows for the hourly ticker, as written by settle()."""
+    cursor = await db.conn.execute(
+        "SELECT agent, price, count FROM trades"
+        " WHERE ticker = ? AND action = 'close'",
+        (HOURLY_TICKER,),
+    )
+    return await cursor.fetchall()
+
+
+class TestHourlyNoLifecycle:
+    @pytest.mark.asyncio
+    async def test_win_path(
+        self, hourly_db_broker: tuple[Database, PaperBroker],
+    ) -> None:
+        db, broker = hourly_db_broker
+        contracts = await _enter_hourly_position(db, broker)
+
+        # Top-of-hour settlement: NO wins
+        await broker.settle(HOURLY_TICKER, "no")
+
+        positions = await broker.get_positions()
+        assert positions == []
+
+        # Exact payout math: entry cost + taker fee out, $1/contract in
+        entry_fee = fee_for_order(contracts, 0.47, is_taker=True)
+        assert await broker.get_balance() == pytest.approx(
+            10_000 - contracts * 0.47 - entry_fee + contracts * 1.0,
+        )
+
+        # Next-cycle reconcile is a no-op: the settlement close already
+        # exists, sync must not duplicate it (#628)
+        await sync_positions(db, await broker.get_positions())
+
+        # #622 semantics: the settlement close is a single
+        # agent='settlement' row at price 1.0 and COUNTS toward daily P&L
+        closes = await _settlement_closes(db)
+        assert len(closes) == 1
+        settlement = closes[0]
+        assert settlement["agent"] == "settlement"
+        assert settlement["price"] == 1.0
+        assert settlement["count"] == contracts
+        assert await get_daily_pnl(db) == pytest.approx(
+            (1.0 - 0.47) * contracts,
+        )
+
+    @pytest.mark.asyncio
+    async def test_loss_path(
+        self, hourly_db_broker: tuple[Database, PaperBroker],
+    ) -> None:
+        db, broker = hourly_db_broker
+        contracts = await _enter_hourly_position(db, broker)
+
+        # BTC closes above the strike: NO loses
+        await broker.settle(HOURLY_TICKER, "yes")
+
+        assert await broker.get_positions() == []
+        entry_fee = fee_for_order(contracts, 0.47, is_taker=True)
+        assert await broker.get_balance() == pytest.approx(
+            10_000 - contracts * 0.47 - entry_fee,
+        )
+
+        closes = await _settlement_closes(db)
+        assert len(closes) == 1
+        settlement = closes[0]
+        assert settlement["agent"] == "settlement"
+        assert settlement["price"] == 0.0
+        # A real realized loss the daily-loss trigger must see
+        assert await get_daily_pnl(db) == pytest.approx(
+            (0.0 - 0.47) * contracts,
+        )
+
+    def test_hourly_gates_are_load_bearing(self) -> None:
+        # Negative control: with hourly_series empty, the relaxed gates
+        # vanish — each proven in isolation
+        cfg = _hourly_config(series=[])
+
+        # (a) min-days floor: a 29-minute market whose NO price (0.60)
+        # sits INSIDE the flat band, so the days check is the gate that
+        # actually rejects it
+        in_band = _hourly_market().model_copy(update={
+            "yes_bid": 0.38, "yes_ask": 0.42, "last_price": 0.40,
+        })
+        assert filter_markets([in_band], cfg) == []
+
+        # (b) flat price band: the standard fixture's NO 0.45 falls
+        # below the flat 0.55 floor (the hourly band admitted it)
+        assert filter_markets([_hourly_market()], cfg) == []
+
+        # (c) the global 0.90 probability floor rejects 0.72
+        result = validate_trade(
+            _hourly_market(), 500.0, 0.72, 10_000,
+            0.0, 0, [], cfg, is_taker=True,
+        )
+        assert not result.approved
+        assert any("90% minimum" in f for f in result.failures)
+
+
+class TestHourlyMakerHonesty:
+    @pytest.mark.asyncio
+    async def test_post_only_no_counterparty_cancels(
+        self, hourly_db_broker: tuple[Database, PaperBroker],
+    ) -> None:
+        # The #690 honest no-fill that the --taker design encodes: a
+        # maker order with no opposing liquidity cancels, deploys
+        # nothing, and leaves no position
+        _, broker = hourly_db_broker
+        params = CreateOrderParams(
+            ticker=HOURLY_TICKER, action=OrderAction.BUY,
+            side=OrderSide.NO, count=100, no_price=0.47,
+            post_only=True,
+        )
+        order = await broker.create_order(
+            params, _ob_hourly_no_counterparty(),
+        )
+        assert order.status == "canceled"
+        assert "no opposing liquidity" in (order.reason or "")
+        assert await broker.get_positions() == []
+        assert await broker.get_balance() == 10_000
+
+    @pytest.mark.asyncio
+    async def test_post_only_liquid_book_fills_at_limit_as_maker(
+        self, hourly_db_broker: tuple[Database, PaperBroker],
+    ) -> None:
+        # Paper-mode maker fills are OPTIMISTIC (#255): the remainder
+        # fills at your limit without a counterparty actually crossing.
+        # This is exactly why the hourly experiment runs the taker
+        # lane — the +466% maker backtest twin cannot be honestly
+        # simulated on paper.
+        _, broker = hourly_db_broker
+        params = CreateOrderParams(
+            ticker=HOURLY_TICKER, action=OrderAction.BUY,
+            side=OrderSide.NO, count=100, no_price=0.45,
+            post_only=True,
+        )
+        order = await broker.create_order(params, _ob_hourly())
+        assert order.status == "executed"
+        fills = await broker.list_fills(HOURLY_TICKER)
+        assert fills and all(not f.is_taker for f in fills)
+
+
+class TestHourlyTimingBudget:
+    @pytest.mark.asyncio
+    async def test_mechanical_path_fits_clamp(
+        self, hourly_db_broker: tuple[Database, PaperBroker],
+    ) -> None:
+        """#725 timing budget: the mechanical scan->order->settle path
+        must consume a negligible slice of the hourly window clamp.
+
+        The loop clamps every hourly cycle to the window remainder —
+        at the default lead of 29 minutes that is at most
+        hourly_lead_minutes * 60 = 1740 seconds for the whole
+        Scout -> Caddie -> Closer pass. A unit test cannot measure the
+        live LLM agents' wall-clock; what it CAN pin is that the
+        CLI/broker machinery is nowhere near the budget, so a blown
+        clamp in production is LLM wall-clock by elimination — and
+        scanner.hourly_lead_minutes is the tuning knob (see the README
+        recipe for log-based live measurement).
+        """
+        db, broker = hourly_db_broker
+        clamp = _hourly_config().scanner.hourly_lead_minutes * 60
+        assert clamp == 1740
+
+        start = time.perf_counter()
+        await _enter_hourly_position(db, broker)
+        await broker.settle(HOURLY_TICKER, "no")
+        elapsed = time.perf_counter() - start
+
+        # Generous CI margin; the real number is milliseconds. <2% of
+        # the clamp means the mechanical path can never be the reason
+        # an hourly cycle times out. min() keeps the budget meaningful
+        # if the default lead ever shrinks.
+        assert elapsed < min(30.0, clamp * 0.02)

--- a/tests/unit/test_pipeline_e2e.py
+++ b/tests/unit/test_pipeline_e2e.py
@@ -423,7 +423,8 @@ async def _enter_hourly_position(
 
     # The KXBTCD base-rate floor promotes a low NO-side estimate to
     # exactly the hourly gate (floor==gate by design, #722)
-    floored = apply_base_rate_floor(0.60, market.ticker, side="no")
+    raw_prob = 0.60
+    floored = apply_base_rate_floor(raw_prob, market.ticker, side="no")
     assert floored == 0.70
 
     # Production auto-sizing prices at the side-effective MID and
@@ -451,7 +452,7 @@ async def _enter_hourly_position(
     await insert_trade(db, TradeDecision(
         ticker=HOURLY_TICKER, action=TradeDecision.Action.OPEN,
         side="no", count=contracts, price=no_price,
-        model_probability=0.72, agent="closer",
+        model_probability=raw_prob, agent="closer",
     ))
 
     # post_only=False is what `gimmes order --taker` wires (#722)
@@ -475,6 +476,17 @@ async def _settlement_closes(db: Database) -> list:
         (HOURLY_TICKER,),
     )
     return await cursor.fetchall()
+
+
+async def _settlement_date(db: Database) -> str:
+    """The close row's own date — passing it to get_daily_pnl makes the
+    assertion deterministic even across a UTC-midnight straddle."""
+    cursor = await db.conn.execute(
+        "SELECT date(replace(timestamp, ' ', 'T')) AS d FROM trades"
+        " WHERE ticker = ? AND action = 'close'",
+        (HOURLY_TICKER,),
+    )
+    return (await cursor.fetchone())["d"]
 
 
 class TestHourlyNoLifecycle:
@@ -509,7 +521,9 @@ class TestHourlyNoLifecycle:
         assert settlement["agent"] == "settlement"
         assert settlement["price"] == 1.0
         assert settlement["count"] == contracts
-        assert await get_daily_pnl(db) == pytest.approx(
+        assert await get_daily_pnl(
+            db, today=await _settlement_date(db),
+        ) == pytest.approx(
             (1.0 - 0.47) * contracts,
         )
 
@@ -535,7 +549,9 @@ class TestHourlyNoLifecycle:
         assert settlement["agent"] == "settlement"
         assert settlement["price"] == 0.0
         # A real realized loss the daily-loss trigger must see
-        assert await get_daily_pnl(db) == pytest.approx(
+        assert await get_daily_pnl(
+            db, today=await _settlement_date(db),
+        ) == pytest.approx(
             (0.0 - 0.47) * contracts,
         )
 


### PR DESCRIPTION
## Summary

Final part of #721 — the hourly strike-ladder feature is now validated end to end on the paper stack and documented for the operator. Pure test + docs PR; `git diff --stat` shows zero `src/` changes.

**E2E validation** (tests/unit/test_pipeline_e2e.py, +3 test classes): the full hourly NO lifecycle — scanner admission via the min-days bypass and hourly band, the KXBTCD 0.70 base-rate floor, the hourly validator floor, taker sizing at the effective mid with the floored probability (faithful to the order command's actual call shape, per review), a taker order crossing the NO ask, and top-of-hour settlement on both the win and loss paths with **exact payout arithmetic** (entry cost + taker fee out, $1/contract in). The settlement close is asserted as `agent='settlement'` at 1.0/0.0 counting toward daily P&L (#622), and a reconcile-after-settle proves no duplicate close (#628). Negative controls isolate each relaxed gate independently (review fix: the original control conflated the band and min-days gates). The maker-honesty pair pins why the experiment runs the taker twin: an empty-book post-only order cancels (#690 — the `--taker` rationale), and a liquid-book post-only order fills optimistically at the limit (#255 — paper maker fills can't honestly simulate the +466% maker backtest).

Per the review's coverage analysis, the marginal value over parts A–C's unit tests is concentrated in three genuinely new seams: `log_settlement_close` → `get_daily_pnl` compatibility end-to-end, taker-flag persistence through the fills table, and the first NO-side broker-settle exact semantics anywhere.

**Timing budget** (honest scope): a unit test cannot measure live Scout→Caddie→Closer LLM wall-clock. The test pins that the mechanical scan→order→settle path consumes <2% of the 1740-second window clamp — so a blown clamp in production is LLM wall-clock by elimination — and the README carries the live measurement procedure (cycle-log timestamps vs the clamp; `scanner.hourly_lead_minutes` is the knob; chronic clamp timeouts never trip the circuit breaker and look like a quiet day).

**README**: third cycle-type bullet + the `### Hourly ladders (KXBTCD paper experiment)` recipe. Review-driven hardening: the **`strategy.side = "no"` prerequisite is stated as load-bearing** (an operator on `both`/`yes` would silently run an unbacktested hourly YES lane under the relaxed gates), the exit semantics are accurate to the merged Monitor behavior (no discretionary exits; the stop-loss backstop still applies), and the startup-guard wording matches what the code does (warns loudly; the runtime remainder gate is what prevents dispatch).

**CHANGELOG**: intentionally untouched — house process writes release entries at release time; the v0.8.12 entry will carry all four #721 parts.

**Deferred beyond #721** (tracked in the issue): championship (real-money) hourly, maker-order hourly lane, release-window-overlap hourly scanning, other hourly series base rates, push-based settlement, budget/cycle_timeout default changes, and live LLM wall-clock measurement as an operational task.

Closes #725
Closes #721

## Test plan

- 6 new tests (win/loss lifecycle, gate isolation, maker honesty pair, timing budget); 13/13 in the file.
- Full unit suite: **2177 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB