### PR TITLE
Enforce the hourly price band at execution and sweep time

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2591,15 +2591,13 @@ async def _log_sweep_fill(db, broker, order, n: int) -> None:  # type: ignore[no
     await sync_positions_with_trade(db, positions, trade)
 
 
-async def _sweep_resting_paper_orders(broker, client, db, *, config=None, quiet: bool = False):  # type: ignore[no-untyped-def]
+async def _sweep_resting_paper_orders(broker, client, db, *, config, quiet: bool = False):  # type: ignore[no-untyped-def]
     """Expire overdue resting paper orders, then fill any that have
     become marketable (rest-on-miss lane, #743). Returns
     (order, newly_filled) pairs and writes ledger rows for the fills."""
     import logging
 
     logger = logging.getLogger("gimmes")
-    if config is None:
-        config = load_config()
     try:
         await broker.expire_resting_orders()
     except Exception:
@@ -2636,6 +2634,8 @@ async def _sweep_resting_paper_orders(broker, client, db, *, config=None, quiet:
     # keeps its expiry either way and stays eligible next sweep.
     from gimmes.strategy.scanner import effective_price
 
+    band_lo = config.strategy.hourly_min_market_price
+    band_hi = config.strategy.hourly_max_market_price
     for t in list(orderbooks):
         if not config.is_hourly_ticker(t):
             continue
@@ -2646,9 +2646,7 @@ async def _sweep_resting_paper_orders(broker, client, db, *, config=None, quiet:
             if yes_bid is not None and yes_ask is not None
             else None
         )
-        band_lo = config.strategy.hourly_min_market_price
-        band_hi = config.strategy.hourly_max_market_price
-        if eff_mid is not None and band_lo <= eff_mid <= band_hi:
+        if eff_mid is not None and config.strategy.in_hourly_band(eff_mid):
             continue
         del orderbooks[t]
         shown = f"${eff_mid:.2f}" if eff_mid is not None else "undeterminable"

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2629,25 +2629,41 @@ async def _sweep_resting_paper_orders(broker, client, db, *, config, quiet: bool
     # #750: an hourly resting order advances only when the market is
     # back INSIDE the validated band — the book touching the limit
     # while the effective mid sits outside it is the adverse-repricing
-    # case the band exists to exclude. An undeterminable mid
-    # (one-sided book) skips the fill pass conservatively; the order
-    # keeps its expiry either way and stays eligible next sweep.
+    # case the band exists to exclude. Band membership is judged in
+    # each resting ORDER's own side terms (review-found): the config
+    # side can be flipped between placement and sweep, and a ticker's
+    # book survives only if EVERY resting side's mid is in band —
+    # over-blocking deploys no capital and the order keeps its expiry.
+    # An undeterminable mid (one-sided book) skips conservatively.
     from gimmes.strategy.scanner import effective_price
 
     band_lo = config.strategy.hourly_min_market_price
     band_hi = config.strategy.hourly_max_market_price
+    sides_by_ticker: dict[str, set[str]] = {}
+    for o in resting:
+        sides_by_ticker.setdefault(o.ticker, set()).add(o.side.value)
     for t in list(orderbooks):
         if not config.is_hourly_ticker(t):
             continue
         book = orderbooks[t]
         yes_bid, yes_ask = book.best_yes_bid, book.best_yes_ask
-        eff_mid = (
-            effective_price((yes_bid + yes_ask) / 2, config.strategy.side)
+        yes_mid = (
+            (yes_bid + yes_ask) / 2
             if yes_bid is not None and yes_ask is not None
             else None
         )
-        if eff_mid is not None and config.strategy.in_hourly_band(eff_mid):
-            continue
+        eff_mid = None
+        if yes_mid is not None:
+            out_of_band = [
+                effective_price(yes_mid, side)
+                for side in sorted(sides_by_ticker.get(t, ()))
+                if not config.strategy.in_hourly_band(
+                    effective_price(yes_mid, side)
+                )
+            ]
+            if not out_of_band:
+                continue
+            eff_mid = out_of_band[0]
         del orderbooks[t]
         shown = f"${eff_mid:.2f}" if eff_mid is not None else "undeterminable"
         logger.info(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -2591,13 +2591,15 @@ async def _log_sweep_fill(db, broker, order, n: int) -> None:  # type: ignore[no
     await sync_positions_with_trade(db, positions, trade)
 
 
-async def _sweep_resting_paper_orders(broker, client, db, *, quiet: bool = False):  # type: ignore[no-untyped-def]
+async def _sweep_resting_paper_orders(broker, client, db, *, config=None, quiet: bool = False):  # type: ignore[no-untyped-def]
     """Expire overdue resting paper orders, then fill any that have
     become marketable (rest-on-miss lane, #743). Returns
     (order, newly_filled) pairs and writes ledger rows for the fills."""
     import logging
 
     logger = logging.getLogger("gimmes")
+    if config is None:
+        config = load_config()
     try:
         await broker.expire_resting_orders()
     except Exception:
@@ -2625,6 +2627,42 @@ async def _sweep_resting_paper_orders(broker, client, db, *, quiet: bool = False
                 )
         else:
             orderbooks[t] = book
+
+    # #750: an hourly resting order advances only when the market is
+    # back INSIDE the validated band — the book touching the limit
+    # while the effective mid sits outside it is the adverse-repricing
+    # case the band exists to exclude. An undeterminable mid
+    # (one-sided book) skips the fill pass conservatively; the order
+    # keeps its expiry either way and stays eligible next sweep.
+    from gimmes.strategy.scanner import effective_price
+
+    for t in list(orderbooks):
+        if not config.is_hourly_ticker(t):
+            continue
+        book = orderbooks[t]
+        yes_bid, yes_ask = book.best_yes_bid, book.best_yes_ask
+        eff_mid = (
+            effective_price((yes_bid + yes_ask) / 2, config.strategy.side)
+            if yes_bid is not None and yes_ask is not None
+            else None
+        )
+        band_lo = config.strategy.hourly_min_market_price
+        band_hi = config.strategy.hourly_max_market_price
+        if eff_mid is not None and band_lo <= eff_mid <= band_hi:
+            continue
+        del orderbooks[t]
+        shown = f"${eff_mid:.2f}" if eff_mid is not None else "undeterminable"
+        logger.info(
+            "Skipping resting fills for %s: effective mid %s outside"
+            " hourly band $%.2f-$%.2f (#750)",
+            t, shown, band_lo, band_hi,
+        )
+        if not quiet:
+            console.print(
+                f"  [yellow]Resting fill for {t} skipped: effective"
+                f" mid {shown} outside hourly band"
+                f" ${band_lo:.2f}-${band_hi:.2f} (#750)[/yellow]"
+            )
     try:
         filled = await broker.fill_resting_orders(orderbooks)
     except Exception as exc:
@@ -2677,7 +2715,9 @@ def reconcile() -> None:
         async with trading_context(config) as (client, broker, db):
             # Expire + fill resting paper orders against current market data
             if broker:
-                await _sweep_resting_paper_orders(broker, client, db)
+                await _sweep_resting_paper_orders(
+                    broker, client, db, config=config,
+                )
 
             old_positions = await get_positions(db)
             old_tickers = {p.ticker: p for p in old_positions}
@@ -5782,7 +5822,7 @@ def _sleep_with_resting_sweep(config: GimmesConfig, seconds: float) -> None:
                 return
             while True:
                 await _sweep_resting_paper_orders(
-                    broker, client, db, quiet=True,
+                    broker, client, db, config=config, quiet=True,
                 )
                 remaining = deadline - _time.monotonic()
                 if remaining <= 0:

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -372,6 +372,16 @@ class StrategyConfig(BaseModel):
             "max_val": 0.99,
         },
     )
+    def in_hourly_band(self, price: float) -> bool:
+        """True when a side-effective price sits inside the hourly band,
+        bounds inclusive (#750). The single source of the membership
+        semantics for the validator and the resting-order sweep — the
+        scanner's band SELECTION (hourly vs. regular, scanner.py) stays
+        separate by design."""
+        return (
+            self.hourly_min_market_price <= price <= self.hourly_max_market_price
+        )
+
     min_edge_after_fees: float = Field(
         default=0.05, gt=0.0, le=1.0,
         json_schema_extra={

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -197,6 +197,27 @@ def validate_trade(
     else:
         checks.append("Edge check skipped (no probability provided)")
 
+    # 6b. Hourly price band (#750). The backtest validated hourly
+    # entries only inside the side-relative band; review enforces it,
+    # but the price can leave the band between approval and placement
+    # — and for a NO buy a collapsed price passes the #743
+    # approval-price cap as "improvement" while the market is
+    # repricing against the thesis. Enforced here so no agent path
+    # can skip it.
+    if config.is_hourly_ticker(market.ticker):
+        band_lo = config.strategy.hourly_min_market_price
+        band_hi = config.strategy.hourly_max_market_price
+        if band_lo <= price <= band_hi:
+            checks.append(
+                f"Hourly band OK (${price:.2f} in"
+                f" ${band_lo:.2f}-${band_hi:.2f})"
+            )
+        else:
+            failures.append(
+                f"Hourly price outside band: effective ${price:.2f}"
+                f" not in ${band_lo:.2f}-${band_hi:.2f} (#750)"
+            )
+
     # 7. Duplicate check (skipped for SIZE UP — adding to existing position)
     if market.ticker in existing_tickers:
         if size_up:

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -207,7 +207,7 @@ def validate_trade(
     if config.is_hourly_ticker(market.ticker):
         band_lo = config.strategy.hourly_min_market_price
         band_hi = config.strategy.hourly_max_market_price
-        if band_lo <= price <= band_hi:
+        if config.strategy.in_hourly_band(price):
             checks.append(
                 f"Hourly band OK (${price:.2f} in"
                 f" ${band_lo:.2f}-${band_hi:.2f})"

--- a/tests/unit/test_resting_sweep.py
+++ b/tests/unit/test_resting_sweep.py
@@ -12,7 +12,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from gimmes.config import PaperTradingConfig
+from gimmes.config import (
+    GimmesConfig,
+    Mode,
+    PaperTradingConfig,
+    ScannerConfig,
+    StrategyConfig,
+)
 from gimmes.models.market import Orderbook, OrderbookLevel
 from gimmes.models.order import CreateOrderParams, OrderAction, OrderSide
 from gimmes.paper.broker import PaperBroker
@@ -54,17 +60,34 @@ def _return_book() -> Orderbook:
     )
 
 
-async def _place_resting(broker: PaperBroker, *, expires_in: int = 3600):
+def _plain_config() -> GimmesConfig:
+    """Hermetic config: hourly_series empty, no #750 band filtering."""
+    return GimmesConfig(mode=Mode.DRIVING_RANGE)
+
+
+def _hourly_config() -> GimmesConfig:
+    """KXTEST is an hourly series: the #750 band filter applies."""
+    return GimmesConfig(
+        mode=Mode.DRIVING_RANGE,
+        strategy=StrategyConfig(side="no"),
+        scanner=ScannerConfig(hourly_series=["KXTEST"]),
+    )
+
+
+async def _place_resting(
+    broker: PaperBroker, *, expires_in: int = 3600,
+    no_price: float = 0.25, book: Orderbook | None = None,
+):
     params = CreateOrderParams(
         ticker="KXTEST-MKT",
         action=OrderAction.BUY,
         side=OrderSide.NO,
         count=10,
-        no_price=0.25,
+        no_price=no_price,
         post_only=False,
         expiration_ts=int(time.time()) + expires_in,
     )
-    order = await broker.create_order(params, _miss_book())
+    order = await broker.create_order(params, book or _miss_book())
     assert order.status == "resting"
     return order
 
@@ -84,7 +107,7 @@ class TestSweep:
             AsyncMock(return_value=_return_book()),
         ):
             filled = await _sweep_resting_paper_orders(
-                broker, client, db, quiet=True,
+                broker, client, db, config=_plain_config(), quiet=True,
             )
 
         assert len(filled) == 1
@@ -121,7 +144,7 @@ class TestSweep:
 
         client = AsyncMock()
         filled = await _sweep_resting_paper_orders(
-            broker, client, db, quiet=True,
+            broker, client, db, config=_plain_config(), quiet=True,
         )
 
         assert filled == []
@@ -153,3 +176,125 @@ class TestSweep:
         assert (
             has_active_resting_paper_orders(tmp_path / "nope.db") is False
         )
+
+
+class TestSweepHourlyBand:
+    """#750: an hourly resting order advances only when the effective
+    mid is back inside the validated band — the book touching the
+    limit while the mid sits below the floor is the adverse-repricing
+    case the band excludes. One-sided books skip conservatively."""
+
+    @staticmethod
+    def _hourly_miss_book() -> Orderbook:
+        # Implied NO ask 0.45 — a NO bid at 0.40 misses and rests
+        return Orderbook(
+            ticker="KXTEST-MKT",
+            yes_bids=[OrderbookLevel(price=0.55, quantity=200)],
+            no_bids=[OrderbookLevel(price=0.43, quantity=200)],
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_band_return_fills(
+        self, broker: PaperBroker, db: Database
+    ) -> None:
+        from gimmes.cli import _sweep_resting_paper_orders
+
+        order = await _place_resting(
+            broker, no_price=0.40, book=self._hourly_miss_book(),
+        )
+        # NO ask hits the 0.40 limit; yes mid 0.61 -> NO mid 0.39,
+        # inside 0.30-0.85: the fill advances.
+        in_band_book = Orderbook(
+            ticker="KXTEST-MKT",
+            yes_bids=[OrderbookLevel(price=0.60, quantity=200)],
+            no_bids=[OrderbookLevel(price=0.38, quantity=200)],
+        )
+        client = AsyncMock()
+        with patch(
+            "gimmes.kalshi.markets.get_orderbook",
+            AsyncMock(return_value=in_band_book),
+        ):
+            filled = await _sweep_resting_paper_orders(
+                broker, client, db, config=_hourly_config(), quiet=True,
+            )
+        assert len(filled) == 1
+        assert filled[0][0].order_id == order.order_id
+
+    @pytest.mark.asyncio
+    async def test_out_of_band_return_skips_fill(
+        self, broker: PaperBroker, db: Database
+    ) -> None:
+        from gimmes.cli import _sweep_resting_paper_orders
+
+        order = await _place_resting(
+            broker, no_price=0.40, book=self._hourly_miss_book(),
+        )
+        # NO ask 0.20 crosses the 0.40 limit (price-wise fillable),
+        # but yes mid 0.825 -> NO mid 0.175 is below the 0.30 floor:
+        # the c1989 loss shape. No fill, order stays resting.
+        crashed_book = Orderbook(
+            ticker="KXTEST-MKT",
+            yes_bids=[OrderbookLevel(price=0.80, quantity=200)],
+            no_bids=[OrderbookLevel(price=0.15, quantity=200)],
+        )
+        client = AsyncMock()
+        with patch(
+            "gimmes.kalshi.markets.get_orderbook",
+            AsyncMock(return_value=crashed_book),
+        ):
+            filled = await _sweep_resting_paper_orders(
+                broker, client, db, config=_hourly_config(), quiet=True,
+            )
+        assert filled == []
+        resting = await broker.list_orders(status="resting")
+        assert [o.order_id for o in resting] == [order.order_id]
+        # Log-on-fill: no ledger row for the skipped fill
+        cursor = await db.conn.execute("SELECT COUNT(*) AS n FROM trades")
+        assert int((await cursor.fetchone())["n"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_one_sided_book_skips_conservatively(
+        self, broker: PaperBroker, db: Database
+    ) -> None:
+        from gimmes.cli import _sweep_resting_paper_orders
+
+        order = await _place_resting(
+            broker, no_price=0.40, book=self._hourly_miss_book(),
+        )
+        # yes side only: implied NO ask 0.25 would fill price-wise,
+        # but the mid is undeterminable -> conservative skip.
+        one_sided = Orderbook(
+            ticker="KXTEST-MKT",
+            yes_bids=[OrderbookLevel(price=0.75, quantity=200)],
+            no_bids=[],
+        )
+        client = AsyncMock()
+        with patch(
+            "gimmes.kalshi.markets.get_orderbook",
+            AsyncMock(return_value=one_sided),
+        ):
+            filled = await _sweep_resting_paper_orders(
+                broker, client, db, config=_hourly_config(), quiet=True,
+            )
+        assert filled == []
+        assert [
+            o.order_id for o in await broker.list_orders(status="resting")
+        ] == [order.order_id]
+
+    @pytest.mark.asyncio
+    async def test_non_hourly_ticker_unaffected(
+        self, broker: PaperBroker, db: Database
+    ) -> None:
+        from gimmes.cli import _sweep_resting_paper_orders
+
+        order = await _place_resting(broker)
+        client = AsyncMock()
+        with patch(
+            "gimmes.kalshi.markets.get_orderbook",
+            AsyncMock(return_value=_return_book()),
+        ):
+            filled = await _sweep_resting_paper_orders(
+                broker, client, db, config=_plain_config(), quiet=True,
+            )
+        assert len(filled) == 1
+        assert filled[0][0].order_id == order.order_id

--- a/tests/unit/test_resting_sweep.py
+++ b/tests/unit/test_resting_sweep.py
@@ -298,3 +298,39 @@ class TestSweepHourlyBand:
             )
         assert len(filled) == 1
         assert filled[0][0].order_id == order.order_id
+
+    @pytest.mark.asyncio
+    async def test_band_judged_in_order_side_terms(
+        self, broker: PaperBroker, db: Database
+    ) -> None:
+        from gimmes.cli import _sweep_resting_paper_orders
+
+        # Review-found: config side can be flipped after placement.
+        # Config says "yes" (YES mid 0.825 IS in band) but the resting
+        # order is NO (NO mid 0.175 is below the floor) — the order's
+        # own side terms govern, so the fill must be skipped.
+        config = GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="yes"),
+            scanner=ScannerConfig(hourly_series=["KXTEST"]),
+        )
+        order = await _place_resting(
+            broker, no_price=0.40, book=self._hourly_miss_book(),
+        )
+        crashed_book = Orderbook(
+            ticker="KXTEST-MKT",
+            yes_bids=[OrderbookLevel(price=0.80, quantity=200)],
+            no_bids=[OrderbookLevel(price=0.15, quantity=200)],
+        )
+        client = AsyncMock()
+        with patch(
+            "gimmes.kalshi.markets.get_orderbook",
+            AsyncMock(return_value=crashed_book),
+        ):
+            filled = await _sweep_resting_paper_orders(
+                broker, client, db, config=config, quiet=True,
+            )
+        assert filled == []
+        assert [
+            o.order_id for o in await broker.list_orders(status="resting")
+        ] == [order.order_id]

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -524,3 +524,92 @@ class TestHourlyProbabilityFloor:
         )
         assert result.approved is False
         assert any("event" in f.lower() for f in result.failures)
+
+
+class TestHourlyPriceBand:
+    """#750: hourly tickers gate on the side-relative market price band
+    at validation time — review-level band checks can be minutes stale,
+    and the #743 approval-price cap alone passes a collapsed NO price
+    as "improvement". Non-hourly tickers see no band lines at all."""
+
+    HOURLY_TICKER = "KXBTCD-26JUN23H14-T119999.99"
+
+    @staticmethod
+    def _hourly_config() -> GimmesConfig:
+        return GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="no"),
+            scanner=ScannerConfig(hourly_series=["KXBTCD"]),
+        )
+
+    def _validate(self, config: GimmesConfig, ticker: str, *, yes_bid: float, yes_ask: float):
+        return validate_trade(
+            market=_make_market(
+                ticker=ticker, yes_bid=yes_bid, yes_ask=yes_ask,
+                last_price=round((yes_bid + yes_ask) / 2, 4),
+            ),
+            trade_dollars=200,
+            true_probability=0.72,
+            bankroll=10000,
+            daily_pnl=0,
+            open_position_count=3,
+            existing_tickers=[],
+            config=config,
+        )
+
+    def test_in_band_passes(self) -> None:
+        # NO effective mid 0.40 — inside 0.30-0.85
+        result = self._validate(
+            self._hourly_config(), self.HOURLY_TICKER,
+            yes_bid=0.58, yes_ask=0.62,
+        )
+        assert any("Hourly band OK" in c for c in result.checks)
+        assert not any("outside band" in f for f in result.failures)
+
+    def test_floor_boundary_passes(self) -> None:
+        # NO effective mid exactly 0.30 — >= not >, the floor is in-band
+        result = self._validate(
+            self._hourly_config(), self.HOURLY_TICKER,
+            yes_bid=0.68, yes_ask=0.72,
+        )
+        assert any("Hourly band OK" in c for c in result.checks)
+
+    def test_below_floor_rejected(self) -> None:
+        # NO effective mid 0.21 — the c1989 loss shape (#750)
+        result = self._validate(
+            self._hourly_config(), self.HOURLY_TICKER,
+            yes_bid=0.77, yes_ask=0.81,
+        )
+        assert result.approved is False
+        assert any(
+            "Hourly price outside band" in f and "#750" in f
+            for f in result.failures
+        ), result.failures
+
+    def test_above_ceiling_rejected(self) -> None:
+        # NO effective mid 0.90 — above the 0.85 ceiling
+        result = self._validate(
+            self._hourly_config(), self.HOURLY_TICKER,
+            yes_bid=0.08, yes_ask=0.12,
+        )
+        assert result.approved is False
+        assert any("Hourly price outside band" in f for f in result.failures)
+
+    def test_non_hourly_sees_no_band_lines(self) -> None:
+        # Same collapsed price on a non-hourly ticker: no band check,
+        # no band failure — the band is scoped to the hourly lane.
+        result = self._validate(
+            self._hourly_config(), "KXTEST",
+            yes_bid=0.77, yes_ask=0.81,
+        )
+        assert not any("band" in c.lower() for c in result.checks)
+        assert not any("band" in f.lower() for f in result.failures)
+
+    def test_inert_when_hourly_series_empty(self, config: GimmesConfig) -> None:
+        # Stock install: KXBTCD is not an hourly ticker, no band lines
+        result = self._validate(
+            config, self.HOURLY_TICKER,
+            yes_bid=0.77, yes_ask=0.81,
+        )
+        assert not any("band" in c.lower() for c in result.checks)
+        assert not any("band" in f.lower() for f in result.failures)

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -18,6 +18,19 @@ def _make_market(**kwargs) -> Market:  # type: ignore[no-untyped-def]
     return Market(**defaults)
 
 
+HOURLY_TICKER = "KXBTCD-26JUN23H14-T119999.99"
+
+
+def _hourly_config() -> GimmesConfig:
+    """KXBTCD is an hourly series, NO side — shared by the hourly
+    floor (#722) and band (#750) test classes."""
+    return GimmesConfig(
+        mode=Mode.DRIVING_RANGE,
+        strategy=StrategyConfig(side="no"),
+        scanner=ScannerConfig(hourly_series=["KXBTCD"]),
+    )
+
+
 class TestValidateTrade:
     def test_all_checks_pass(self, config: GimmesConfig) -> None:
         market = _make_market()
@@ -441,16 +454,6 @@ class TestHourlyProbabilityFloor:
     """#722: hourly-series tickers gate on hourly_min_true_probability;
     the global floor and its message literals stay untouched."""
 
-    HOURLY_TICKER = "KXBTCD-26JUN23H14-T119999.99"
-
-    @staticmethod
-    def _hourly_config() -> GimmesConfig:
-        return GimmesConfig(
-            mode=Mode.DRIVING_RANGE,
-            strategy=StrategyConfig(side="no"),
-            scanner=ScannerConfig(hourly_series=["KXBTCD"]),
-        )
-
     def _validate(self, config: GimmesConfig, ticker: str, prob: float):
         return validate_trade(
             market=_make_market(ticker=ticker),
@@ -464,7 +467,7 @@ class TestHourlyProbabilityFloor:
         )
 
     def test_hourly_floor_accepts_072(self) -> None:
-        result = self._validate(self._hourly_config(), self.HOURLY_TICKER, 0.72)
+        result = self._validate(_hourly_config(), HOURLY_TICKER, 0.72)
         assert not any("probability too low" in f.lower() for f in result.failures)
         assert any("hourly floor" in c for c in result.checks)
 
@@ -474,19 +477,19 @@ class TestHourlyProbabilityFloor:
         # lower KXBTCD estimate to exactly 0.70, so check 5 is a
         # formality on auto-sized NO orders by design — check 6 (edge
         # after fees) and Caddie's sanity checks are the binding gates.
-        result = self._validate(self._hourly_config(), self.HOURLY_TICKER, 0.70)
+        result = self._validate(_hourly_config(), HOURLY_TICKER, 0.70)
         assert not any("probability too low" in f.lower() for f in result.failures)
         assert any("hourly floor" in c for c in result.checks)
 
     def test_hourly_floor_rejects_below(self) -> None:
-        result = self._validate(self._hourly_config(), self.HOURLY_TICKER, 0.65)
+        result = self._validate(_hourly_config(), HOURLY_TICKER, 0.65)
         assert result.approved is False
         assert any(
             "70% hourly minimum" in f for f in result.failures
         ), result.failures
 
     def test_global_floor_untouched_for_non_hourly(self) -> None:
-        result = self._validate(self._hourly_config(), "KXTEST", 0.72)
+        result = self._validate(_hourly_config(), "KXTEST", 0.72)
         assert result.approved is False
         failures = [f for f in result.failures if "probability too low" in f.lower()]
         assert failures == ["True probability too low: 72% < 90% minimum"]
@@ -494,7 +497,7 @@ class TestHourlyProbabilityFloor:
     def test_inertness_message_byte_identical(self, config: GimmesConfig) -> None:
         # hourly_series empty: a KXBTCD ticker fails with the exact
         # pre-#722 literal — no "hourly" wording anywhere
-        result = self._validate(config, self.HOURLY_TICKER, 0.85)
+        result = self._validate(config, HOURLY_TICKER, 0.85)
         failures = [f for f in result.failures if "probability too low" in f.lower()]
         assert failures == ["True probability too low: 85% < 90% minimum"]
 
@@ -504,7 +507,7 @@ class TestHourlyProbabilityFloor:
         # (KXBTCD-<date>H<hour> grouping all strikes) is asserted here
         # from Kalshi's series convention; live verification of the API
         # response shape is a #721 part D deliverable.
-        config = self._hourly_config()
+        config = _hourly_config()
         market = _make_market(
             ticker="KXBTCD-26JUN23H14-T118999.99",
             event_ticker="KXBTCD-26JUN23H14",
@@ -532,16 +535,6 @@ class TestHourlyPriceBand:
     and the #743 approval-price cap alone passes a collapsed NO price
     as "improvement". Non-hourly tickers see no band lines at all."""
 
-    HOURLY_TICKER = "KXBTCD-26JUN23H14-T119999.99"
-
-    @staticmethod
-    def _hourly_config() -> GimmesConfig:
-        return GimmesConfig(
-            mode=Mode.DRIVING_RANGE,
-            strategy=StrategyConfig(side="no"),
-            scanner=ScannerConfig(hourly_series=["KXBTCD"]),
-        )
-
     def _validate(self, config: GimmesConfig, ticker: str, *, yes_bid: float, yes_ask: float):
         return validate_trade(
             market=_make_market(
@@ -560,7 +553,7 @@ class TestHourlyPriceBand:
     def test_in_band_passes(self) -> None:
         # NO effective mid 0.40 — inside 0.30-0.85
         result = self._validate(
-            self._hourly_config(), self.HOURLY_TICKER,
+            _hourly_config(), HOURLY_TICKER,
             yes_bid=0.58, yes_ask=0.62,
         )
         assert any("Hourly band OK" in c for c in result.checks)
@@ -569,7 +562,7 @@ class TestHourlyPriceBand:
     def test_floor_boundary_passes(self) -> None:
         # NO effective mid exactly 0.30 — >= not >, the floor is in-band
         result = self._validate(
-            self._hourly_config(), self.HOURLY_TICKER,
+            _hourly_config(), HOURLY_TICKER,
             yes_bid=0.68, yes_ask=0.72,
         )
         assert any("Hourly band OK" in c for c in result.checks)
@@ -577,7 +570,7 @@ class TestHourlyPriceBand:
     def test_below_floor_rejected(self) -> None:
         # NO effective mid 0.21 — the c1989 loss shape (#750)
         result = self._validate(
-            self._hourly_config(), self.HOURLY_TICKER,
+            _hourly_config(), HOURLY_TICKER,
             yes_bid=0.77, yes_ask=0.81,
         )
         assert result.approved is False
@@ -589,7 +582,7 @@ class TestHourlyPriceBand:
     def test_above_ceiling_rejected(self) -> None:
         # NO effective mid 0.90 — above the 0.85 ceiling
         result = self._validate(
-            self._hourly_config(), self.HOURLY_TICKER,
+            _hourly_config(), HOURLY_TICKER,
             yes_bid=0.08, yes_ask=0.12,
         )
         assert result.approved is False
@@ -599,7 +592,7 @@ class TestHourlyPriceBand:
         # Same collapsed price on a non-hourly ticker: no band check,
         # no band failure — the band is scoped to the hourly lane.
         result = self._validate(
-            self._hourly_config(), "KXTEST",
+            _hourly_config(), "KXTEST",
             yes_bid=0.77, yes_ask=0.81,
         )
         assert not any("band" in c.lower() for c in result.checks)
@@ -608,7 +601,7 @@ class TestHourlyPriceBand:
     def test_inert_when_hourly_series_empty(self, config: GimmesConfig) -> None:
         # Stock install: KXBTCD is not an hourly ticker, no band lines
         result = self._validate(
-            config, self.HOURLY_TICKER,
+            config, HOURLY_TICKER,
             yes_bid=0.77, yes_ask=0.81,
         )
         assert not any("band" in c.lower() for c in result.checks)


### PR DESCRIPTION
Closes #750.

## What

The hourly band (0.30–0.85 side-relative, backtest-validated) existed only in the scanner and agent judgment — nothing enforced it at the point capital moves. On 2026-07-22 cycle 1989 filled 1,010 NO @ 21¢ (band floor 0.30) eleven minutes after approval and lost $212.10; a resting order was later placed at 15¢. The #743 approval-price cap only bounds the ceiling — for a NO buy, a collapsed price passes as "improvement" while the market reprices against the thesis.

- **`validate_trade` check 6b**: hourly tickers gate on `StrategyConfig.in_hourly_band(effective price)` — covers `gimmes validate` and `gimmes order` (taker AND rest-on-miss legs). Ordinary `--force` overridability matches the adjacent #658 bound check (agent paths never pass `--force`).
- **Sweep filter**: `_sweep_resting_paper_orders` advances an hourly resting fill only when the book's effective mid is back INSIDE the band — the book touching the limit while the mid sits below the floor is the adverse-repricing case the band excludes. Undeterminable mid (one-sided book) skips conservatively; the order keeps its expiry.
- **`StrategyConfig.in_hourly_band`** is the single source of the membership semantics (bounds inclusive) for both sites; the scanner's band *selection* stays separate by design.
- Sweep `config` is now a required parameter (both call sites already had it; the `load_config()` fallback was dead and would have been a fresh-disk-read divergence trap).

Inert for stock installs: empty `scanner.hourly_series` means no hourly tickers, no band lines anywhere (pinned by test).

## Review

Security review: clean. Four-angle quality review (reuse/simplification/efficiency/altitude) applied: shared band helper, required config param, hoisted loop invariants, deduplicated test fixtures. Skipped as speculative: per-order (BUY-only) sweep filtering — rest-on-miss is BUY-only today; noted for any future resting-exit feature.

## Testing

- 10 new unit tests: band accept/reject/boundary + non-hourly and empty-series inertness (validator); in-band fill advance, out-of-band skip (the c1989 shape), one-sided-book conservative skip, non-hourly passthrough (sweep).
- Full frozen gate to run once pre-merge on the #749 branch stacked on this one.
- Ruff clean; mypy delta zero (4 pre-existing errors in config.py, unchanged).