### PR TITLE
Hourly windows outrank position windows; gap position cycles clamp to the next hourly open

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -6448,25 +6448,27 @@ def _autonomous_loop(
                             _staleness_warned = True
 
             # Determine cycle type based on trade window calendar.
-            # Precedence: release > position > hourly > monitor.
-            # Position outranks hourly (#723 review): the post-hourly
-            # sleep lands exactly at the next hourly open, so anything
-            # below hourly is unreachable in steady state — a held
-            # NON-hourly position nearing settlement must keep its full
-            # cycles (hourly-series positions are excluded from position
-            # windows by _position_window_hit, so they can't preempt).
+            # Precedence: release > hourly > position > monitor (#755).
+            # Hourly outranks position (reversing #723's original
+            # ordering): every hourly cycle runs full Step 2
+            # surveillance — StopGate, flags, 2c review, and the #659
+            # backstop — for NON-hourly positions too, so preempting
+            # the hourly lane bought no protection while one held
+            # position could silence the experiment for a whole session
+            # (2026-07-24: cycles 2026-2032, ~7 hourly windows lost).
+            # Position windows now interleave in the inter-window gaps,
+            # clamped so a gap cycle can never eat the next hourly open
+            # (hourly-series positions remain excluded from position
+            # windows by _position_window_hit). With hourly disabled,
+            # position windows behave exactly as before (#723).
             # Release windows fully mask any hourly window they cover
             # (full cycles don't scan the hourly series) — e.g. the
             # 14:00-16:00 ET index window masks 2 of 24 hourly windows
             # every weekday. Accepted miss per #723.
             effective_timeout = config.strategy.cycle_timeout
             in_window, release_name, _secs_to_close = is_in_trade_window()
-            in_pos_window, pos_ticker = False, None
-            if not in_window:
-                _pw_result = asyncio.run(_check_position_windows())
-                in_pos_window, pos_ticker = _pw_result or (False, None)
             hourly_fire = False
-            if not in_window and not in_pos_window and hourly_enabled:
+            if not in_window and hourly_enabled:
                 _now_et = datetime.now(ET)
                 if is_in_hourly_window(_now_et, lead_minutes=hourly_lead):
                     _, h_close = hourly_window(_now_et, lead_minutes=hourly_lead)
@@ -6481,6 +6483,33 @@ def _autonomous_loop(
                         and _remaining >= HOURLY_MIN_CYCLE_SECONDS
                     ):
                         hourly_fire = True
+            in_pos_window, pos_ticker = False, None
+            if not in_window and not hourly_fire:
+                _pw_result = asyncio.run(_check_position_windows())
+                in_pos_window, pos_ticker = _pw_result or (False, None)
+                if in_pos_window and hourly_enabled:
+                    # #755: a gap position cycle must never eat the
+                    # next hourly window. Clamp it to the gap; when the
+                    # tail is too short for a useful full cycle, sleep
+                    # to the open instead of spawning a doomed
+                    # subprocess (a clamp kill would count toward the
+                    # failure breaker for zero work).
+                    _gap = seconds_until_next_hourly_open(
+                        lead_minutes=hourly_lead,
+                    )
+                    if _gap < HOURLY_MIN_CYCLE_SECONDS:
+                        console.print(
+                            f"[dim]Position window ({pos_ticker}) yields"
+                            f" — hourly window opens in {_gap}s;"
+                            f" sleeping to the open (#755)[/dim]"
+                        )
+                        # No subprocess spawns on this path — give the
+                        # cycle number and the --max-cycles slot back.
+                        cycle -= 1
+                        cycles_run -= 1
+                        _sleep_with_resting_sweep(config, _gap)
+                        continue
+                    effective_timeout = min(effective_timeout, _gap)
             if in_window:
                 cycle_type = "full"
                 cycle_prompt = "Run one trading cycle."

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -6484,15 +6484,20 @@ def _autonomous_loop(
                     # tail is too short for a useful full cycle, sleep
                     # to the open instead of spawning a doomed
                     # subprocess (a clamp kill would count toward the
-                    # failure breaker for zero work). Reuse _now_et —
-                    # a fresh now() here could cross the open during
-                    # the position-window DB check and mis-derive the
-                    # gap as the FOLLOWING window's open (review-found
-                    # TOCTOU), spawning an unclamped cycle inside the
-                    # window this clamp exists to protect.
+                    # failure breaker for zero work). Two clocks, both
+                    # review-found: the TARGET open derives from
+                    # _now_et — a fresh now() could cross the open
+                    # during the position-window DB check and
+                    # mis-derive the gap as the FOLLOWING window's —
+                    # while the REMAINING time subtracts the probe's
+                    # own duration, so a slow probe can't inflate the
+                    # clamp past the open it protects.
                     _gap = seconds_until_next_hourly_open(
                         _now_et, lead_minutes=hourly_lead,
                     )
+                    _gap = max(1, _gap - int(
+                        (datetime.now(ET) - _now_et).total_seconds()
+                    ))
                     if _gap < HOURLY_MIN_CYCLE_SECONDS:
                         console.print(
                             f"[dim]Position window ({pos_ticker}) yields"

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -6405,9 +6405,6 @@ def _autonomous_loop(
                 _sleep_with_resting_sweep(config, secs)
                 continue
 
-            cycle += 1
-            cycles_run += 1
-
             # Code staleness check
             _cur, _stale, _stale_msg = _check_code_staleness(
                 project_root, _startup_commit,
@@ -6448,23 +6445,17 @@ def _autonomous_loop(
                             _staleness_warned = True
 
             # Determine cycle type based on trade window calendar.
-            # Precedence: release > hourly > position > monitor (#755).
-            # Hourly outranks position (reversing #723's original
-            # ordering): every hourly cycle runs full Step 2
-            # surveillance — StopGate, flags, 2c review, and the #659
-            # backstop — for NON-hourly positions too, so preempting
-            # the hourly lane bought no protection while one held
-            # position could silence the experiment for a whole session
-            # (2026-07-24: cycles 2026-2032, ~7 hourly windows lost).
-            # Position windows now interleave in the inter-window gaps,
-            # clamped so a gap cycle can never eat the next hourly open
-            # (hourly-series positions remain excluded from position
-            # windows by _position_window_hit). With hourly disabled,
-            # position windows behave exactly as before (#723).
-            # Release windows fully mask any hourly window they cover
-            # (full cycles don't scan the hourly series) — e.g. the
-            # 14:00-16:00 ET index window masks 2 of 24 hourly windows
-            # every weekday. Accepted miss per #723.
+            # Precedence: release > hourly > position > monitor (#755,
+            # reversing #723's position>hourly): every hourly cycle
+            # runs full Step 2 surveillance — StopGate, flags, 2c
+            # review, the #659 backstop — for NON-hourly positions too,
+            # so preempting the hourly lane bought no protection; see
+            # #755 for the starvation incident. Position windows
+            # interleave in the inter-window gaps (hourly-series
+            # positions stay excluded via _position_window_hit); with
+            # hourly disabled they behave exactly as before (#723).
+            # Release windows fully mask any hourly window they cover —
+            # accepted miss per #723.
             effective_timeout = config.strategy.cycle_timeout
             in_window, release_name, _secs_to_close = is_in_trade_window()
             hourly_fire = False
@@ -6493,9 +6484,14 @@ def _autonomous_loop(
                     # tail is too short for a useful full cycle, sleep
                     # to the open instead of spawning a doomed
                     # subprocess (a clamp kill would count toward the
-                    # failure breaker for zero work).
+                    # failure breaker for zero work). Reuse _now_et —
+                    # a fresh now() here could cross the open during
+                    # the position-window DB check and mis-derive the
+                    # gap as the FOLLOWING window's open (review-found
+                    # TOCTOU), spawning an unclamped cycle inside the
+                    # window this clamp exists to protect.
                     _gap = seconds_until_next_hourly_open(
-                        lead_minutes=hourly_lead,
+                        _now_et, lead_minutes=hourly_lead,
                     )
                     if _gap < HOURLY_MIN_CYCLE_SECONDS:
                         console.print(
@@ -6503,13 +6499,15 @@ def _autonomous_loop(
                             f" — hourly window opens in {_gap}s;"
                             f" sleeping to the open (#755)[/dim]"
                         )
-                        # No subprocess spawns on this path — give the
-                        # cycle number and the --max-cycles slot back.
-                        cycle -= 1
-                        cycles_run -= 1
                         _sleep_with_resting_sweep(config, _gap)
                         continue
                     effective_timeout = min(effective_timeout, _gap)
+
+            # Counters increment only once an iteration is committed to
+            # spawning — every skip path above (budget, #755 yield)
+            # exits via `continue` without burning a --max-cycles slot.
+            cycle += 1
+            cycles_run += 1
             if in_window:
                 cycle_type = "full"
                 cycle_prompt = "Run one trading cycle."

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -2468,39 +2468,6 @@ class TestHourlyLadder:
         assert types.count("monitor") == 1
         assert len(types) == 25
 
-    def test_position_precedence_over_hourly(self, capsys) -> None:
-        # #723 review: a held NON-hourly position near settlement must
-        # keep its full cycles even when an hourly window is open —
-        # otherwise the steady-state hourly cadence starves position
-        # surveillance (overnight/weekends have no release windows)
-        mock_proc = _mock_popen()
-        with (
-            patch("shutil.which", return_value="/usr/bin/claude"),
-            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
-            patch("gimmes.cli._communicate_interruptible", return_value=b""),
-            patch("gimmes.clubhouse.server.start_background", return_value=None),
-            patch("gimmes.cli.load_config", side_effect=self._hourly_load_config()),
-            patch(
-                "asyncio.run",
-                side_effect=lambda coro: (
-                    coro.close(), (True, "KXINX-26JUN23-B5000"),
-                )[1],
-            ),
-            patch(
-                "gimmes.strategy.calendar.is_in_hourly_window",
-                lambda dt=None, *, lead_minutes: True,
-            ),
-            patch(
-                "gimmes.strategy.calendar.hourly_window",
-                self._dt_relative_window(1500),
-            ),
-        ):
-            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
-
-        env = mock_popen.call_args.kwargs["env"]
-        assert env["GIMMES_CYCLE_TYPE"] == "full"
-        assert "POSITION WINDOW" in capsys.readouterr().out
-
     def test_post_hourly_sleep_takes_sooner_release_window(self) -> None:
         # The post-hourly min must consider the release calendar too —
         # a release window opening before the next hourly open wins
@@ -2688,6 +2655,45 @@ class TestCycleDeadlineEnv:
         assert -2760 <= low <= -2600, (low, high)
 
 
+def _loop_isolation(tmp_path, monkeypatch, *, asyncio_run):  # type: ignore[no-untyped-def]
+    """Shared loop-isolation stack: outside any release window, session
+    store stubbed, staleness checks quiet. `asyncio_run` controls the
+    position-window probe result (close the coro, return the hit).
+    TestAutonomousLoop/TestHourlyLadder predate this helper and keep
+    their own copies; new loop test classes should delegate here."""
+    from contextlib import ExitStack
+
+    monkeypatch.setenv("GIMMES_MODE", "driving_range")
+    monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+    stack = ExitStack()
+    for p in (
+        patch("gimmes.store.session.create_session", return_value=1),
+        patch("gimmes.store.session.end_session"),
+        patch("gimmes.store.session.mark_stale_sessions", return_value=0),
+        patch("gimmes.store.session.update_session_cycle"),
+        patch("asyncio.run", side_effect=asyncio_run),
+        patch(
+            "gimmes.strategy.calendar.is_in_trade_window",
+            return_value=(False, None, None),
+        ),
+        patch(
+            "gimmes.strategy.calendar.next_trade_window",
+            return_value=(_make_future_dt(), "Index contracts"),
+        ),
+        patch(
+            "gimmes.strategy.calendar.seconds_until_next_window",
+            return_value=3600,
+        ),
+        patch(
+            "gimmes.cli._check_code_staleness",
+            return_value=("abc123", False, None),
+        ),
+        patch("gimmes.cli._check_remote_staleness", return_value=None),
+    ):
+        stack.enter_context(p)
+    return stack
+
+
 class TestPositionYieldsToHourly:
     """#755: precedence is release > hourly > position > monitor.
     Hourly cycles run full Step 2 surveillance for non-hourly positions
@@ -2697,42 +2703,11 @@ class TestPositionYieldsToHourly:
 
     @pytest.fixture(autouse=True)
     def _patch_session_funcs(self, tmp_path, monkeypatch):
-        # Same isolation as TestHourlyLadder: outside any release window,
-        # but asyncio.run reports a position-window HIT (the #755 seam).
-        monkeypatch.setenv("GIMMES_MODE", "driving_range")
-        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
-
         def _pos_hit(coro):  # type: ignore[no-untyped-def]
             coro.close()
             return (True, "KXGDP-26JUL30-T2.0")
 
-        with (
-            patch("gimmes.store.session.create_session", return_value=1),
-            patch("gimmes.store.session.end_session"),
-            patch("gimmes.store.session.mark_stale_sessions", return_value=0),
-            patch("gimmes.store.session.update_session_cycle"),
-            patch("asyncio.run", side_effect=_pos_hit),
-            patch(
-                "gimmes.strategy.calendar.is_in_trade_window",
-                return_value=(False, None, None),
-            ),
-            patch(
-                "gimmes.strategy.calendar.next_trade_window",
-                return_value=(_make_future_dt(), "Index contracts"),
-            ),
-            patch(
-                "gimmes.strategy.calendar.seconds_until_next_window",
-                return_value=3600,
-            ),
-            patch(
-                "gimmes.cli._check_code_staleness",
-                return_value=("abc123", False, None),
-            ),
-            patch(
-                "gimmes.cli._check_remote_staleness",
-                return_value=None,
-            ),
-        ):
+        with _loop_isolation(tmp_path, monkeypatch, asyncio_run=_pos_hit):
             yield
 
     def test_hourly_outranks_position_window(self) -> None:
@@ -2782,7 +2757,7 @@ class TestPositionYieldsToHourly:
             ),
             patch(
                 "gimmes.strategy.calendar.seconds_until_next_hourly_open",
-                lambda *, lead_minutes: 900,
+                lambda dt=None, *, lead_minutes: 900,
             ),
         ):
             _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
@@ -2808,7 +2783,7 @@ class TestPositionYieldsToHourly:
             ),
             patch(
                 "gimmes.strategy.calendar.seconds_until_next_hourly_open",
-                lambda *, lead_minutes: 60,
+                lambda dt=None, *, lead_minutes: 60,
             ),
             patch(
                 "gimmes.cli._sleep_with_resting_sweep",

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -2686,3 +2686,153 @@ class TestCycleDeadlineEnv:
         low = (before - deadline).total_seconds()
         high = (after - deadline).total_seconds()
         assert -2760 <= low <= -2600, (low, high)
+
+
+class TestPositionYieldsToHourly:
+    """#755: precedence is release > hourly > position > monitor.
+    Hourly cycles run full Step 2 surveillance for non-hourly positions
+    (#659 backstop included), so a held position must never silence the
+    hourly lane; position cycles interleave in the inter-window gaps,
+    clamped so they can't eat the next hourly open."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_session_funcs(self, tmp_path, monkeypatch):
+        # Same isolation as TestHourlyLadder: outside any release window,
+        # but asyncio.run reports a position-window HIT (the #755 seam).
+        monkeypatch.setenv("GIMMES_MODE", "driving_range")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+
+        def _pos_hit(coro):  # type: ignore[no-untyped-def]
+            coro.close()
+            return (True, "KXGDP-26JUL30-T2.0")
+
+        with (
+            patch("gimmes.store.session.create_session", return_value=1),
+            patch("gimmes.store.session.end_session"),
+            patch("gimmes.store.session.mark_stale_sessions", return_value=0),
+            patch("gimmes.store.session.update_session_cycle"),
+            patch("asyncio.run", side_effect=_pos_hit),
+            patch(
+                "gimmes.strategy.calendar.is_in_trade_window",
+                return_value=(False, None, None),
+            ),
+            patch(
+                "gimmes.strategy.calendar.next_trade_window",
+                return_value=(_make_future_dt(), "Index contracts"),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=3600,
+            ),
+            patch(
+                "gimmes.cli._check_code_staleness",
+                return_value=("abc123", False, None),
+            ),
+            patch(
+                "gimmes.cli._check_remote_staleness",
+                return_value=None,
+            ),
+        ):
+            yield
+
+    def test_hourly_outranks_position_window(self) -> None:
+        # Both active: the hourly window fires; the position check is
+        # never consulted (hourly Step 2 surveils the position anyway).
+        mock_proc = _mock_popen()
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("gimmes.cli._communicate_interruptible", return_value=b""),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=TestHourlyLadder._hourly_load_config(),
+            ),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: True,
+            ),
+            patch(
+                "gimmes.strategy.calendar.hourly_window",
+                TestHourlyLadder._dt_relative_window(1500),
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "hourly"
+
+    def test_position_cycle_clamped_to_next_hourly_open(self) -> None:
+        # Gap case: no hourly window now, position cycle fires but its
+        # timeout is clamped to the next hourly open.
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=_mock_popen()) as mock_popen,
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ) as mock_comm,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=TestHourlyLadder._hourly_load_config(),
+            ),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: False,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda *, lead_minutes: 900,
+            ),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "full"
+        assert mock_comm.call_args.kwargs["timeout"] == 900
+
+    def test_position_yields_sleep_when_gap_tiny(self) -> None:
+        # Tail shorter than a useful cycle: no subprocess spawns; the
+        # loop sleeps straight to the hourly open.
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+            patch(
+                "gimmes.cli.load_config",
+                side_effect=TestHourlyLadder._hourly_load_config(),
+            ),
+            patch(
+                "gimmes.strategy.calendar.is_in_hourly_window",
+                lambda dt=None, *, lead_minutes: False,
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_hourly_open",
+                lambda *, lead_minutes: 60,
+            ),
+            patch(
+                "gimmes.cli._sleep_with_resting_sweep",
+                side_effect=KeyboardInterrupt,
+            ) as mock_sleep,
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        mock_popen.assert_not_called()
+        assert mock_sleep.call_args.args[1] == 60
+
+    def test_position_unclamped_when_hourly_disabled(self) -> None:
+        # Stock install (empty hourly_series): position windows behave
+        # exactly as before #755 — full cycle, full timeout.
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen", return_value=_mock_popen()) as mock_popen,
+            patch(
+                "gimmes.cli._communicate_interruptible", return_value=b"",
+            ) as mock_comm,
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop("driving_range", max_cycles=1, pause_seconds=0)
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["GIMMES_CYCLE_TYPE"] == "full"
+        assert mock_comm.call_args.kwargs["timeout"] == 2700


### PR DESCRIPTION
Closes #755.

## What

On 2026-07-24 one held index position preempted ~7 hourly windows via position-window precedence (cycles 2026-2032), silencing the hourly experiment for a session while buying no protection — every hourly cycle already runs full Step 2 surveillance (StopGate, flags, 2c review, the #659 backstop) for non-hourly positions.

- **Precedence is now release > hourly > position > monitor** (reversing #723's position>hourly). Position windows interleave in the inter-window gaps.
- **Gap position cycles clamp to the next hourly open** so they can never eat the window; a tail shorter than `HOURLY_MIN_CYCLE_SECONDS` sleeps to the open instead of spawning a doomed subprocess (which would have fed the failure breaker for zero work).
- **Cycle counters now increment only when an iteration commits to spawning** — skip paths (budget cap, the new yield) can't burn `--max-cycles` slots.
- Stock installs unchanged: with `scanner.hourly_series` empty, position windows behave exactly as before (pinned by test).

## Review findings (all fixed in this PR)

- **Stale test**: the #723-era `test_position_precedence_over_hourly` asserted the old ordering and failed under the new one — deleted; its inverse (`test_hourly_outranks_position_window`) carries the #755 rationale. Verified no other consumer assumes the old order (README + agent prompts consistent).
- **TOCTOU at the window-open boundary**: the clamp re-derived now() after the position-window DB check; an iteration arriving seconds before an open could cross it mid-check and mis-derive the gap as the FOLLOWING window's open, spawning an unclamped cycle inside the window the clamp protects. Fixed: the clamp reuses the same `_now_et` sample as the hourly decision.
- **Counter giveback bandaid** → replaced by the commit-then-count restructure above.
- Test-side: loop-isolation fixture deduplicated into a shared `_loop_isolation` helper.
- Known accepted asymmetry (flagged, deliberately not changed here): a ≥120s gap cycle killed at its clamp still counts toward the failure breaker — same pre-existing pattern as hourly clamp kills (#723 calls them routine).

Security review: no findings; capital-safety property verified (no path grants a longer timeout than before; budget/failure accounting not bypassed).

## Testing

4 new precedence tests (hourly-outranks-position, gap clamp, tiny-gap yield-sleep, hourly-disabled inertness). Frozen full-suite gate running on this branch; result posted before merge. Ruff clean; mypy delta zero.