### PR TITLE
Hourly scan: tickers must settle at the next top of hour

### DIFF
--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -33,7 +33,7 @@ A gimme candidate MUST meet ALL of these minimum thresholds (applied by `gimmes 
 - Price between configured `strategy.min_market_price` and `strategy.max_market_price`
 - 24h volume >= configured `scanner.min_volume`
 - Open interest >= configured `scanner.min_open_interest`
-- Resolution between configured `scanner.min_days_to_resolution` and `scanner.max_days_to_resolution` (hourly-series tickers bypass the min-days floor — see Hourly Series below)
+- Resolution between configured `scanner.min_days_to_resolution` and `scanner.max_days_to_resolution` (hourly-series tickers instead must settle at the next top of hour — see Hourly Series below)
 - Clear settlement rules (no discretion clauses or ambiguity)
 
 Preferred (not required):
@@ -44,7 +44,7 @@ Preferred (not required):
 
 When the Caddie Master instructs an hourly scan, run `gimmes scan -s SERIES` once per named series (e.g. `gimmes scan -s KXBTCD`) — do NOT run an unscoped `gimmes scan`. Hourly-series candidates print an `HOURLY` tag in the scan results; expect a strike ladder — many strikes settling on the same top-of-hour close.
 
-The CLI already applies the relaxed hourly gates (no action needed from you): hourly tickers bypass the `scanner.min_days_to_resolution` floor (sub-hour resolution is the design, not a defect) and use the hourly price band (`strategy.hourly_min_market_price` to `strategy.hourly_max_market_price`) instead of the global band. NEVER skip an hourly candidate for resolving "too soon".
+The CLI already applies the hourly gates (no action needed from you): hourly tickers must settle at the NEXT top of hour (#736) — far-hour strikes and stale stragglers are silently dropped by the scanner, so a thin result is the bound working, not an error — and they use the hourly price band (`strategy.hourly_min_market_price` to `strategy.hourly_max_market_price`) instead of the global band with no min-days floor. NEVER skip an hourly candidate for resolving "too soon", and NEVER re-run the scan because the ladder looks thin.
 
 **Batched skip-logging (hourly ladders only).** A ladder can put ~20 sibling strikes below threshold for the same reason. Per-candidate skip rows remain REQUIRED — zero exceptions, every skipped strike gets its own `gimmes log-trade TICKER --action skip` with its own real `--price`/`--prob`/`--score` — but the rationale file may be shared: group skipped strikes by reason, write ONE rationale file per group stating the shared reason, reuse that `--rationale-file` across the group's log-trade commands, and `rm` it after the group's last command. Liquidity skips keep `--reason liquidity` per command (#710). This bounds the mktemp/heredoc overhead to once per group instead of once per strike — the scan window is short.
 

--- a/src/gimmes/backtest/engine.py
+++ b/src/gimmes/backtest/engine.py
@@ -640,6 +640,36 @@ async def run_backtest(
             f" {ALLOWED_CANDLE_PERIODS}, got"
             f" {config.candle_period_minutes!r}",
         )
+    # Union all series across sides — the fetch watchlist, also scoping
+    # the hourly guard below
+    all_series: set[str] = (
+        set(gc.scanner.series)
+        | set(gc.scanner.yes_series)
+        | set(gc.scanner.no_series or [])
+    )
+    _hourly_overlap = set(gc.scanner.hourly_series) & all_series
+    if _hourly_overlap:
+        # Fail fast (#713 doctrine): entry-day views carry a SYNTHETIC
+        # now-anchored close_time (now + entry_offset_days, see
+        # _entry_day_view), so the hourly next-top-of-hour close bound
+        # (#736) would reject every view — nondeterministically, by
+        # the wall-clock minute the run starts. Hourly backtests need
+        # a per-entry clock model; until then, fail loudly instead of
+        # silently returning zero trades. Scoped to the OVERLAP with
+        # the fetched series (review-found): hourly_series armed for
+        # the LIVE loop but absent from the backtest watchlists cannot
+        # affect any fetched view and must not block backtests.
+        raise ValueError(
+            f"hourly series {sorted(_hourly_overlap)!r} cannot be"
+            " backtested through this engine: entry-day views use"
+            " synthetic now-anchored close times that the hourly"
+            " next-top-of-hour bound (#736) rejects. Remove the series"
+            " from the backtest watchlist (scanner.series/yes_series/"
+            "no_series) — do NOT clear scanner.hourly_series, which"
+            " arms the live loop (hourly ladders are explored with"
+            " min_days overrides instead, as the pre-#722 KXBTCD"
+            " backtests did)",
+        )
     ledger = BacktestLedger(config.starting_balance)
 
     # --- 1. Fetch settled markets per series via live API ---
@@ -651,12 +681,6 @@ async def run_backtest(
         config.end_date.year, config.end_date.month,
         config.end_date.day, 23, 59, 59, tzinfo=UTC,
     )
-    # Union all series across sides to ensure we fetch everything needed
-    all_series: set[str] = set(gc.scanner.series or [])
-    if gc.scanner.yes_series:
-        all_series.update(gc.scanner.yes_series)
-    if gc.scanner.no_series:
-        all_series.update(gc.scanner.no_series)
     series_list = sorted(all_series)
     chunks = monthly_chunks(config.start_date, config.end_date)
     logger.info(

--- a/src/gimmes/strategy/calendar.py
+++ b/src/gimmes/strategy/calendar.py
@@ -331,6 +331,19 @@ def position_window(
     return open_et, close_et
 
 
+def next_hour_top(dt: datetime) -> datetime:
+    """Next top-of-hour strictly after *dt*, as a UTC-aware datetime.
+
+    Computed in UTC so it is DST-immune (#723): ET is always a
+    whole-hour offset from UTC. A *dt* exactly at a top of hour maps
+    to the FOLLOWING top.
+    """
+    dt_utc = dt.astimezone(UTC)
+    return (dt_utc + timedelta(hours=1)).replace(
+        minute=0, second=0, microsecond=0,
+    )
+
+
 def hourly_window(
     dt: datetime | None = None,
     *,
@@ -351,8 +364,7 @@ def hourly_window(
     """
     if dt is None:
         dt = datetime.now(ET)
-    dt_utc = dt.astimezone(UTC)
-    next_top = (dt_utc + timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
+    next_top = next_hour_top(dt)
     open_dt = next_top - timedelta(minutes=lead_minutes)
     return open_dt.astimezone(ET), next_top.astimezone(ET)
 

--- a/src/gimmes/strategy/scanner.py
+++ b/src/gimmes/strategy/scanner.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from gimmes.config import GimmesConfig
 from gimmes.models.market import Market, MarketStatus
+from gimmes.strategy.calendar import next_hour_top
 
 
 def effective_price(yes_price: float, side: str) -> float:
@@ -54,11 +55,20 @@ def tradeable_edge(prob: float, yes_price: float, side: str) -> float:
     return prob - eff
 
 
-def days_until(dt: datetime | None) -> float | None:
-    """Calculate days from now until a datetime."""
+# Hourly ladders settle exactly at the top of the hour; the tolerance
+# absorbs second-level stamping jitter in API close_times without ever
+# admitting the following hour's ladder (anything < 1h cannot) (#736).
+HOURLY_CLOSE_TOLERANCE = timedelta(seconds=60)
+
+
+def days_until(
+    dt: datetime | None, *, now: datetime | None = None,
+) -> float | None:
+    """Calculate days from *now* (default: wall clock) until a datetime."""
     if dt is None:
         return None
-    now = datetime.now(UTC)
+    if now is None:
+        now = datetime.now(UTC)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     delta = dt - now
@@ -70,6 +80,7 @@ def filter_markets(
     config: GimmesConfig,
     *,
     exclude_tickers: set[str] | None = None,
+    now: datetime | None = None,
 ) -> list[Market]:
     """Filter markets by gimme scanning criteria.
 
@@ -79,13 +90,21 @@ def filter_markets(
       tickers use hourly_min/max_market_price instead)
     - Minimum volume / open interest
     - Market status (active only)
-    - Time to resolution (hourly-series tickers skip the min-days floor)
+    - Time to resolution (hourly-series tickers must settle at the
+      NEXT top of hour — close_time in (now, next_hour_top + 60s] —
+      instead of the min-days floor, #736)
+
+    *now* anchors every time comparison (tests inject it; live callers
+    omit it for the wall clock). When provided it MUST be tz-aware.
 
     Category filtering is handled upstream by fetching markets per series.
     Returns filtered markets sorted by volume (descending).
     """
     sc = config.scanner
     st = config.strategy
+    if now is None:
+        now = datetime.now(UTC)
+    hourly_close_bound = next_hour_top(now) + HOURLY_CLOSE_TOLERANCE
     candidates: list[Market] = []
 
     for m in markets:
@@ -117,13 +136,28 @@ def filter_markets(
             continue
 
         # Time to resolution — reject markets with no time info
-        days = days_until(m.close_time)
-        if days is None:
-            days = days_until(m.expiration_time)
-        if days is None:
+        resolve_dt = (
+            m.close_time if m.close_time is not None else m.expiration_time
+        )
+        if resolve_dt is None:
             continue  # Perpetual or unknown — skip
-        # Hourly ladders resolve in <1h by design — the min-days floor
-        # would reject every candidate (#721). max_days still applies.
+        if resolve_dt.tzinfo is None:
+            resolve_dt = resolve_dt.replace(tzinfo=UTC)
+        days = days_until(resolve_dt, now=now)
+        # Hourly ladders settle at the NEXT top of hour (#736): the
+        # #721 min-days bypass had no bound of its own, so far-hour
+        # strikes (and stale past-close stragglers) leaked through.
+        # (now, next_top + tolerance] rejects both; max_days below is
+        # implied but kept as defense in depth.
+        if hourly and not (now < resolve_dt <= hourly_close_bound):
+            # Observability (#736 review): a mis-stamped ladder would
+            # otherwise silently yield 0 candidates every hour
+            logging.getLogger(__name__).debug(
+                "hourly ticker %s rejected by close bound:"
+                " close=%s not in (%s, %s]",
+                m.ticker, resolve_dt, now, hourly_close_bound,
+            )
+            continue
         if not hourly and days < sc.min_days_to_resolution:
             continue
         if days > sc.max_days_to_resolution:

--- a/src/gimmes/strategy/scanner.py
+++ b/src/gimmes/strategy/scanner.py
@@ -69,6 +69,8 @@ def days_until(
         return None
     if now is None:
         now = datetime.now(UTC)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)  # same coercion as dt below
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     delta = dt - now
@@ -95,7 +97,7 @@ def filter_markets(
       instead of the min-days floor, #736)
 
     *now* anchors every time comparison (tests inject it; live callers
-    omit it for the wall clock). When provided it MUST be tz-aware.
+    omit it for the wall clock). Naive values coerce to UTC.
 
     Category filtering is handled upstream by fetching markets per series.
     Returns filtered markets sorted by volume (descending).
@@ -104,6 +106,11 @@ def filter_markets(
     st = config.strategy
     if now is None:
         now = datetime.now(UTC)
+    elif now.tzinfo is None:
+        # Coerce like days_until does for dt — a naive now would
+        # otherwise be interpreted as SYSTEM-LOCAL time by
+        # next_hour_top's astimezone(), silently skewing the bound
+        now = now.replace(tzinfo=UTC)
     hourly_close_bound = next_hour_top(now) + HOURLY_CLOSE_TOLERANCE
     candidates: list[Market] = []
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -2667,7 +2667,10 @@ def test_scout_hourly_scan_section(scout_text: str) -> None:
     keeps per-candidate rows (#710)."""
     assert "gimmes scan -s" in scout_text
     assert "HOURLY" in scout_text
-    assert "bypass the `scanner.min_days_to_resolution` floor" in scout_text
+    # #736: the min-days bypass became the next-top-of-hour bound
+    assert "must settle at the NEXT top of hour (#736)" in scout_text
+    assert "a thin result is the bound working, not an error" in scout_text
+    assert "NEVER re-run the scan" in scout_text
     assert "Per-candidate skip rows remain REQUIRED" in scout_text
     assert "ONE rationale file per group" in scout_text
     assert "do NOT run an unscoped `gimmes scan`" in scout_text

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -477,6 +477,11 @@ def _backtest_config_with_overrides(**overrides):
     cfg.scanner.series = ["KXCPI"]
     cfg.scanner.no_series = []
     cfg.scanner.yes_series = []
+    # load_config() reads the LIVE installed DB — with the hourly
+    # experiment armed there, the #736 engine guard would fire in
+    # every test using this helper. Same isolation reset as the
+    # series lists above.
+    cfg.scanner.hourly_series = []
     return BacktestConfig(
         start_date=date(2026, 3, 1),
         end_date=date(2026, 5, 11),
@@ -1728,6 +1733,63 @@ class TestEntryOffset(_EntryDayHarness):
             with pytest.raises(ValueError, match="entry_offset_days"):
                 await run_backtest(client=None, config=config)
         assert list_calls == []  # guard fired before any fetch
+
+    @pytest.mark.asyncio
+    async def test_hourly_series_fails_fast(self, monkeypatch) -> None:
+        """#736: entry-day views carry a SYNTHETIC now-anchored
+        close_time, so the hourly next-top-of-hour bound would reject
+        every view nondeterministically — the engine must fail loudly
+        before any fetch instead of silently returning zero trades."""
+        list_calls = []
+
+        async def _fake_list(*args, **kwargs):
+            list_calls.append(1)
+            return []
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+        config = self._offset_config(1.0)
+        gc = config.gimmes_config
+        # The guard fires only on OVERLAP with the fetched watchlist —
+        # KXBTCD must be in BOTH hourly_series and series
+        config.gimmes_config = gc.model_copy(update={
+            "scanner": gc.scanner.model_copy(update={
+                "hourly_series": ["KXBTCD"],
+                "series": ["KXBTCD"],
+            }),
+        })
+        with pytest.raises(ValueError, match="KXBTCD"):
+            await run_backtest(client=None, config=config)
+        assert list_calls == []  # guard fired before any fetch
+
+    @pytest.mark.asyncio
+    async def test_hourly_series_disjoint_from_watchlist_allowed(
+        self, monkeypatch,
+    ) -> None:
+        """#736 review: hourly_series armed for the LIVE loop but absent
+        from the backtest watchlists cannot affect any fetched view —
+        the guard must NOT block backtests on the production config."""
+        list_calls = []
+
+        async def _fake_list(*args, **kwargs):
+            list_calls.append(1)
+            return []
+
+        monkeypatch.setattr(
+            "gimmes.backtest.engine.list_all_markets", _fake_list,
+        )
+        config = self._offset_config(1.0)
+        gc = config.gimmes_config
+        # The live shape: KXBTCD hourly-armed, watchlist is econ series
+        config.gimmes_config = gc.model_copy(update={
+            "scanner": gc.scanner.model_copy(
+                update={"hourly_series": ["KXBTCD"]},
+            ),
+        })
+        result = await run_backtest(client=None, config=config)
+        assert list_calls  # fetch ran — no spurious guard
+        assert result.trades == []
 
     @pytest.mark.asyncio
     async def test_subday_offset_warns(

--- a/tests/unit/test_pipeline_e2e.py
+++ b/tests/unit/test_pipeline_e2e.py
@@ -25,6 +25,7 @@ from gimmes.paper.broker import PaperBroker
 from gimmes.risk.validator import validate_trade
 from gimmes.store.database import Database
 from gimmes.store.queries import get_daily_pnl, insert_trade, sync_positions
+from gimmes.strategy.calendar import next_hour_top
 from gimmes.strategy.fees import edge_after_fees, fee_for_order
 from gimmes.strategy.kelly import apply_base_rate_floor, position_size
 from gimmes.strategy.scanner import effective_price, filter_markets
@@ -352,7 +353,7 @@ def _hourly_config(series: list[str] | None = None) -> GimmesConfig:
     )
 
 
-def _hourly_market() -> Market:
+def _hourly_market(now: datetime | None = None) -> Market:
     return Market(
         ticker=HOURLY_TICKER,
         event_ticker="KXBTCD-26JUN23H14",
@@ -365,7 +366,10 @@ def _hourly_market() -> Market:
         volume=5000,
         volume_24h=1200,
         open_interest=800,
-        close_time=datetime.now(UTC) + timedelta(minutes=29),
+        # Hourly markets settle exactly at the next top of hour — the
+        # #736 close bound requires it, and a naive now+29min would
+        # cross the hour boundary for half of every wall-clock hour
+        close_time=next_hour_top(now if now is not None else datetime.now(UTC)),
         rules_primary="Resolves YES if BTC price is above the strike at the hour close.",
     )
 
@@ -408,11 +412,13 @@ async def _enter_hourly_position(
     filter -> score -> base-rate floor -> size (taker) -> validate
     (hourly floor) -> log open trade -> taker order. Returns count."""
     cfg = _hourly_config()
-    market = _hourly_market()
+    now = datetime.now(UTC)
+    market = _hourly_market(now)
 
-    # Scanner admission: min-days bypass + hourly band (NO 0.45 in
-    # 0.30-0.85; the flat 0.55 floor would reject it)
-    passed = filter_markets([market], cfg)
+    # Scanner admission: next-hour close bound (#736) + hourly band
+    # (NO 0.45 in 0.30-0.85; the flat 0.55 floor would reject it) —
+    # one injected clock, zero wall-clock race
+    passed = filter_markets([market], cfg, now=now)
     assert [m.ticker for m in passed] == [HOURLY_TICKER]
 
     # quick_score under-scores hourly NO honestly (~55 < threshold 75):

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -348,3 +348,16 @@ class TestHourlyFilter:
             yes_bid=0.38, yes_ask=0.42, last_price=0.40,
         )
         assert filter_markets([sub_day, cheap], cfg, now=_HOURLY_NOW) == []
+
+    def test_naive_now_coerces_to_utc(self) -> None:
+        # Copilot review on #736: a naive injected clock must behave
+        # exactly like its UTC-aware twin, not TypeError or silently
+        # shift to system-local time
+        naive_now = _HOURLY_NOW.replace(tzinfo=None)
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H14-T119999.99",
+            close_time=_NEXT_TOP,
+        )
+        result = filter_markets([m], _hourly_config(), now=naive_now)
+        assert [r.ticker for r in result] == [m.ticker]
+        assert days_until(_NEXT_TOP, now=naive_now) == 0.5 / 24

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 from gimmes.config import GimmesConfig, Mode, ScannerConfig, StrategyConfig
 from gimmes.models.market import Market, MarketStatus
-from gimmes.strategy.scanner import filter_markets
+from gimmes.strategy.scanner import days_until, filter_markets
 
 
 def _make_market(**kwargs) -> Market:  # type: ignore[no-untyped-def]
@@ -109,37 +109,179 @@ def _hourly_config(**strategy_kwargs) -> GimmesConfig:
     )
 
 
+# Fixed clock for the hourly tests (#736): the next-top-of-hour bound
+# makes wall-clock fixtures flaky (now+29min crosses the hour boundary
+# for roughly half of every hour), so every hourly test injects now=.
+_HOURLY_NOW = datetime(2026, 6, 23, 13, 30, tzinfo=UTC)  # next top 14:00 UTC
+_NEXT_TOP = datetime(2026, 6, 23, 14, 0, tzinfo=UTC)
+
+
 class TestHourlyFilter:
-    """#722: hourly-series tickers bypass the min-days floor and use the
-    hourly price band; everything is inert while hourly_series is empty."""
+    """#722/#736: hourly-series tickers use the hourly price band and
+    must settle at the NEXT top of hour; everything is inert while
+    hourly_series is empty."""
 
     def test_hourly_bypasses_min_days_floor(self) -> None:
         m = _make_market(
             ticker="KXBTCD-26JUN23H14-T119999.99",
-            close_time=datetime.now(UTC) + timedelta(minutes=29),
+            close_time=_HOURLY_NOW + timedelta(minutes=29),
         )
-        result = filter_markets([m], _hourly_config())
+        result = filter_markets([m], _hourly_config(), now=_HOURLY_NOW)
         assert [r.ticker for r in result] == [m.ticker]
 
     def test_inert_when_hourly_series_empty(self, config: GimmesConfig) -> None:
         # Identical market, default config: min-days floor rejects it
         m = _make_market(
             ticker="KXBTCD-26JUN23H14-T119999.99",
-            close_time=datetime.now(UTC) + timedelta(minutes=29),
+            close_time=_HOURLY_NOW + timedelta(minutes=29),
         )
-        assert filter_markets([m], config) == []
+        assert filter_markets([m], config, now=_HOURLY_NOW) == []
 
     def test_hourly_respects_max_days(self) -> None:
+        # Now doubly rejected: the next-hour bound (#736) fires first,
+        # max_days remains defense in depth
         m = _make_market(
             ticker="KXBTCD-26DEC31H14-T119999.99",
-            close_time=datetime.now(UTC) + timedelta(days=120),
+            close_time=_HOURLY_NOW + timedelta(days=120),
         )
-        assert filter_markets([m], _hourly_config()) == []
+        assert filter_markets([m], _hourly_config(), now=_HOURLY_NOW) == []
+
+    def test_hourly_far_hour_rejected(self) -> None:
+        # The #736 headline bug: a ticker settling at the hour AFTER
+        # next (90 min out) must not reach the shortlist
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H15-T119999.99",
+            close_time=_NEXT_TOP + timedelta(hours=1),
+        )
+        assert filter_markets([m], _hourly_config(), now=_HOURLY_NOW) == []
+
+    def test_hourly_past_close_rejected(self) -> None:
+        # The latent #736 bug: the min-days bypass also skipped the
+        # negative-days rejection, so a stale straggler passed
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H13-T119999.99",
+            close_time=_HOURLY_NOW - timedelta(minutes=5),
+        )
+        assert filter_markets([m], _hourly_config(), now=_HOURLY_NOW) == []
+
+    def test_hourly_close_at_now_rejected(self) -> None:
+        # Strict lower bound: settling this instant is not tradeable
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H13-T119999.99",
+            close_time=_HOURLY_NOW,
+        )
+        assert filter_markets([m], _hourly_config(), now=_HOURLY_NOW) == []
+
+    def test_hourly_exactly_at_next_top_passes(self) -> None:
+        # The normal case: hourly markets close exactly at the top
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H14-T119999.99",
+            close_time=_NEXT_TOP,
+        )
+        result = filter_markets([m], _hourly_config(), now=_HOURLY_NOW)
+        assert [r.ticker for r in result] == [m.ticker]
+
+    def test_hourly_tolerance_edge(self) -> None:
+        inside = _make_market(
+            ticker="KXBTCD-26JUN23H14-T1",
+            close_time=_NEXT_TOP + timedelta(seconds=60),
+        )
+        outside = _make_market(
+            ticker="KXBTCD-26JUN23H14-T2",
+            close_time=_NEXT_TOP + timedelta(seconds=61),
+        )
+        result = filter_markets(
+            [inside, outside], _hourly_config(), now=_HOURLY_NOW,
+        )
+        assert [r.ticker for r in result] == ["KXBTCD-26JUN23H14-T1"]
+
+    def test_hourly_naive_close_time_passes(self) -> None:
+        # tz-safety: naive close_times coerce to UTC (test fixtures)
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H14-T119999.99",
+            close_time=datetime(2026, 6, 23, 13, 59),
+        )
+        result = filter_markets([m], _hourly_config(), now=_HOURLY_NOW)
+        assert [r.ticker for r in result] == [m.ticker]
+
+    def test_hourly_dst_fall_back_sanity(self) -> None:
+        # Inside the repeated 1 AM ET hour: pure-UTC arithmetic is
+        # unaffected by the fold
+        now = datetime(2026, 11, 1, 5, 30, tzinfo=UTC)  # 01:30 EDT
+        this_hour = _make_market(
+            ticker="KXBTCD-26NOV01H01-T1",
+            close_time=datetime(2026, 11, 1, 6, 0, tzinfo=UTC),
+        )
+        next_hour = _make_market(
+            ticker="KXBTCD-26NOV01H01-T2",
+            close_time=datetime(2026, 11, 1, 7, 0, tzinfo=UTC),
+        )
+        result = filter_markets(
+            [this_hour, next_hour], _hourly_config(), now=now,
+        )
+        assert [r.ticker for r in result] == ["KXBTCD-26NOV01H01-T1"]
+
+    def test_inert_far_hour_rejected_by_min_days(self) -> None:
+        # Inertness of the new bound: with hourly_series empty, a
+        # far-hour KXBTCD ticker is still rejected — by the min-days
+        # floor, exactly as before #736
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H15-T119999.99",
+            close_time=_HOURLY_NOW + timedelta(minutes=90),
+        )
+        cfg = GimmesConfig(mode=Mode.DRIVING_RANGE)
+        assert filter_markets([m], cfg, now=_HOURLY_NOW) == []
+
+    def test_hourly_expiration_fallback(self) -> None:
+        # The resolve_dt refactor's fallback: close_time None, bound
+        # applies to expiration_time (kills the fallback-drop mutation)
+        passes = _make_market(
+            ticker="KXBTCD-26JUN23H14-T1",
+            close_time=None, expiration_time=_NEXT_TOP,
+        )
+        rejected = _make_market(
+            ticker="KXBTCD-26JUN23H15-T2",
+            close_time=None,
+            expiration_time=_NEXT_TOP + timedelta(hours=1),
+        )
+        result = filter_markets(
+            [passes, rejected], _hourly_config(), now=_HOURLY_NOW,
+        )
+        assert [r.ticker for r in result] == ["KXBTCD-26JUN23H14-T1"]
+
+    def test_hourly_just_after_now_passes(self) -> None:
+        # Strict lower bound from the passing side
+        m = _make_market(
+            ticker="KXBTCD-26JUN23H13-T1",
+            close_time=_HOURLY_NOW + timedelta(seconds=1),
+        )
+        result = filter_markets([m], _hourly_config(), now=_HOURLY_NOW)
+        assert [r.ticker for r in result] == [m.ticker]
+
+    def test_hourly_dst_spring_forward_sanity(self) -> None:
+        # 2026-03-08 06:45 UTC = 01:45 EST, spring-forward night
+        now = datetime(2026, 3, 8, 6, 45, tzinfo=UTC)
+        this_hour = _make_market(
+            ticker="KXBTCD-26MAR08H02-T1",
+            close_time=datetime(2026, 3, 8, 7, 0, tzinfo=UTC),
+        )
+        next_hour = _make_market(
+            ticker="KXBTCD-26MAR08H03-T2",
+            close_time=datetime(2026, 3, 8, 8, 0, tzinfo=UTC),
+        )
+        result = filter_markets(
+            [this_hour, next_hour], _hourly_config(), now=now,
+        )
+        assert [r.ticker for r in result] == ["KXBTCD-26MAR08H02-T1"]
+
+    def test_days_until_now_param(self) -> None:
+        # The injected clock is new public API of #736
+        assert days_until(_NEXT_TOP, now=_HOURLY_NOW) == 0.5 / 24
 
     def test_hourly_price_band_no_side(self) -> None:
         # Band is in effective (NO-side) terms: NO price = 1 - YES price
         cfg = _hourly_config(side="no")
-        close = datetime.now(UTC) + timedelta(minutes=29)
+        close = _HOURLY_NOW + timedelta(minutes=29)
         markets = [
             # YES mid 0.90 -> NO 0.10 < 0.30 floor: rejected
             _make_market(
@@ -157,7 +299,7 @@ class TestHourlyFilter:
                 yes_bid=0.03, yes_ask=0.07, last_price=0.05, close_time=close,
             ),
         ]
-        result = filter_markets(markets, cfg)
+        result = filter_markets(markets, cfg, now=_HOURLY_NOW)
         assert [r.ticker for r in result] == ["KXBTCD-26JUN23H14-T2"]
 
     def test_hourly_max_band_applies_over_flat_max(self) -> None:
@@ -168,14 +310,14 @@ class TestHourlyFilter:
             ticker="KXBTCD-26JUN23H14-T1",
             # YES mid 0.10 -> NO 0.90: inside flat 0.95, above hourly 0.85
             yes_bid=0.08, yes_ask=0.12, last_price=0.10,
-            close_time=datetime.now(UTC) + timedelta(minutes=29),
+            close_time=_HOURLY_NOW + timedelta(minutes=29),
         )
-        assert filter_markets([m], cfg) == []
+        assert filter_markets([m], cfg, now=_HOURLY_NOW) == []
 
     def test_hourly_band_boundaries_inclusive(self) -> None:
         # price < min or price > max: both bounds inclusive
         cfg = _hourly_config(side="no")
-        close = datetime.now(UTC) + timedelta(minutes=29)
+        close = _HOURLY_NOW + timedelta(minutes=29)
         markets = [
             # YES mid 0.70 -> NO 0.30: exactly the floor, passes
             _make_market(
@@ -188,7 +330,7 @@ class TestHourlyFilter:
                 yes_bid=0.13, yes_ask=0.17, last_price=0.15, close_time=close,
             ),
         ]
-        result = filter_markets(markets, cfg)
+        result = filter_markets(markets, cfg, now=_HOURLY_NOW)
         assert sorted(r.ticker for r in result) == [
             "KXBTCD-26JUN23H14-T1", "KXBTCD-26JUN23H14-T2",
         ]
@@ -199,10 +341,10 @@ class TestHourlyFilter:
         cfg = _hourly_config()
         sub_day = _make_market(
             ticker="KXCPIYOY-26MAR-T3.5",
-            close_time=datetime.now(UTC) + timedelta(minutes=29),
+            close_time=_HOURLY_NOW + timedelta(minutes=29),
         )
         cheap = _make_market(
             ticker="KXCPIYOY-26MAR-T4.0",
             yes_bid=0.38, yes_ask=0.42, last_price=0.40,
         )
-        assert filter_markets([sub_day, cheap], cfg) == []
+        assert filter_markets([sub_day, cheap], cfg, now=_HOURLY_NOW) == []


### PR DESCRIPTION
## Summary

Fixes the 2026-07-17 finding: `gimmes scan -s KXBTCD` surfaced the entire day's ladder, so every hourly cycle's research budget was diluted by far-hour strikes (17:00 EDT tickers in the 04:31 shortlist), and one far-hour ticker was wrongly approved before dying at the clamp. Fixes the latent sibling bug too — the #721 min-days bypass also let stale past-close stragglers through.

- **Scanner**: hourly tickers must have `close_time` in `(now, next_hour_top + 60s]`. The tolerance absorbs stamping jitter and can never admit the following hour. `next_hour_top` is extracted into calendar.py (the DST-immune UTC arithmetic, shared with `hourly_window` — pinned by the existing DST fold tests plus new scanner-level fall-back AND spring-forward sanity tests). The filter gains an injectable tz-aware `now=` — the plan review discovered the existing `now+29min` fixtures were wall-clock-flaky under the bound for half of every hour, so the fixed-clock rework de-flakes the whole hourly test suite. Bound rejections log at debug level so a mis-stamped ladder is observable rather than a silent 0-candidate hour (hunter finding).
- **Backtest engine**: fails fast when a backtest watchlist overlaps `hourly_series` — entry-day views use *synthetic now-anchored* close times (the plan agent corrected my original framing) that the bound would reject nondeterministically by wall-clock minute. **Review-caught bug in my first guard**: it fired on any non-empty `hourly_series`, which would have bricked every `gimmes backtest` on the production config (hourly armed, KXBTCD not in any watchlist) and told the operator to disarm the live lane. The shipped guard fires only on the overlap, with a remediation message that protects the live config; a regression test pins the production shape passing.
- **scout.md**: the hourly gate is now the next-top-of-hour bound; a thin ladder is the bound working — never a reason to re-scan.
- **Timing safety verified** (hunter): the loop's hourly window and the filter derive from the same `next_hour_top`, so at any scan instant inside the window the intended ladder passes — no rejection window exists.
- **Test-isolation fix**: `_backtest_config_with_overrides` reads the LIVE config DB and broke when the experiment armed `hourly_series`; it now resets the field like the neighboring series lists.

Live effect after release: each hourly cycle's shortlist contains only the strikes settling at the top of the current window's hour — Caddie's whole research budget goes to tradeable candidates.

Closes #736

## Test plan

- 12 new/updated scanner tests on a fixed injected clock (far-hour, past-close, at-now, at-top, ±60s tolerance edge, expiration-time fallback, both DST transitions, strict-lower-bound pass side, naive-datetime coercion, inertness both ways), `days_until(now=)` direct test, engine guard pair (overlap fires before any fetch / production disjoint shape passes), scout drift-guard update.
- Full unit suite: **2227 passed** (16:12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraN34AP4re87cAzt9LRKB