### PR TITLE
Partial cycle logs on timeout + clamp-kill breaker fairness (#761)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -6784,6 +6784,7 @@ def _autonomous_loop(
                     )
                     _resilient_sleep(rl_pause)
                     consecutive_failures = 0
+                    consecutive_trade_path_kills = 0
                     continue
 
                 # --- Anthropic API error detection ---
@@ -6795,6 +6796,7 @@ def _autonomous_loop(
                 )
                 if had_api_error:
                     consecutive_failures += 1
+                    consecutive_trade_path_kills = 0
                     kind = "transient API error" if is_transient else "API error"
                     snippet = api_detail[:200].replace("\n", " ")
                     console.print(
@@ -6867,6 +6869,9 @@ def _autonomous_loop(
                     _sleep_with_resting_sweep(config, pause_seconds)
                     continue
                 consecutive_failures += 1
+                # A real failure breaks any unbroken run of
+                # trade-path-done kills (Copilot-review-found).
+                consecutive_trade_path_kills = 0
                 console.print(
                     f"[yellow]Cycle {cycle} timed out after"
                     f" {effective_timeout}s"
@@ -6882,6 +6887,7 @@ def _autonomous_loop(
 
             if returncode != 0:
                 consecutive_failures += 1
+                consecutive_trade_path_kills = 0
                 console.print(
                     f"[yellow]Cycle {cycle} exited with code"
                     f" {returncode}"

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -5551,7 +5551,11 @@ def _communicate_interruptible(
     closes the pipe and unblocks the daemon reader thread.
 
     Returns the captured stdout bytes.  Raises ``subprocess.TimeoutExpired``
-    if the subprocess has not finished within *timeout* seconds.
+    if the subprocess has not finished within *timeout* seconds; the
+    bytes read so far are attached as the exception's ``output`` so a
+    killed cycle still leaves its partial transcript (#761 — before
+    this, a timed-out cycle discarded everything it had streamed and
+    left no evidence of where it stalled).
     """
     import threading
     import time
@@ -5563,14 +5567,20 @@ def _communicate_interruptible(
 
     stdout = proc.stdout  # narrowed to IO[bytes] for the closure
 
-    output: list[bytes] = []
+    buf = bytearray()
+    buf_lock = threading.Lock()
     error: list[BaseException] = []
 
     def _reader() -> None:
+        # Chunked reads (not one blocking read-to-EOF) so the buffer
+        # holds everything streamed so far when the deadline fires.
         try:
-            data = stdout.read()
-            if data:
-                output.append(data)
+            while True:
+                data = stdout.read(65536)
+                if not data:
+                    break
+                with buf_lock:
+                    buf.extend(data)
         except BaseException as exc:
             error.append(exc)
 
@@ -5589,7 +5599,11 @@ def _communicate_interruptible(
         reader.join(timeout=min(poll_interval, remaining))
 
     if reader.is_alive():
-        raise subprocess.TimeoutExpired(cmd=proc.args, timeout=timeout)
+        with buf_lock:
+            partial = bytes(buf)
+        raise subprocess.TimeoutExpired(
+            cmd=proc.args, timeout=timeout, output=partial,
+        )
 
     if error:
         raise error[0]
@@ -5606,7 +5620,66 @@ def _communicate_interruptible(
             "killing process group",
         )
         _kill_process_group(proc)
-    return b"".join(output)
+    return bytes(buf)
+
+
+def _classify_timeout_outcome(
+    db_path: Path,
+    cycle: int,
+    since_utc: datetime,
+) -> str:
+    """Classify a clamp-killed cycle from its activity_log trail (#761).
+
+    Returns one of:
+
+    - ``"complete"`` — the cycle logged its own completion marker before
+      the kill (it finished its work; only process exit was outrun).
+    - ``"trade_path_done"`` — the trade path concluded (Closer ran or
+      was explicitly skipped); the clamp truncated only post-trade
+      steps, which the deadline protocol already treats as sheddable.
+    - ``"failure"`` — neither marker exists, or the DB is unreadable.
+      Unreadable defaults to failure so the circuit breaker never loses
+      coverage to a telemetry problem.
+
+    The markers are the same activity_log rows operators already use to
+    diagnose timeouts by hand.  Rows are matched by their ``cycle``
+    column; ``since_utc`` additionally bounds the query so a same-
+    numbered cycle from an earlier loop run (fresh-DB restart) can
+    never match.
+    """
+    import sqlite3
+
+    since = since_utc.strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro", uri=True, timeout=5,
+        )
+        try:
+            rows = conn.execute(
+                "SELECT message FROM activity_log"
+                " WHERE cycle = ? AND timestamp >= ?",
+                (cycle, since),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return "failure"
+
+    messages = [row[0] for row in rows]
+    if any(m.startswith(f"Cycle {cycle} complete") for m in messages):
+        return "complete"
+    trade_path_markers = (
+        "Closer executed",
+        "Closer skipped",
+        "Hourly 4c: dispatching Closer",
+    )
+    if any(
+        m.startswith(marker)
+        for m in messages
+        for marker in trade_path_markers
+    ):
+        return "trade_path_done"
+    return "failure"
 
 
 def _result_dict_to_text(data: dict[str, object]) -> bytes:
@@ -6032,6 +6105,29 @@ def _resolve_budget_cap(
     if config_value is not None:
         return config_value
     return default
+
+
+def _write_cycle_log(log_path: Path, raw: bytes) -> None:
+    """Write a cycle's stream-json transcript to its log file.
+
+    Shared by the success and timeout paths (#761) — a clamp-killed
+    cycle writes whatever it streamed before the kill, so stalls leave
+    a transcript instead of nothing.
+    """
+    try:
+        with open(log_path, "wb") as log_file:
+            log_file.write(_wrap_stream_json(raw))
+    except OSError:
+        import logging
+
+        logging.getLogger("gimmes").warning(
+            "Failed to write cycle log to %s", log_path,
+            exc_info=True,
+        )
+        console.print(
+            f"[yellow]Warning: could not write log"
+            f" {log_path}[/yellow]"
+        )
 
 
 def _wrap_stream_json(raw: bytes) -> bytes:
@@ -6574,7 +6670,8 @@ def _autonomous_loop(
             # of being killed mid-review with nothing recorded.
             import datetime as _dl
 
-            _deadline = _dl.datetime.now(_dl.UTC) + _dl.timedelta(
+            _cycle_started_utc = _dl.datetime.now(_dl.UTC)
+            _deadline = _cycle_started_utc + _dl.timedelta(
                 seconds=effective_timeout,
             )
             env["GIMMES_CYCLE_DEADLINE"] = _deadline.strftime(
@@ -6612,19 +6709,7 @@ def _autonomous_loop(
                     )
                 finally:
                     _active_proc = None
-                try:
-                    with open(log_path, "wb") as log_file:
-                        log_file.write(_wrap_stream_json(stdout_bytes))
-                except OSError:
-                    import logging
-                    logging.getLogger("gimmes").warning(
-                        "Failed to write cycle log to %s", log_path,
-                        exc_info=True,
-                    )
-                    console.print(
-                        f"[yellow]Warning: could not write log"
-                        f" {log_path}[/yellow]"
-                    )
+                _write_cycle_log(log_path, stdout_bytes)
                 terminal_text = _extract_terminal_text(stdout_bytes)
                 sys.stdout.buffer.write(terminal_text)
                 sys.stdout.buffer.flush()
@@ -6692,12 +6777,40 @@ def _autonomous_loop(
                         break
                     continue
 
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as timeout_exc:
                 _kill_process_group(proc)
                 # Anthropic charged for the killed subprocess's tokens —
                 # count the session (#545 intent; the hourly clamp makes
                 # timeouts a routine outcome rather than an anomaly, #723)
                 budget_tracker.record_session_no_usage()
+                # #761: the partial transcript is the only evidence of
+                # where a stalled cycle spent its time — write it.
+                _write_cycle_log(log_path, timeout_exc.output or b"")
+                # #761: a clamp kill is not automatically a failure.
+                # c2134 logged "Cycle complete" 24s before its clamp;
+                # hourly clamp kills routinely truncate only sheddable
+                # post-trade steps. Only cycles whose trade path never
+                # concluded feed the circuit breaker.
+                outcome = _classify_timeout_outcome(
+                    config.db_path, cycle, _cycle_started_utc,
+                )
+                if outcome == "complete":
+                    consecutive_failures = 0
+                    console.print(
+                        f"[yellow]Cycle {cycle} completed but overran"
+                        f" the {effective_timeout}s clamp before"
+                        f" process exit — not counted as a failure"
+                        f" (#761)[/yellow]"
+                    )
+                    continue
+                if outcome == "trade_path_done":
+                    console.print(
+                        f"[yellow]Cycle {cycle} clamp-killed at"
+                        f" {effective_timeout}s after its trade path"
+                        f" concluded — post-trade steps truncated, not"
+                        f" counted as a failure (#761)[/yellow]"
+                    )
+                    continue
                 consecutive_failures += 1
                 console.print(
                     f"[yellow]Cycle {cycle} timed out after"

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -5535,6 +5535,8 @@ def _kill_process_group(proc: subprocess.Popen[bytes]) -> None:
 def _communicate_interruptible(
     proc: subprocess.Popen[bytes],
     timeout: float,
+    *,
+    kill_on_timeout: bool = False,
 ) -> bytes:
     """Read subprocess stdout in a background thread so the main thread
     remains interruptible by KeyboardInterrupt.
@@ -5548,7 +5550,12 @@ def _communicate_interruptible(
 
     The caller is responsible for killing the subprocess on
     ``TimeoutExpired`` or ``KeyboardInterrupt``; killing the process
-    closes the pipe and unblocks the daemon reader thread.
+    closes the pipe and unblocks the daemon reader thread.  With
+    ``kill_on_timeout=True`` the deadline path kills the process group
+    itself BEFORE snapshotting, so bytes the child flushes as it dies
+    — the closest evidence to the stall point — make it into the
+    snapshot (review-found; the caller-side kill happens after the
+    raise, too late for the buffer).
 
     Returns the captured stdout bytes.  Raises ``subprocess.TimeoutExpired``
     if the subprocess has not finished within *timeout* seconds; the
@@ -5599,6 +5606,12 @@ def _communicate_interruptible(
         reader.join(timeout=min(poll_interval, remaining))
 
     if reader.is_alive():
+        if kill_on_timeout:
+            # Kill first: process death closes the pipe, the reader
+            # drains the final flushed bytes and hits EOF — then the
+            # snapshot includes the transcript's diagnostic tail.
+            _kill_process_group(proc)
+            reader.join(timeout=5)
         with buf_lock:
             partial = bytes(buf)
         raise subprocess.TimeoutExpired(
@@ -5623,6 +5636,19 @@ def _communicate_interruptible(
     return bytes(buf)
 
 
+# #761 clamp-kill classification markers. Both are MANDATED
+# log-activity templates in the agent prompts — "Cycle $GIMMES_CYCLE
+# complete" (caddie-master.md Step 8) and "Closer executed N trades"
+# (closer.md completion) — and both are pinned by drift-guard tests in
+# tests/unit/test_agent_prompts.py so a prompt rewording cannot
+# silently degrade every clamp kill back to "failure". Deliberately
+# NOT in the set: "Hourly 4c: dispatching Closer" fires BEFORE the
+# Closer runs — a Closer hanging mid-order-placement must classify as
+# a failure (review-found breaker blind spot).
+CYCLE_COMPLETE_MARKER_TEMPLATE = "Cycle {cycle} complete"
+CLOSER_CONCLUDED_MARKER_PREFIX = "Closer executed"
+
+
 def _classify_timeout_outcome(
     db_path: Path,
     cycle: int,
@@ -5634,9 +5660,9 @@ def _classify_timeout_outcome(
 
     - ``"complete"`` — the cycle logged its own completion marker before
       the kill (it finished its work; only process exit was outrun).
-    - ``"trade_path_done"`` — the trade path concluded (Closer ran or
-      was explicitly skipped); the clamp truncated only post-trade
-      steps, which the deadline protocol already treats as sheddable.
+    - ``"trade_path_done"`` — the Closer concluded ("Closer executed N
+      trades" logged); the clamp truncated only post-trade steps, which
+      the deadline protocol already treats as sheddable.
     - ``"failure"`` — neither marker exists, or the DB is unreadable.
       Unreadable defaults to failure so the circuit breaker never loses
       coverage to a telemetry problem.
@@ -5663,20 +5689,23 @@ def _classify_timeout_outcome(
         finally:
             conn.close()
     except sqlite3.Error:
+        # Loud degradation (#659 rule): a systematically-broken
+        # classifier silently reverts every clamp kill to pre-#761
+        # breaker behavior — the operator must be able to see that.
+        import logging
+
+        logging.getLogger("gimmes").warning(
+            "Clamp-kill classification failed for cycle %s —"
+            " counting as failure (#761)", cycle, exc_info=True,
+        )
         return "failure"
 
     messages = [row[0] for row in rows]
-    if any(m.startswith(f"Cycle {cycle} complete") for m in messages):
+    complete_marker = CYCLE_COMPLETE_MARKER_TEMPLATE.format(cycle=cycle)
+    if any(m.startswith(complete_marker) for m in messages):
         return "complete"
-    trade_path_markers = (
-        "Closer executed",
-        "Closer skipped",
-        "Hourly 4c: dispatching Closer",
-    )
     if any(
-        m.startswith(marker)
-        for m in messages
-        for marker in trade_path_markers
+        m.startswith(CLOSER_CONCLUDED_MARKER_PREFIX) for m in messages
     ):
         return "trade_path_done"
     return "failure"
@@ -6309,6 +6338,9 @@ def _autonomous_loop(
     cycle = get_max_global_cycle(config.db_path)
     cycles_run = 0
     consecutive_failures = 0
+    # #761: unbroken runs of trade-path-done clamp kills (post-trade
+    # steps shed every cycle) warn without feeding the breaker.
+    consecutive_trade_path_kills = 0
     session_status = "stopped"
 
     # Hourly-ladder state (#723): track the single active window only —
@@ -6706,6 +6738,7 @@ def _autonomous_loop(
                 try:
                     stdout_bytes = _communicate_interruptible(
                         proc, timeout=effective_timeout,
+                        kill_on_timeout=True,
                     )
                 finally:
                     _active_proc = None
@@ -6778,6 +6811,8 @@ def _autonomous_loop(
                     continue
 
             except subprocess.TimeoutExpired as timeout_exc:
+                # Idempotent backstop — the helper already killed the
+                # group on the kill_on_timeout path.
                 _kill_process_group(proc)
                 # Anthropic charged for the killed subprocess's tokens —
                 # count the session (#545 intent; the hourly clamp makes
@@ -6796,20 +6831,40 @@ def _autonomous_loop(
                 )
                 if outcome == "complete":
                     consecutive_failures = 0
+                    consecutive_trade_path_kills = 0
                     console.print(
                         f"[yellow]Cycle {cycle} completed but overran"
                         f" the {effective_timeout}s clamp before"
                         f" process exit — not counted as a failure"
                         f" (#761)[/yellow]"
                     )
+                    # A kill path must never respawn hot: same
+                    # inter-cycle pause (and rest-on-miss sweep
+                    # window) as a normal completion.
+                    _sleep_with_resting_sweep(config, pause_seconds)
                     continue
                 if outcome == "trade_path_done":
+                    consecutive_trade_path_kills += 1
                     console.print(
                         f"[yellow]Cycle {cycle} clamp-killed at"
                         f" {effective_timeout}s after its trade path"
                         f" concluded — post-trade steps truncated, not"
                         f" counted as a failure (#761)[/yellow]"
                     )
+                    if consecutive_trade_path_kills >= 3:
+                        # Not a breaker matter (#746 deems post-trade
+                        # steps sheddable), but an UNBROKEN run of
+                        # sheds is a capacity regression the operator
+                        # should see.
+                        console.print(
+                            f"[yellow bold]"
+                            f"{consecutive_trade_path_kills}"
+                            f" consecutive clamp kills have truncated"
+                            f" post-trade steps — surveillance is"
+                            f" being shed every cycle (#761)"
+                            f"[/yellow bold]"
+                        )
+                    _sleep_with_resting_sweep(config, pause_seconds)
                     continue
                 consecutive_failures += 1
                 console.print(
@@ -6841,6 +6896,7 @@ def _autonomous_loop(
                 continue
             else:
                 consecutive_failures = 0
+                consecutive_trade_path_kills = 0
 
             if max_cycles > 0 and cycles_run >= max_cycles:
                 break

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3042,3 +3042,36 @@ def test_preload_boilerplate_definition() -> None:
     assert "Near-identical lines ACROSS a ladder's rungs are EXPECTED" in cm_text
     assert "never against its siblings" in cm_text
     assert "pre-filter and review-reuse deaths never confer" in cm_text
+
+
+def test_clamp_kill_classification_markers_pinned() -> None:
+    """#761: the loop classifies clamp-killed cycles from two mandated
+    activity markers — "Cycle $GIMMES_CYCLE complete" (Caddie Master
+    Step 8) and "Closer executed N trades" (Closer completion). If a
+    prompt rewording drops either template, every clamp kill silently
+    degrades back to a breaker failure, the exact false-positive #761
+    removes. The cli constants and the prompt templates must agree."""
+    from gimmes.cli import (
+        CLOSER_CONCLUDED_MARKER_PREFIX,
+        CYCLE_COMPLETE_MARKER_TEMPLATE,
+    )
+
+    cm_text = (AGENTS_DIR / "caddie-master.md").read_text()
+    closer_text = (AGENTS_DIR / "closer.md").read_text()
+
+    # The prompt templates the agents are mandated to log
+    prompt_complete = CYCLE_COMPLETE_MARKER_TEMPLATE.format(
+        cycle="$GIMMES_CYCLE",
+    )
+    assert f'--message "{prompt_complete}"' in cm_text, (
+        "caddie-master.md must mandate the Step 8 completion marker"
+        " the #761 classifier keys on"
+    )
+    assert '--message "Closer executed N trades"' in closer_text, (
+        "closer.md must mandate the Closer completion marker the #761"
+        " classifier keys on"
+    )
+    # The classifier prefix must match the template's fixed prefix
+    assert "Closer executed N trades".startswith(
+        CLOSER_CONCLUDED_MARKER_PREFIX,
+    )

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -531,7 +531,7 @@ class TestAutonomousLoop:
         """A TimeoutExpired cycle counts as a failure but the loop continues."""
         comm_count = 0
 
-        def comm_side_effect(proc, timeout):
+        def comm_side_effect(proc, timeout, **kwargs):
             nonlocal comm_count
             comm_count += 1
             if comm_count == 1:
@@ -951,7 +951,7 @@ class TestAutonomousLoop:
 
         captured = []
 
-        def comm_side_effect(proc, timeout):
+        def comm_side_effect(proc, timeout, **kwargs):
             captured.append(signal.getsignal(signal.SIGINT))
             return b""
 
@@ -2933,7 +2933,7 @@ class TestHourlyLadder:
         from gimmes.config import GIMMES_HOME
         budget_path = GIMMES_HOME / "budget.json"
 
-        def comm_side_effect(proc, timeout):  # type: ignore[no-untyped-def]
+        def comm_side_effect(proc, timeout, **kwargs):  # type: ignore[no-untyped-def]
             raise _subprocess.TimeoutExpired(cmd=proc.args, timeout=timeout)
 
         with (

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -605,7 +605,7 @@ class TestAutonomousLoop:
             patch("gimmes.clubhouse.server.start_background", return_value=None),
         ):
             _autonomous_loop(
-                "driving_range", max_cycles=1,
+                "driving_range", max_cycles=1, pause_seconds=0,
                 max_consecutive_failures=1,
             )
 
@@ -613,14 +613,50 @@ class TestAutonomousLoop:
         assert "completed but overran" in output
         assert "Circuit breaker tripped" not in output
 
+    def test_complete_classified_timeout_resets_accumulated_failures(
+        self, tmp_path, capsys,
+    ) -> None:
+        """The reset is only observable with a NONZERO counter: cycles
+        1 and 3 are plain failures, cycle 2 classifies complete — with
+        max=2 the breaker never trips because the counter went
+        1 → 0 → 1, not 1 → 1 → 2 (#761)."""
+        _seed_activity_log(
+            tmp_path / "gimmes.db", [(2, "Cycle 2 complete", _ts(300))],
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700,
+                ),
+            ),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=3, pause_seconds=0,
+                max_consecutive_failures=2,
+            )
+
+        output = capsys.readouterr().out
+        assert output.count("failure 1/2") == 2
+        assert "failure 2/2" not in output
+        assert "Circuit breaker tripped" not in output
+
     def test_timeout_after_trade_path_not_counted(
         self, tmp_path, capsys,
     ) -> None:
-        """Hourly clamp shape (#761): trade path concluded, clamp
-        truncated only post-trade steps — breaker untouched."""
+        """Hourly clamp shape (#761): Closer concluded, clamp truncated
+        only post-trade steps — breaker untouched."""
         _seed_activity_log(
             tmp_path / "gimmes.db",
-            [(1, "Hourly 4c: dispatching Closer", _ts(300))],
+            [(1, "Closer executed 1 trades", _ts(300))],
         )
         with (
             patch("shutil.which", return_value="/usr/bin/claude"),
@@ -638,14 +674,79 @@ class TestAutonomousLoop:
             patch("gimmes.clubhouse.server.start_background", return_value=None),
         ):
             _autonomous_loop(
-                "driving_range", max_cycles=1,
+                "driving_range", max_cycles=1, pause_seconds=0,
                 max_consecutive_failures=1,
             )
 
-        output = capsys.readouterr().out
-        assert "trade path" in output
-        assert "not" in output and "counted as a failure" in output
+        # Rich wraps console lines — normalize before phrase asserts
+        output = " ".join(capsys.readouterr().out.split())
+        assert "post-trade steps truncated" in output
+        assert "counted as a failure" in output
         assert "Circuit breaker tripped" not in output
+
+    def test_trade_path_done_preserves_failure_counter(
+        self, tmp_path, capsys,
+    ) -> None:
+        """trade_path_done must PRESERVE the counter, not reset it:
+        failure (1/2) → trade-path kill (unchanged) → failure trips at
+        2/2 (#761). Fails if the branch resets like 'complete'."""
+        _seed_activity_log(
+            tmp_path / "gimmes.db",
+            [(2, "Closer executed 1 trades", _ts(300))],
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700,
+                ),
+            ),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=3, pause_seconds=0,
+                max_consecutive_failures=2,
+            )
+
+        output = capsys.readouterr().out
+        assert "failure 2/2" in output
+        assert "Circuit breaker tripped" in output
+
+    def test_timeout_without_output_writes_empty_log(
+        self, tmp_path,
+    ) -> None:
+        """Old-style TimeoutExpired (no output attached) still writes
+        the log file — empty, not absent (#761)."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700,
+                ),
+            ),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=1, pause_seconds=0,
+                max_consecutive_failures=1,
+            )
+
+        log_file = tmp_path / "logs" / "cycle-001.json"
+        assert log_file.exists()
+        assert log_file.read_bytes() == b""
 
     def test_timeout_feeds_circuit_breaker(self, capsys) -> None:
         """Consecutive timeouts trip the circuit breaker."""
@@ -1072,6 +1173,37 @@ class TestCommunicateInterruptible:
         block.set()
         assert excinfo.value.output == b'{"step": "research"}\n'
 
+    def test_timeout_accumulates_multiple_chunks(self) -> None:
+        """Chunks must ACCUMULATE, not overwrite (#761)."""
+        import threading
+
+        block = threading.Event()
+        chunks = [b'{"a": 1}\n', b'{"b": 2}\n']
+
+        def _read(*_):
+            if chunks:
+                return chunks.pop(0)
+            block.wait()
+            return b""
+
+        mock_proc = MagicMock()
+        mock_proc.args = ["claude"]
+        mock_proc.stdout.read = _read
+
+        with pytest.raises(_subprocess.TimeoutExpired) as excinfo:
+            _communicate_interruptible(mock_proc, timeout=0.3)
+
+        block.set()
+        assert excinfo.value.output == b'{"a": 1}\n{"b": 2}\n'
+
+    def test_success_concatenates_chunks(self) -> None:
+        mock_proc = _mock_popen()
+        mock_proc.stdout.read.side_effect = [b"cycle ", b"output", b""]
+
+        result = _communicate_interruptible(mock_proc, timeout=10)
+
+        assert result == b"cycle output"
+
     def test_raises_when_reader_hits_os_error(self) -> None:
         """Exceptions from proc.stdout.read() propagate to the caller."""
         mock_proc = MagicMock()
@@ -1161,15 +1293,27 @@ class TestClassifyTimeoutOutcome:
 
     @pytest.mark.parametrize("marker", [
         "Closer executed 1 trades",
-        "Closer skipped: 0 candidates approved (2 review_reject)",
-        "Hourly 4c: dispatching Closer",
+        "Closer executed 0 trades",
     ])
-    def test_trade_path_markers(self, tmp_path, since, marker) -> None:
+    def test_closer_concluded_markers(
+        self, tmp_path, since, marker,
+    ) -> None:
         db = tmp_path / "gimmes.db"
         _seed_activity_log(db, [(7, marker, _ts(60))])
         assert (
             _classify_timeout_outcome(db, 7, since) == "trade_path_done"
         )
+
+    def test_dispatch_marker_alone_is_failure(self, tmp_path, since) -> None:
+        # "Hourly 4c: dispatching Closer" fires BEFORE the Closer runs
+        # — a Closer hanging mid-order-placement must stay a failure,
+        # or the breaker goes blind to a permanently hanging Closer
+        # (review-found).
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(
+            db, [(7, "Hourly 4c: dispatching Closer", _ts(60))],
+        )
+        assert _classify_timeout_outcome(db, 7, since) == "failure"
 
     def test_complete_outranks_trade_path(self, tmp_path, since) -> None:
         db = tmp_path / "gimmes.db"

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -681,7 +681,7 @@ class TestAutonomousLoop:
         # Rich wraps console lines — normalize before phrase asserts
         output = " ".join(capsys.readouterr().out.split())
         assert "post-trade steps truncated" in output
-        assert "counted as a failure" in output
+        assert "not counted as a failure" in output
         assert "Circuit breaker tripped" not in output
 
     def test_trade_path_done_preserves_failure_counter(
@@ -718,6 +718,82 @@ class TestAutonomousLoop:
         output = capsys.readouterr().out
         assert "failure 2/2" in output
         assert "Circuit breaker tripped" in output
+
+    def test_failure_breaks_trade_path_kill_run(
+        self, tmp_path, capsys,
+    ) -> None:
+        """A real failure resets the unbroken-run counter: TPD, TPD,
+        failure, TPD → never reaches 3 consecutive, no shed warning
+        (Copilot-review-found on #763)."""
+        _seed_activity_log(
+            tmp_path / "gimmes.db",
+            [
+                (1, "Closer executed 1 trades", _ts(300)),
+                (2, "Closer executed 1 trades", _ts(300)),
+                (4, "Closer executed 1 trades", _ts(300)),
+            ],
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700,
+                ),
+            ),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=4, pause_seconds=0,
+                max_consecutive_failures=5,
+            )
+
+        output = " ".join(capsys.readouterr().out.split())
+        assert "consecutive clamp kills have truncated" not in output
+
+    def test_three_consecutive_trade_path_kills_warn(
+        self, tmp_path, capsys,
+    ) -> None:
+        """An UNBROKEN run of 3 trade-path kills prints the shed
+        warning — post-trade surveillance shed every cycle is a
+        capacity regression the operator must see (#761)."""
+        _seed_activity_log(
+            tmp_path / "gimmes.db",
+            [
+                (1, "Closer executed 1 trades", _ts(300)),
+                (2, "Closer executed 1 trades", _ts(300)),
+                (3, "Closer executed 1 trades", _ts(300)),
+            ],
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700,
+                ),
+            ),
+            patch("gimmes.cli._resilient_sleep"),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=3, pause_seconds=0,
+                max_consecutive_failures=5,
+            )
+
+        output = " ".join(capsys.readouterr().out.split())
+        assert "3 consecutive clamp kills have truncated" in output
 
     def test_timeout_without_output_writes_empty_log(
         self, tmp_path,

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -16,6 +16,7 @@ from gimmes.cli import (
     _autonomous_loop,
     _check_code_staleness,
     _check_remote_staleness,
+    _classify_timeout_outcome,
     _communicate_interruptible,
     _detect_api_error,
     _detect_rate_limit,
@@ -37,7 +38,9 @@ def _make_future_dt() -> datetime:
 def _mock_popen(returncode: int = 0, output: bytes = b"") -> MagicMock:
     """Return a mock Popen instance with the given returncode and stdout output."""
     mock_proc = MagicMock()
-    mock_proc.stdout.read.return_value = output
+    # Chunked-read semantics (#761): first read returns the output,
+    # the next returns b"" (EOF) — mirroring a real pipe.
+    mock_proc.stdout.read.side_effect = [output, b""]
     mock_proc.returncode = returncode
     mock_proc.pid = 12345
     mock_proc.args = ["claude"]
@@ -551,6 +554,99 @@ class TestAutonomousLoop:
         output = capsys.readouterr().out
         assert "timed out" in output
 
+    def test_timeout_writes_partial_cycle_log(self, tmp_path) -> None:
+        """A clamp-killed cycle writes the bytes it streamed (#761)."""
+        partial = b'{"step": "conferral"}'
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700, output=partial,
+                ),
+            ),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=1,
+                max_consecutive_failures=1,
+            )
+
+        log_file = tmp_path / "logs" / "cycle-001.json"
+        assert log_file.exists()
+        assert log_file.read_bytes() == partial
+
+    def test_timeout_after_complete_marker_resets_failures(
+        self, tmp_path, capsys,
+    ) -> None:
+        """c2134 shape (#761): 'Cycle N complete' logged before the
+        clamp — the kill is a process-exit race, not a failure."""
+        _seed_activity_log(
+            tmp_path / "gimmes.db", [(1, "Cycle 1 complete", _ts(300))],
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=2700,
+                ),
+            ),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=1,
+                max_consecutive_failures=1,
+            )
+
+        output = capsys.readouterr().out
+        assert "completed but overran" in output
+        assert "Circuit breaker tripped" not in output
+
+    def test_timeout_after_trade_path_not_counted(
+        self, tmp_path, capsys,
+    ) -> None:
+        """Hourly clamp shape (#761): trade path concluded, clamp
+        truncated only post-trade steps — breaker untouched."""
+        _seed_activity_log(
+            tmp_path / "gimmes.db",
+            [(1, "Hourly 4c: dispatching Closer", _ts(300))],
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.cli._communicate_interruptible",
+                side_effect=_subprocess.TimeoutExpired(
+                    cmd="claude", timeout=1740,
+                ),
+            ),
+            patch("os.killpg"),
+            patch("gimmes.clubhouse.server.start_background", return_value=None),
+        ):
+            _autonomous_loop(
+                "driving_range", max_cycles=1,
+                max_consecutive_failures=1,
+            )
+
+        output = capsys.readouterr().out
+        assert "trade path" in output
+        assert "not" in output and "counted as a failure" in output
+        assert "Circuit breaker tripped" not in output
+
     def test_timeout_feeds_circuit_breaker(self, capsys) -> None:
         """Consecutive timeouts trip the circuit breaker."""
         with (
@@ -946,12 +1042,35 @@ class TestCommunicateInterruptible:
         block = threading.Event()
         mock_proc = MagicMock()
         mock_proc.args = ["claude"]
-        mock_proc.stdout.read = lambda: (block.wait(), b"")[-1]
+        mock_proc.stdout.read = lambda *_: (block.wait(), b"")[-1]
 
         with pytest.raises(_subprocess.TimeoutExpired):
             _communicate_interruptible(mock_proc, timeout=0.1)
 
         block.set()  # Let daemon thread exit cleanly
+
+    def test_timeout_attaches_partial_output(self) -> None:
+        """Bytes streamed before the deadline ride the exception (#761)."""
+        import threading
+
+        block = threading.Event()
+        chunks = [b'{"step": "research"}\n']
+
+        def _read(*_):
+            if chunks:
+                return chunks.pop(0)
+            block.wait()
+            return b""
+
+        mock_proc = MagicMock()
+        mock_proc.args = ["claude"]
+        mock_proc.stdout.read = _read
+
+        with pytest.raises(_subprocess.TimeoutExpired) as excinfo:
+            _communicate_interruptible(mock_proc, timeout=0.3)
+
+        block.set()
+        assert excinfo.value.output == b'{"step": "research"}\n'
 
     def test_raises_when_reader_hits_os_error(self) -> None:
         """Exceptions from proc.stdout.read() propagate to the caller."""
@@ -983,6 +1102,111 @@ class TestCommunicateInterruptible:
             result = _communicate_interruptible(mock_proc, timeout=2700)
 
         assert result == b"cycle output"
+
+
+# ---------------------------------------------------------------------------
+# _classify_timeout_outcome (#761)
+# ---------------------------------------------------------------------------
+
+
+def _seed_activity_log(
+    db_path: Path, rows: list[tuple[int, str, str]],
+) -> None:
+    """Create a minimal activity_log and insert (cycle, message, ts) rows."""
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS activity_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cycle INTEGER NOT NULL DEFAULT 0,
+            agent TEXT NOT NULL DEFAULT '',
+            phase TEXT NOT NULL DEFAULT '',
+            message TEXT NOT NULL DEFAULT '',
+            details TEXT NOT NULL DEFAULT '',
+            timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+        )"""
+    )
+    conn.executemany(
+        "INSERT INTO activity_log (cycle, message, timestamp)"
+        " VALUES (?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _ts(offset_seconds: int) -> str:
+    """UTC activity_log timestamp string offset from now."""
+    return (
+        datetime.now(UTC) + timedelta(seconds=offset_seconds)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class TestClassifyTimeoutOutcome:
+    """#761: clamp kills are classified from the cycle's own
+    activity_log trail — completed cycles and concluded trade paths
+    must not feed the circuit breaker."""
+
+    @pytest.fixture()
+    def since(self) -> datetime:
+        return datetime.now(UTC) - timedelta(seconds=1)
+
+    def test_complete_marker(self, tmp_path, since) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(
+            db, [(7, "Cycle 7 complete [DEADLINE-SHED: Step 2]", _ts(60))],
+        )
+        assert _classify_timeout_outcome(db, 7, since) == "complete"
+
+    @pytest.mark.parametrize("marker", [
+        "Closer executed 1 trades",
+        "Closer skipped: 0 candidates approved (2 review_reject)",
+        "Hourly 4c: dispatching Closer",
+    ])
+    def test_trade_path_markers(self, tmp_path, since, marker) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(db, [(7, marker, _ts(60))])
+        assert (
+            _classify_timeout_outcome(db, 7, since) == "trade_path_done"
+        )
+
+    def test_complete_outranks_trade_path(self, tmp_path, since) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(db, [
+            (7, "Closer executed 1 trades", _ts(50)),
+            (7, "Cycle 7 complete", _ts(60)),
+        ])
+        assert _classify_timeout_outcome(db, 7, since) == "complete"
+
+    def test_no_markers_is_failure(self, tmp_path, since) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(
+            db, [(7, "Monitor checking open positions", _ts(60))],
+        )
+        assert _classify_timeout_outcome(db, 7, since) == "failure"
+
+    def test_other_cycles_markers_do_not_match(
+        self, tmp_path, since,
+    ) -> None:
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(db, [(6, "Cycle 6 complete", _ts(60))])
+        assert _classify_timeout_outcome(db, 7, since) == "failure"
+
+    def test_marker_from_before_this_run_is_ignored(
+        self, tmp_path, since,
+    ) -> None:
+        # Fresh-DB restart guard: a same-numbered cycle from an earlier
+        # loop run sits BEFORE since_utc and must not match.
+        db = tmp_path / "gimmes.db"
+        _seed_activity_log(db, [(7, "Cycle 7 complete", _ts(-3600))])
+        assert _classify_timeout_outcome(db, 7, since) == "failure"
+
+    def test_unreadable_db_is_failure(self, tmp_path, since) -> None:
+        # Conservative default: telemetry problems never blind the
+        # circuit breaker.
+        missing = tmp_path / "nope.db"
+        assert _classify_timeout_outcome(missing, 7, since) == "failure"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #761.

## What

Two-day diagnosis (2026-08-04/05) split seven timed-out cycles into three signatures: silent tail stalls burning the full clamp with zero evidence (c2130, c2137), a completed-but-not-exited race counted as failure (c2134: `Cycle complete` logged 24s before the kill), and routine hourly clamp kills of sheddable post-trade steps (c2126/29/33/35). All seven fed the consecutive-failure breaker, which touched 3/5 on a day with zero real failures.

### 1. Partial cycle logs on timeout
`_communicate_interruptible` now reads stdout in 64KB chunks into a locked buffer; on deadline it kills the process group first (`kill_on_timeout=True` — the dying flush is the closest evidence to the stall point), then attaches everything streamed to `TimeoutExpired.output`. The loop's timeout branch writes it via the shared `_write_cycle_log`. A stalled cycle now leaves its transcript instead of nothing — closing the long-standing "timed-out cycles write no per-cycle JSON log" gap.

### 2. Clamp-kill classification (breaker fairness)
`_classify_timeout_outcome` reads the killed cycle's own activity trail (read-only sqlite, scoped by `cycle` column + start-time bound against fresh-DB restarts):

- **`complete`** — `Cycle N complete` logged → failures reset; the kill was a process-exit race.
- **`trade_path_done`** — `Closer executed N trades` logged → counter *preserved, not reset*; the clamp truncated only steps the deadline protocol already deems sheddable. An unbroken run of 3+ warns loudly (capacity regression stays visible).
- **`failure`** — anything else, including a Closer that logged its dispatch marker but never concluded (review-found blind spot: a Closer hanging mid-order-placement must keep feeding the breaker). DB errors log a warning and default to failure — the breaker never loses coverage to a telemetry problem.

Both classification markers are **mandated prompt templates** (caddie-master.md Step 8, closer.md completion), hoisted to constants and pinned by a new drift-guard test — a prompt rewording cannot silently degrade every clamp kill back to "failure".

Both non-failure paths sleep through `_sleep_with_resting_sweep` before respawning (no hot clamp-kill/respawn loops; rest-on-miss orders keep their sweep window — review-found).

## Review

Three review agents (correctness / altitude / test-coverage) ran before this PR; all substantive findings addressed: phantom `"Closer skipped"` marker removed, pre-dispatch marker demoted to failure, reset-vs-preserve counter semantics pinned by tests that fail if either branch changes, kill-then-snapshot ordering, multi-chunk accumulation coverage. The proposed inactivity watchdog was deliberately dropped — legitimate silent sub-agent dispatches run 9–26 min, so any safe threshold adds nothing over the absolute clamp (rationale on the issue).

## Testing

- 19 new/updated targeted tests green in <1s (classifier, chunked reader, drift guard)
- 6 loop-level tests pin the breaker semantics (reset on complete, preserve on trade_path_done, partial-log writes incl. `output=None`)
- Frozen full unit suite gate: 2287 passed / 3 failed — all three were test closures not accepting the new `kill_on_timeout` kwarg; fixed test-side (signature only) and re-passed targeted. No source changes after the gate.
- mypy delta vs baseline: zero (97 pre-existing, unchanged)

https://claude.ai/code/session_01QfSxxQS6EK455D2WnWSqLY
