### PR TITLE
Cycle deadline protocol, candidate cap, and review reuse

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -33,6 +33,29 @@ All full-cycle rules apply verbatim in hourly cycles EXCEPT these overrides:
 5. **Hourly review is mechanical (#739 shadow mode).** The hourly lane trades the backtest-validated mechanical strategy; Caddie's judgment is recorded (Shadow lines), not gating — and YOUR review must not become the replacement judgment gate. In hourly cycles: (a) the `gimme_threshold` score intake does NOT apply — review EVERY hourly candidate with `recommendation = proceed` regardless of GimmeScore; (b) hourly probabilities come from the price-anchored formula `max(min(NO_mid + $0.10, 0.99), 0.70)`, so flat or near-flat probabilities across a ladder's rungs are the expected NORM, not an inconsistency — NEVER reject an hourly event for probability flatness under the cross-threshold consistency rule; (c) your MECHANICAL checks fully apply and are the real selectors — edge after fees vs `cm_min_edge_after_fees` (computed from the stated prob), event/series concentration caps ("approve only the highest-edge thresholds that fit" remains the rung selector), STALE-CLOSE, FLIP-WARN, side constraint; (d) subjective REJECT reasons (thesis hole, signal dependence, timing) become ADVISORY for hourly candidates — record the concern in the decision note as `Concern (advisory): ...` and APPROVE if the mechanical checks pass; rejecting on judgment would relocate the exact uninstrumented gate #739 removed from Caddie. This extends the named paper-only relaxation in override 4 — NEVER extend it to full cycles.
 6. **Hourly positions are hold-to-settlement in Step 2c (#732).** With Step 2 running post-entry, Monitor now reviews hourly-series positions minutes after their taker fill — their maximum-noise window. Do NOT CLOSE and do NOT SIZE UP hourly-series positions in Step 2c: the exit-modeling backtest showed minute-scale mechanical exits destroy the hourly edge (TP80/SL15 at minute resolution: -51.2% vs +121.6% held), and a same-cycle exit pays taker fees both ways on a position that settles within the hour anyway. Log their flags as observations only — the flag record is the experiment's data, not a call to action. This carve-out is hourly-series ONLY: non-hourly positions keep every 2c rule, including the #659 MANDATORY-CLOSE backstop, in hourly cycles too.
 
+## Deadline Protocol (#746)
+
+The loop kills this cycle's process at `$GIMMES_CYCLE_DEADLINE` (UTC, e.g. `2026-07-20T21:45:00Z`). A kill mid-review records nothing — the next cycle re-pays the entire preamble and re-reviews the same candidates, which is how three consecutive cycles died on 2026-07-20 without one Closer dispatch. Your job is to make sure the clock runs out on OPTIONAL work, never on unrecorded decisions.
+
+**At every step boundary** (before starting each of Steps 2, 3, 4, 4c, and 5, in whatever order your cycle type executes them), check the remaining time:
+
+```bash
+date -u +%Y-%m-%dT%H:%M:%SZ   # compare against $GIMMES_CYCLE_DEADLINE
+```
+
+Each row below keys on the step you are ABOUT TO START — apply the row whose step you are entering, whenever you enter it:
+
+| Remaining | Entering | Action |
+|---|---|---|
+| < 30 min | Step 2 (full cycles) | Dispatch Monitor in **time-boxed mode** (see Step 2b) — deferred playbook sweep; general search, price checks, StopGate, and flag triggers still run. The #659 backstop and 2c flag review always run in full. **Hourly cycles: this row does not apply** — Step 2 runs after the trade path there (#732), and the window clamp truncating post-trade surveillance is that design working, not a shed. |
+| < 20 min | Step 4 | Do NOT dispatch Caddie for new research. Candidates without research are logged as `deferred_capacity` skips — they stay eligible next cycle. Proceed to 4c for any candidates that ALREADY have fresh research. |
+| < 12 min | Step 4c | Review only as many candidates as fit at ~4 min each, highest GimmeScore first; log the rest as `deferred_capacity` skips. NEVER start a review you cannot finish: an APPROVE without a decision note is a lost trade, a half-written note is a corrupt audit trail. |
+| < 5 min | anywhere | Stop opening new work. Finish the in-flight decision note, dispatch Closer for already-approved candidates ONLY if the note is written (the crash-recovery anchor rule is unchanged), then jump to Step 8 and log completion with a `[DEADLINE-SHED]` marker listing what was skipped. |
+
+**Never shed, in any time budget:** Step 0/8 logging, Step 1 risk gates, the 2a crash-recovery check, the #659 stop-loss backstop, writing the decision note BEFORE any Closer dispatch, and `deferred_capacity` skip logs for anything you shed (an unlogged shed is invisible to the next cycle and to the audit trail).
+
+If `$GIMMES_CYCLE_DEADLINE` is missing from the environment, assume 45 minutes from your start and apply the same protocol.
+
 ## Cycle Steps
 
 ### Step 0: Log Cycle Start
@@ -141,6 +164,8 @@ Launch the Monitor agent (`monitor.md`). Monitor will:
 2. Write observation notes to the journal.
 3. Write flag notes for positions meeting trigger conditions.
 4. Produce a monitoring report.
+
+**Time-boxed mode (#746):** when the Deadline Protocol check shows less than 30 minutes remaining, open your dispatch prompt with the exact line `TIME-BOXED: defer any due playbook sweep — general search, price checks, StopGate, and flag triggers only this cycle.` Monitor then defers the 13-search playbook sweep even when the #731 cadence says one is due (the expensive part — the deferral is what buys the time back) but STILL runs the single rule-4 general news search per position, price checks, StopGate, and flag triggers. Three overrides beat the time box, in Monitor's hands, because each is evidence- or safety-driven: the #731 48-hour anchor hard-cap (an aged anchor sweeps NOW, whatever the clock says — the validator rejects the alternative), the rule-3d escalation (a regime-change find in the general search upgrades to a full sweep), and cadence `0` (operator explicitly ordered every-cycle sweeps). NEVER use time-boxed mode two cycles in a row for the same position — if the previous cycle was also time-boxed, Monitor runs in full this cycle regardless of the clock.
 
 Wait for Monitor to complete and return its report before proceeding.
 
@@ -324,11 +349,17 @@ Substitute the actual count of Scout candidates for N. If the command fails, not
 
 #### 4b. Dispatch Caddie
 
-Dispatch the **Caddie** agent to research ALL candidates that passed the cooldown check.
+Dispatch the **Caddie** agent to research the candidates that passed the cooldown check, **capped at the configured per-cycle intake (#746)**:
 
-**Priority rule:** Process cap-blocked candidates before new candidates when dispatching to Caddie.
+```bash
+gimmes config get strategy.max_candidates_per_cycle
+```
 
-**Completeness rule (MUST follow — no exceptions):** Every candidate from the Scout's shortlist MUST be accounted for — either sent to Caddie (passed cooldown) or logged as a skip with cooldown rationale. The Caddie Master MUST NOT silently drop candidates.
+If more candidates passed cooldown than the cap, keep the top `max_candidates_per_cycle` by Scout quick score and log each candidate over the cap as a skip with `--reason deferred_capacity` (rationale: "over per-cycle candidate cap (#746) — eligible next cycle"). Research and review time are ~2.5 + ~4 minutes PER candidate; an unbounded intake is how cycles die at the timeout with zero Closer dispatches. If the config read fails, use 5.
+
+**Priority rule:** Process cap-blocked candidates before new candidates when dispatching to Caddie (cap-blocked candidates count toward the per-cycle cap).
+
+**Completeness rule (MUST follow — no exceptions):** Every candidate from the Scout's shortlist MUST be accounted for — sent to Caddie (passed cooldown, within the cap), logged as a cooldown skip, or logged as a `deferred_capacity` skip. The Caddie Master MUST NOT silently drop candidates.
 
 Launch the Caddie agent (`caddie.md`) to:
 1. Research each candidate's underlying event
@@ -383,6 +414,10 @@ For each PROCEED candidate:
    For threshold markets, verify the YES/NO win conditions against the `Rules (primary)` row of `market-info` before APPROVE/REJECT — do NOT accept Caddie's directional description of the contract without this check; if the row shows `—` (empty), settlement is unverifiable → REJECT (#641).
 
    **Edge pre-filter.** If the candidate's net edge after fees is already below `cm_min_edge_after_fees`, REJECT immediately without conferring — the candidate cannot clear the CM floor no matter how the conferral goes. Log the REJECT note with the numeric citation and move on. Skip to sub-step 6 (log rejected candidates as skips).
+
+   **Review reuse (#746) — REJECTs only.** Before conferring, check `gimmes position-notes TICKER` for a `type=decision, agent=caddie-master` note from cycle `$GIMMES_CYCLE` or `$GIMMES_CYCLE - 1` (a timed-out predecessor's review survives as its notes). A `Decision: REJECT for open` note is HONORED without re-conferral — log a `review_reject` skip citing the prior note — UNLESS its cited reason is price-driven: **edge below CM floor, timing, portfolio over-concentration, or cross-threshold inconsistency get a fresh review** (prices and the portfolio move between cycles). Every other Step-4c reject reason is honored as durable: thesis hole, signal dependence, unverifiable settlement (#641), side constraint, stop-loss reopen lockout (#586 — honoring it IS the lockout), post-close stale research (#661 — stale research stays stale until new research exists), and unresolved FLIP-WARN (#660). When in doubt, honoring a REJECT is always safe — it deploys no capital.
+
+   Review reuse NEVER applies to APPROVE notes: an approval without a completed fresh review would dispatch the Closer around the conferral this step declares mandatory (#721 forbids extending any conferral relaxation to full cycles). A prior-cycle APPROVE whose Closer dispatch was lost is already handled by the Step 2a crash-recovery scan — do not re-implement it here. Never reuse anything older than one cycle.
 
 3. **Confer with Caddie using SendMessage.** Probe the research with pointed questions:
    - Is the thesis robust to the most likely contrary scenario?

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -33,6 +33,12 @@ You are the Monitor — the surveillance and journalism agent in the GIMMES pipe
 6. Produce a monitoring report (see Output Format below).
 7. Log completion (see Activity Logging below).
 
+## TIME-BOXED mode (#746)
+
+When the Caddie Master's dispatch prompt opens with `TIME-BOXED: defer any due playbook sweep — general search, price checks, StopGate, and flag triggers only this cycle.`, the cycle deadline is tight. Run a standard #731 NON-SWEEP cycle for every position **even if the cadence says a full sweep is due** — the deferred playbook sweep is what buys the cycle its time back. Everything a non-sweep cycle does still runs in full: position context, market data, the single rule-4 general news search per position (the regime-change escalation valve stays live), the delta observation with its standard footer (`Sweep: skipped (cadence #731 — last full sweep <timestamp>)` carrying the prior anchor; prior citations INHERITED — never downgraded to `not searched`, the validator rejects that), StopGate copying, flag triggers, resolution backfill, and the report.
+
+Three conditions OVERRIDE the time box and force a FULL sweep for the affected position — each is evidence- or safety-driven and outranks the clock: (1) the 48-hour anchor hard-cap — the validator rejects a skipped observation with an anchor older than 48h, so an aged anchor sweeps NOW; (2) rule-3d escalation — the general search surfaced a regime-change event or settlement-relevant release; (3) cadence `0` — the operator ordered every-cycle sweeps. The Caddie Master enforces that two consecutive cycles are never both time-boxed; you do not need to track this.
+
 ## What You Look For (Trigger Conditions)
 
 Flag a position for Caddie Master review — by writing a `flag` note — when ANY of these occur:

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2924,6 +2924,9 @@ _SKIP_REASONS = frozenset({
     "cooldown", "research_failed", "review_reject", "validation_failed",
     "order_failed", "close_failed", "no_position", "price_moved",
     "liquidity", "infra_failed", "already_traded", "order_canceled",
+    # #746: shed by the candidate cap / deadline protocol — not a
+    # verdict on the candidate; it stays eligible next cycle.
+    "deferred_capacity",
 })
 
 # Non-entry skips carry no entry decision — backfilling scan-time
@@ -6479,6 +6482,18 @@ def _autonomous_loop(
 
             env["GIMMES_CYCLE"] = str(cycle)
             env["GIMMES_CYCLE_TYPE"] = cycle_type
+            # #746 deadline protocol: the subprocess is killed at
+            # effective_timeout, so tell it when — Caddie Master checks
+            # remaining time at step boundaries and sheds load instead
+            # of being killed mid-review with nothing recorded.
+            import datetime as _dl
+
+            _deadline = _dl.datetime.now(_dl.UTC) + _dl.timedelta(
+                seconds=effective_timeout,
+            )
+            env["GIMMES_CYCLE_DEADLINE"] = _deadline.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
             log_path = logs_dir / f"cycle-{cycle:03d}.json"
             cmd = [
                 claude_path,

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -434,6 +434,27 @@ class StrategyConfig(BaseModel):
         },
     )
 
+    max_candidates_per_cycle: int = Field(
+        default=5, ge=1,
+        json_schema_extra={
+            "display_name": "Max Candidates Per Cycle",
+            "description": (
+                "How many Scout candidates the Caddie Master researches and\n"
+                "reviews in one cycle (#746). Measured cost is ~2.5 min of\n"
+                "research plus ~4 min of review per candidate — an unbounded\n"
+                "intake overflows the cycle timeout and the cycle dies before\n"
+                "the Closer runs. Candidates over the cap are logged as\n"
+                "deferred_capacity skips and stay eligible next cycle.\n"
+                "\n"
+                "  • 5 (default): fits a 60-minute cycle with margin\n"
+                "  • Lower (e.g. 3): favors depth on the highest scorers\n"
+                "  • Higher: only with a raised strategy.cycle_timeout"
+            ),
+            "min_val": 1,
+            "max_val": 20,
+        },
+    )
+
     @model_validator(mode="after")
     def _reconcile_cm_floor(self) -> StrategyConfig:
         cm_explicit = "cm_min_edge_after_fees" in self.model_fields_set

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -209,6 +209,11 @@ NON_ENTRY_SKIP_REASONS = frozenset({
     # missed entry — its inherited analytics would otherwise land it
     # in the FNR numerator as an automatic false negative.
     "order_canceled",
+    # #746: shed by the per-cycle candidate cap — "not a verdict on
+    # the candidate; it stays eligible next cycle", so counting it as
+    # a missed entry double-counts the SAME candidate against the
+    # cycle that actually decides it.
+    "deferred_capacity",
 })
 
 MIN_TRADES_THRESHOLD = 30

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -2910,3 +2910,52 @@ def test_sweep_cadence_cap_matches_config(monitor_text: str) -> None:
         " claim (#731/#577)"
     )
     assert "48 hours" in monitor_text
+
+
+def test_cycle_deadline_protocol() -> None:
+    """#746: deadline protocol, candidate cap, review reuse, and the
+    time-boxed Monitor contract — all four load-bearing strings must
+    stay in sync across caddie-master.md, monitor.md, config, and the
+    loop's env export."""
+    import inspect
+
+    from gimmes import cli as cli_mod
+    from gimmes.cli import _SKIP_REASONS
+    from gimmes.config import StrategyConfig
+
+    cm_text = (AGENTS_DIR / "caddie-master.md").read_text()
+    assert "## Deadline Protocol (#746)" in cm_text
+    assert "$GIMMES_CYCLE_DEADLINE" in cm_text
+    assert "Never shed, in any time budget" in cm_text
+    assert "strategy.max_candidates_per_cycle" in cm_text
+    assert "Review reuse (#746)" in cm_text
+    # A shed candidate must be logged, never silently dropped
+    assert "deferred_capacity" in cm_text
+
+    # Review reuse must never bypass the mandatory conferral (#721)
+    assert "Review reuse NEVER applies to APPROVE notes" in cm_text
+
+    # The time-boxed dispatch line is verbatim-matched by Monitor
+    timebox_line = (
+        "TIME-BOXED: defer any due playbook sweep — general search,"
+        " price checks, StopGate, and flag triggers only this cycle."
+    )
+    assert timebox_line in cm_text
+    mon_text = (AGENTS_DIR / "monitor.md").read_text()
+    assert timebox_line in mon_text
+    assert "TIME-BOXED mode (#746)" in mon_text
+    # Time-boxed observations must inherit, not launder (#731 validator)
+    assert "never downgraded to `not searched`" in mon_text
+    # Safety overrides beat the time box in BOTH docs: the 48h anchor
+    # hard-cap and the rule-3d escalation valve stay live
+    assert "48-hour anchor hard-cap" in mon_text
+    assert "48-hour anchor hard-cap" in cm_text
+
+    # The config knob the cap instruction reads must exist
+    assert StrategyConfig().max_candidates_per_cycle == 5
+    # The skip vocabulary accepts the deferral reason
+    assert "deferred_capacity" in _SKIP_REASONS
+    # The loop exports the deadline the protocol reads
+    assert "GIMMES_CYCLE_DEADLINE" in inspect.getsource(
+        cli_mod._autonomous_loop,
+    )

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -2618,3 +2618,71 @@ class TestHourlyLadder:
         data = _json.loads(budget_path.read_text())
         today = _frozen.date().isoformat()
         assert data["days"][today]["sessions"] == 1
+
+
+class TestCycleDeadlineEnv:
+    """#746: the loop tells the subprocess when it will be killed."""
+
+    @staticmethod
+    def _pinned_timeout_config():
+        """load_config side_effect pinning strategy.cycle_timeout=2700
+        (the machine's real config may differ)."""
+        from gimmes import cli as gimmes_cli
+
+        original = gimmes_cli.load_config
+
+        def patched(*args, **kwargs):  # type: ignore[no-untyped-def]
+            cfg = original(*args, **kwargs)
+            return cfg.model_copy(update={
+                "strategy": cfg.strategy.model_copy(
+                    update={"cycle_timeout": 2700},
+                ),
+            })
+
+        return patched
+
+    def test_deadline_env_matches_effective_timeout(self) -> None:
+        from datetime import UTC, datetime
+
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch(
+                "gimmes.strategy.calendar.is_in_trade_window",
+                return_value=(True, "Index contracts", 3600),
+            ),
+            patch(
+                "gimmes.strategy.calendar.next_trade_window",
+                return_value=(_make_future_dt(), "Index contracts"),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=3600,
+            ),
+            patch(
+                "gimmes.cli._check_code_staleness",
+                return_value=("abc123", False, None),
+            ),
+            patch("gimmes.cli._check_remote_staleness", return_value=None),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=self._pinned_timeout_config(),
+            ),
+        ):
+            before = datetime.now(UTC)
+            _autonomous_loop("driving_range", max_cycles=1)
+            after = datetime.now(UTC)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert "GIMMES_CYCLE_DEADLINE" in env
+        deadline = datetime.strptime(
+            env["GIMMES_CYCLE_DEADLINE"], "%Y-%m-%dT%H:%M:%SZ",
+        ).replace(tzinfo=UTC)
+        # Pinned cycle_timeout is 2700s; the deadline lands that far
+        # from launch (loose bounds absorb test-runtime skew).
+        low = (before - deadline).total_seconds()
+        high = (after - deadline).total_seconds()
+        assert -2760 <= low <= -2600, (low, high)


### PR DESCRIPTION
Closes #746.

## What

Trade-window cycles overflowed the 45-minute timeout on 2026-07-20 (cycles 1958–1960, three consecutive; breaker reached 4/5): ~30 minutes of Monitor+Scout+Caddie preamble left CM review of 5–8 approved candidates no room, and every timeout destroyed its own review progress. This PR makes cycles deadline-aware and bounds the work so the clock runs out on optional work, never on unrecorded decisions:

- **Deadline protocol**: the loop exports `GIMMES_CYCLE_DEADLINE` (UTC, matches `date -u` format); Caddie Master checks remaining time entering each step and sheds in a defined order — time-boxed Monitor at <30 min, no new research at <20 min, capped review batch at <12 min, wrap-up-only at <5 min. The shed table keys on the step being ENTERED, so it works under the hourly lane's inverted step order (#732); the Monitor row explicitly does not apply to hourly cycles. Never shed: risk gates, crash recovery, the #659 backstop, decision-notes-before-Closer, and `deferred_capacity` skip logs for everything shed.
- **Candidate cap**: new `strategy.max_candidates_per_cycle` (default 5, derived from measured ~2.5 min research + ~4 min review per candidate). Over-cap candidates are logged with the new `deferred_capacity` skip reason and stay eligible next cycle. The reason joins `NON_ENTRY_SKIP_REASONS` (review-found) so capacity sheds never pollute the missed-entry FNR audit.
- **Review reuse — REJECTs only** (review-narrowed): a prior-cycle REJECT decision note is honored without re-conferral unless its reason is price-driven (edge floor, timing, concentration, cross-threshold); all safety rejects (#586 lockout, #661 stale research, #660 FLIP-WARN, side constraint, #641) are durable. Reuse NEVER applies to APPROVEs — that would bypass the #721-mandatory conferral; orphaned approvals remain Step 2a crash recovery's job.
- **Time-boxed Monitor**: defers only the expensive 13-search #731 playbook sweep; the per-position general news search (the regime-change escalation valve), price checks, StopGate, and flags still run. Three overrides beat the time box: the 48-hour anchor hard-cap, rule-3d escalation, and cadence 0. Never two consecutive time-boxed cycles.

## Review findings (all fixed in this PR)

The coherence review caught my first draft creating two capital-safety defects: an APPROVE-reuse path that skipped the mandatory conferral and omitted the #586 lockout, and a TIME-BOXED mode that deadlocked against the 48h sweep validator while disabling the escalation valve. Both were redesigned as described above; the shed-table/hourly ordering conflict, the incomplete reject taxonomy, and the FNR-audit pollution were also review-found and fixed.

## Operational note

`strategy.cycle_timeout` was bumped 2700→3600 by operator config on 2026-07-20 as a stopgap; this PR is the structural fix and works at either setting. Loop restart required after update (cli.py changed) — the next scheduled 08:00 start covers it.

## Testing

- New: cross-file drift guard pinning the deadline protocol, candidate cap, REJECTs-only reuse, the verbatim TIME-BOXED dispatch line in both agent docs, the 48h-override pins, the config default, the skip-vocabulary entry, and the loop's env export; a loop test asserting `GIMMES_CYCLE_DEADLINE` lands in the subprocess env at startup+cycle_timeout (config-pinned so it doesn't depend on machine config).
- Frozen pre-merge gate: **2267 passed, 1 failed** — `tests/integration/test_orders.py::test_place_and_cancel_order`, the known-environmental live-API test (Kalshi 410 on the first listed market; fails identically on unmodified main, verified earlier today). Ruff clean; mypy delta zero.

https://claude.ai/code/session_01XMaeS5z38Zq2i8YVKPinsN
