### PR TITLE
Book-depth telemetry at order placement (#762)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -822,6 +822,30 @@ def validate(
     _run(_validate())
 
 
+def _depth_snapshot(
+    orderbook,  # type: ignore[no-untyped-def]
+    side: str,
+    limit_price: float,
+) -> tuple[int, int, float | None]:
+    """Displayed depth at order placement, in the ORDER's side terms (#762).
+
+    Returns ``(touch_qty, executable_within_limit, best_implied_ask)``:
+    contracts displayed at the best opposing level, contracts executable
+    at or under ``limit_price``, and the best implied ask price (None on
+    a one-sided book). Volume/OI pass the scanner's liquidity gates
+    while saying nothing about instantaneous depth at the limit — the
+    only number that governs the fill (a 686-contract order filled
+    1-of-686 at a 1-contract touch, 2026-08-04).
+    """
+    opposing = orderbook.no_bids if side == "yes" else orderbook.yes_bids
+    if not opposing:
+        return 0, 0, None
+    touch_qty = opposing[0].quantity
+    best_ask = round(1.0 - opposing[0].price, 2)
+    executable = orderbook.depth_at_price(limit_price, side)
+    return touch_qty, executable, best_ask
+
+
 @app.command(rich_help_panel="Trading")
 def order(
     ticker: str = typer.Argument(..., help="Market ticker"),
@@ -1313,6 +1337,18 @@ def order(
                     result = await broker.create_order(params, orderbook, fees=fees)
                     label = "[yellow]PAPER[/yellow] "
                 else:
+                    # #762: depth telemetry wants the book even on the
+                    # real path — but a failed snapshot fetch must
+                    # never block a real order.
+                    orderbook = None
+                    if is_buy:
+                        try:
+                            orderbook = await get_orderbook(client, ticker)
+                        except Exception:
+                            logger.debug(
+                                "Depth snapshot fetch failed (#762)",
+                                exc_info=True,
+                            )
                     from gimmes.kalshi.orders import create_order
 
                     result = await create_order(client, params)
@@ -1387,6 +1423,61 @@ def order(
                     logger.error("Failed to log error to DB", exc_info=True)
                 console.print(f"[red bold]Order FAILED: {exc}[/red bold]")
                 raise typer.Exit(1)
+
+            # #762: record displayed depth for every BUY — including
+            # canceled no-fills, which are exactly the thin-touch case
+            # the telemetry exists to measure. Never blocks the order
+            # flow; failures degrade to an error log line.
+            if is_buy and orderbook is not None:
+                try:
+                    import os as _os
+
+                    from gimmes.store.queries import insert_activity
+
+                    touch_qty, executable, best_ask = _depth_snapshot(
+                        orderbook, side, final_price,
+                    )
+                    shown_ask = (
+                        f"${best_ask:.2f}" if best_ask is not None
+                        else "one-sided"
+                    )
+                    console.print(
+                        f"[dim]Depth: touch {touch_qty} @ {shown_ask},"
+                        f" executable within ${final_price:.2f} limit:"
+                        f" {executable} (sized {final_count})"
+                        f" (#762)[/dim]"
+                    )
+                    _session_env = _os.getenv("GIMMES_SESSION_ID")
+                    await insert_activity(
+                        db,
+                        cycle=int(_os.getenv("GIMMES_CYCLE", "0") or 0),
+                        agent=agent,
+                        phase="info",
+                        message=(
+                            f"Depth: {ticker} sized {final_count}"
+                            f" {side.upper()} @ ${final_price:.2f} —"
+                            f" touch {touch_qty}, executable-within-"
+                            f"limit {executable} (#762)"
+                        ),
+                        details=json.dumps({
+                            "ticker": ticker,
+                            "side": side,
+                            "sized": final_count,
+                            "limit_price": final_price,
+                            "touch_qty": touch_qty,
+                            "executable_within_limit": executable,
+                            "best_implied_ask": best_ask,
+                            "order_status": result.status,
+                        }),
+                        session_id=(
+                            int(_session_env) if _session_env else None
+                        ),
+                    )
+                except Exception:
+                    logger.error(
+                        "Depth telemetry failed for %s (#762)",
+                        ticker, exc_info=True,
+                    )
 
             if result.status == "canceled":
                 # #690: a canceled order placed NOTHING — green

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -822,30 +822,6 @@ def validate(
     _run(_validate())
 
 
-def _depth_snapshot(
-    orderbook,  # type: ignore[no-untyped-def]
-    side: str,
-    limit_price: float,
-) -> tuple[int, int, float | None]:
-    """Displayed depth at order placement, in the ORDER's side terms (#762).
-
-    Returns ``(touch_qty, executable_within_limit, best_implied_ask)``:
-    contracts displayed at the best opposing level, contracts executable
-    at or under ``limit_price``, and the best implied ask price (None on
-    a one-sided book). Volume/OI pass the scanner's liquidity gates
-    while saying nothing about instantaneous depth at the limit — the
-    only number that governs the fill (a 686-contract order filled
-    1-of-686 at a 1-contract touch, 2026-08-04).
-    """
-    opposing = orderbook.no_bids if side == "yes" else orderbook.yes_bids
-    if not opposing:
-        return 0, 0, None
-    touch_qty = opposing[0].quantity
-    best_ask = round(1.0 - opposing[0].price, 2)
-    executable = orderbook.depth_at_price(limit_price, side)
-    return touch_qty, executable, best_ask
-
-
 @app.command(rich_help_panel="Trading")
 def order(
     ticker: str = typer.Argument(..., help="Market ticker"),
@@ -1338,12 +1314,17 @@ def order(
                     label = "[yellow]PAPER[/yellow] "
                 else:
                     # #762: depth telemetry wants the book even on the
-                    # real path — but a failed snapshot fetch must
-                    # never block a real order.
+                    # real path — but a failed OR SLOW snapshot fetch
+                    # must never delay a real, deadline-sensitive
+                    # order (the client's own timeout is 30s; 2s is
+                    # the most telemetry may cost pre-placement).
                     orderbook = None
                     if is_buy:
                         try:
-                            orderbook = await get_orderbook(client, ticker)
+                            async with asyncio.timeout(2):
+                                orderbook = await get_orderbook(
+                                    client, ticker,
+                                )
                         except Exception:
                             logger.debug(
                                 "Depth snapshot fetch failed (#762)",
@@ -1434,8 +1415,8 @@ def order(
 
                     from gimmes.store.queries import insert_activity
 
-                    touch_qty, executable, best_ask = _depth_snapshot(
-                        orderbook, side, final_price,
+                    touch_qty, executable, best_ask = (
+                        orderbook.depth_snapshot(side, final_price)
                     )
                     shown_ask = (
                         f"${best_ask:.2f}" if best_ask is not None
@@ -1447,10 +1428,26 @@ def order(
                         f" {executable} (sized {final_count})"
                         f" (#762)[/dim]"
                     )
-                    _session_env = _os.getenv("GIMMES_SESSION_ID")
+                    # Malformed env degrades ONE field, never the row —
+                    # a bad export is session-wide, and int() raising
+                    # here would silently kill the whole telemetry
+                    # stream for that session (review-found).
+                    try:
+                        _cycle_env = int(
+                            _os.getenv("GIMMES_CYCLE", "0") or 0,
+                        )
+                    except ValueError:
+                        _cycle_env = 0
+                    try:
+                        _session_raw = _os.getenv("GIMMES_SESSION_ID")
+                        _session_env = (
+                            int(_session_raw) if _session_raw else None
+                        )
+                    except ValueError:
+                        _session_env = None
                     await insert_activity(
                         db,
-                        cycle=int(_os.getenv("GIMMES_CYCLE", "0") or 0),
+                        cycle=_cycle_env,
                         agent=agent,
                         phase="info",
                         message=(
@@ -1468,10 +1465,9 @@ def order(
                             "executable_within_limit": executable,
                             "best_implied_ask": best_ask,
                             "order_status": result.status,
+                            "order_id": result.order_id,
                         }),
-                        session_id=(
-                            int(_session_env) if _session_env else None
-                        ),
+                        session_id=_session_env,
                     )
                 except Exception:
                     logger.error(

--- a/src/gimmes/models/market.py
+++ b/src/gimmes/models/market.py
@@ -113,3 +113,26 @@ class Orderbook(BaseModel):
                 if implied_ask <= price:
                     total += level.quantity
         return total
+
+    def depth_snapshot(
+        self, side: str, limit_price: float,
+    ) -> tuple[int, int, float | None]:
+        """Displayed depth for a buyer of ``side``, in that side's terms (#762).
+
+        Returns ``(touch_qty, executable_within_limit, best_implied_ask)``:
+        contracts displayed at the best opposing level, contracts
+        executable at or under ``limit_price``, and the best implied ask
+        price (None on a one-sided book). The touch is found by best
+        PRICE, not array position — the parser copies the API arrays
+        verbatim and guarantees no ordering (review-found: a best-last
+        book would otherwise report the far end of the ladder as the
+        touch, inverting the thin-touch signal this exists to record).
+        """
+        opposing = self.no_bids if side == "yes" else self.yes_bids
+        if not opposing:
+            return 0, 0, None
+        best = max(opposing, key=lambda level: level.price)
+        touch_qty = best.quantity
+        best_ask = round(1.0 - best.price, 2)
+        executable = self.depth_at_price(limit_price, side)
+        return touch_qty, executable, best_ask

--- a/tests/unit/test_churn_guard.py
+++ b/tests/unit/test_churn_guard.py
@@ -382,10 +382,6 @@ class TestSellRoundtripWarning:
 
         with (
             patch(
-                "gimmes.store.queries.get_last_entry_trade",
-                AsyncMock(return_value=open_row),
-            ),
-            patch(
                 "gimmes.store.queries.get_entry_analytics",
                 AsyncMock(return_value=None),
             ),
@@ -394,8 +390,12 @@ class TestSellRoundtripWarning:
                 AsyncMock(return_value=None),
             ),
         ):
+            # last_entry rides the harness param — an outer
+            # get_last_entry_trade patch would be overridden by the
+            # harness's own inner patch (#762 harness change).
             result, console, insert_error = h._run_order_cli(
                 broker, sync_side_effect=_sync,
+                last_entry=open_row,
                 cli_args=[
                     "order", "TEST-TICKER", "--action", "sell",
                     "--side", "yes", "--count", "10",

--- a/tests/unit/test_depth_telemetry.py
+++ b/tests/unit/test_depth_telemetry.py
@@ -8,12 +8,14 @@ against a 1-contract touch.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from gimmes.models.market import Orderbook, OrderbookLevel
 
 
 def _book(
-    yes_bids: list[tuple[float, int]] = (),
-    no_bids: list[tuple[float, int]] = (),
+    yes_bids: Sequence[tuple[float, int]] = (),
+    no_bids: Sequence[tuple[float, int]] = (),
 ) -> Orderbook:
     return Orderbook(
         ticker="KXTEST-MKT",

--- a/tests/unit/test_depth_telemetry.py
+++ b/tests/unit/test_depth_telemetry.py
@@ -1,4 +1,4 @@
-"""Tests for _depth_snapshot — displayed depth at order placement (#762).
+"""Tests for Orderbook.depth_snapshot — displayed depth at placement (#762).
 
 Depth is judged in the ORDER's own side terms: a NO buyer's asks are
 implied from YES bids (1 - bid) and vice versa. Volume/OI say nothing
@@ -8,7 +8,6 @@ against a 1-contract touch.
 
 from __future__ import annotations
 
-from gimmes.cli import _depth_snapshot
 from gimmes.models.market import Orderbook, OrderbookLevel
 
 
@@ -32,14 +31,14 @@ class TestDepthSnapshot:
         # yes_bid 0.42 -> implied NO ask 0.58 (touch, 1 contract);
         # yes_bid 0.40 -> implied NO ask 0.60 (outside a 0.58 limit).
         book = _book(yes_bids=[(0.42, 1), (0.40, 500)])
-        touch, executable, best_ask = _depth_snapshot(book, "no", 0.58)
+        touch, executable, best_ask = book.depth_snapshot("no", 0.58)
         assert touch == 1
         assert executable == 1
         assert best_ask == 0.58
 
     def test_limit_above_second_level_includes_it(self) -> None:
         book = _book(yes_bids=[(0.42, 1), (0.40, 500)])
-        touch, executable, best_ask = _depth_snapshot(book, "no", 0.60)
+        touch, executable, best_ask = book.depth_snapshot("no", 0.60)
         assert touch == 1
         assert executable == 501
         assert best_ask == 0.58
@@ -49,15 +48,26 @@ class TestDepthSnapshot:
         book = _book(
             yes_bids=[(0.40, 99)], no_bids=[(0.55, 30), (0.50, 70)],
         )
-        touch, executable, best_ask = _depth_snapshot(book, "yes", 0.45)
+        touch, executable, best_ask = book.depth_snapshot("yes", 0.45)
         assert touch == 30
         assert executable == 30
         assert best_ask == 0.45
 
+    def test_touch_found_by_price_not_array_position(self) -> None:
+        # The parser copies API arrays verbatim with no ordering
+        # contract — a best-LAST (ascending) book must still report
+        # the true touch, not the far end of the ladder
+        # (review-found: [0] would report 5000 @ $0.99 here).
+        book = _book(yes_bids=[(0.01, 5000), (0.40, 500), (0.42, 1)])
+        touch, executable, best_ask = book.depth_snapshot("no", 0.58)
+        assert touch == 1
+        assert executable == 1
+        assert best_ask == 0.58
+
     def test_one_sided_book_is_zero_depth(self) -> None:
         # NO buyer with no YES bids anywhere: nothing to take.
         book = _book(no_bids=[(0.55, 30)])
-        touch, executable, best_ask = _depth_snapshot(book, "no", 0.58)
+        touch, executable, best_ask = book.depth_snapshot("no", 0.58)
         assert touch == 0
         assert executable == 0
         assert best_ask is None
@@ -66,7 +76,17 @@ class TestDepthSnapshot:
         # Book displayed but the limit misses it — the rest-on-miss
         # shape: touch is visible, executable is zero.
         book = _book(yes_bids=[(0.42, 100)])
-        touch, executable, best_ask = _depth_snapshot(book, "no", 0.50)
+        touch, executable, best_ask = book.depth_snapshot("no", 0.50)
         assert touch == 100
         assert executable == 0
+        assert best_ask == 0.58
+
+    def test_zero_quantity_touch_level(self) -> None:
+        # The parser does not filter zero-quantity levels: touch
+        # reports the DISPLAYED top level (possibly a stale zero)
+        # while executable counts the real depth behind it.
+        book = _book(yes_bids=[(0.42, 0), (0.40, 500)])
+        touch, executable, best_ask = book.depth_snapshot("no", 0.60)
+        assert touch == 0
+        assert executable == 500
         assert best_ask == 0.58

--- a/tests/unit/test_depth_telemetry.py
+++ b/tests/unit/test_depth_telemetry.py
@@ -1,0 +1,72 @@
+"""Tests for _depth_snapshot — displayed depth at order placement (#762).
+
+Depth is judged in the ORDER's own side terms: a NO buyer's asks are
+implied from YES bids (1 - bid) and vice versa. Volume/OI say nothing
+about instantaneous depth at the limit — the 2026-08-04 fill sized 686
+against a 1-contract touch.
+"""
+
+from __future__ import annotations
+
+from gimmes.cli import _depth_snapshot
+from gimmes.models.market import Orderbook, OrderbookLevel
+
+
+def _book(
+    yes_bids: list[tuple[float, int]] = (),
+    no_bids: list[tuple[float, int]] = (),
+) -> Orderbook:
+    return Orderbook(
+        ticker="KXTEST-MKT",
+        yes_bids=[
+            OrderbookLevel(price=p, quantity=q) for p, q in yes_bids
+        ],
+        no_bids=[
+            OrderbookLevel(price=p, quantity=q) for p, q in no_bids
+        ],
+    )
+
+
+class TestDepthSnapshot:
+    def test_no_buyer_reads_yes_bids(self) -> None:
+        # yes_bid 0.42 -> implied NO ask 0.58 (touch, 1 contract);
+        # yes_bid 0.40 -> implied NO ask 0.60 (outside a 0.58 limit).
+        book = _book(yes_bids=[(0.42, 1), (0.40, 500)])
+        touch, executable, best_ask = _depth_snapshot(book, "no", 0.58)
+        assert touch == 1
+        assert executable == 1
+        assert best_ask == 0.58
+
+    def test_limit_above_second_level_includes_it(self) -> None:
+        book = _book(yes_bids=[(0.42, 1), (0.40, 500)])
+        touch, executable, best_ask = _depth_snapshot(book, "no", 0.60)
+        assert touch == 1
+        assert executable == 501
+        assert best_ask == 0.58
+
+    def test_yes_buyer_reads_no_bids(self) -> None:
+        # no_bid 0.55 -> implied YES ask 0.45 (touch, 30 contracts)
+        book = _book(
+            yes_bids=[(0.40, 99)], no_bids=[(0.55, 30), (0.50, 70)],
+        )
+        touch, executable, best_ask = _depth_snapshot(book, "yes", 0.45)
+        assert touch == 30
+        assert executable == 30
+        assert best_ask == 0.45
+
+    def test_one_sided_book_is_zero_depth(self) -> None:
+        # NO buyer with no YES bids anywhere: nothing to take.
+        book = _book(no_bids=[(0.55, 30)])
+        touch, executable, best_ask = _depth_snapshot(book, "no", 0.58)
+        assert touch == 0
+        assert executable == 0
+        assert best_ask is None
+
+    def test_limit_below_best_ask_is_zero_executable(self) -> None:
+        # Book displayed but the limit misses it — the rest-on-miss
+        # shape: touch is visible, executable is zero.
+        book = _book(yes_bids=[(0.42, 100)])
+        touch, executable, best_ask = _depth_snapshot(book, "no", 0.50)
+        assert touch == 100
+        assert executable == 0
+        assert best_ask == 0.58

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -95,6 +95,7 @@ def _run_order_cli(
     insert_error_side_effect=None, extra_args=None, market=None,
     snapshot_mock=None, validation=None, cli_args=None,
     last_close=None, last_close_effect=None, config=None,
+    orderbook=None, insert_activity_mock=None,
 ):
     """Invoke the order CLI command with a mocked broker.
 
@@ -136,7 +137,20 @@ def _run_order_cli(
             snapshot_mock if snapshot_mock is not None
             else AsyncMock(return_value=True),
         ),
-        patch("gimmes.kalshi.markets.get_orderbook", AsyncMock(return_value=MagicMock())),
+        patch(
+            "gimmes.kalshi.markets.get_orderbook",
+            AsyncMock(
+                return_value=orderbook if orderbook is not None
+                else MagicMock(),
+            ),
+        ),
+        # #762: depth telemetry writes an activity row after placement;
+        # always mocked so no test touches the mocked DB's internals.
+        patch(
+            "gimmes.store.queries.insert_activity",
+            insert_activity_mock if insert_activity_mock is not None
+            else AsyncMock(return_value=1),
+        ),
         patch("gimmes.strategy.fee_cache.get_multipliers", MagicMock(return_value=mock_fees)),
         patch(
             "gimmes.risk.validator.validate_trade",
@@ -156,6 +170,13 @@ def _run_order_cli(
             AsyncMock(
                 return_value=last_close, side_effect=last_close_effect,
             ),
+        ),
+        # #661 sell path: round-trip churn check reads the last entry;
+        # None keeps it out of unrelated tests (mocked DB rows are not
+        # dict()-able).
+        patch(
+            "gimmes.store.queries.get_last_entry_trade",
+            AsyncMock(return_value=None),
         ),
     ]
 
@@ -1260,3 +1281,103 @@ class TestRestOnMissCli:
         params = create_order.call_args.args[1]
         assert params.expiration_ts is None
         assert "paper-only" in _printed(mock_console)
+
+
+# ---------------------------------------------------------------------------
+# Depth telemetry at placement (#762)
+# ---------------------------------------------------------------------------
+
+
+class TestDepthTelemetry:
+    """#762: every BUY records displayed depth at placement — touch
+    quantity and executable-within-limit — as an activity row. The
+    686-sized/1-filled order of 2026-08-04 was invisible to analysis
+    because depth was recorded nowhere."""
+
+    @staticmethod
+    def _thin_touch_book():
+        from gimmes.models.market import Orderbook, OrderbookLevel
+
+        # NO buyer at 0.58: touch (yes_bid 0.42 -> implied NO ask 0.58)
+        # shows only 1 contract; a worse level (yes_bid 0.40 -> ask
+        # 0.60) is outside the 0.58 limit.
+        return Orderbook(
+            ticker="TEST-TICKER",
+            yes_bids=[
+                OrderbookLevel(price=0.42, quantity=1),
+                OrderbookLevel(price=0.40, quantity=500),
+            ],
+            no_bids=[OrderbookLevel(price=0.40, quantity=200)],
+        )
+
+    def test_buy_writes_depth_activity_row(self) -> None:
+        activity = AsyncMock(return_value=1)
+        broker = _make_mock_broker()
+
+        result, mock_console, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "686",
+                "--price", "58", "--yes", "--agent", "closer",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        activity.assert_awaited_once()
+        kwargs = activity.await_args.kwargs
+        assert kwargs["agent"] == "closer"
+        assert kwargs["message"].startswith("Depth: TEST-TICKER")
+        details = json.loads(kwargs["details"])
+        assert details["sized"] == 686
+        assert details["touch_qty"] == 1
+        assert details["executable_within_limit"] == 1
+        assert details["best_implied_ask"] == 0.58
+        assert "Depth:" in _printed(mock_console)
+
+    def test_sell_writes_no_depth_row(self) -> None:
+        activity = AsyncMock(return_value=1)
+        broker = _make_mock_broker()
+        broker.get_positions = AsyncMock(return_value=[
+            Position(
+                ticker="TEST-TICKER", side="yes", count=20,
+                avg_price=0.30, current_price=0.40,
+            ),
+        ])
+
+        result, mock_console, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER", "--action", "sell",
+                "--side", "yes", "--count", "10", "--price", "40",
+                "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        # The mocked-DB harness cannot run the sell path's post-order
+        # sync to completion; "Order placed" proves execution passed
+        # THROUGH the depth-telemetry site without writing a row.
+        assert "Order placed" in _printed(mock_console)
+        activity.assert_not_awaited()
+
+    def test_telemetry_failure_never_blocks_the_order(self) -> None:
+        activity = AsyncMock(side_effect=RuntimeError("db locked"))
+        broker = _make_mock_broker()
+
+        result, mock_console, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        assert "Order placed" in _printed(mock_console)

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -96,7 +96,7 @@ def _run_order_cli(
     snapshot_mock=None, validation=None, cli_args=None,
     last_close=None, last_close_effect=None, config=None,
     orderbook=None, orderbook_side_effect=None,
-    insert_activity_mock=None,
+    insert_activity_mock=None, last_entry=None,
 ):
     """Invoke the order CLI command with a mocked broker.
 
@@ -174,11 +174,13 @@ def _run_order_cli(
             ),
         ),
         # #661 sell path: round-trip churn check reads the last entry;
-        # None keeps it out of unrelated tests (mocked DB rows are not
-        # dict()-able).
+        # None default keeps it out of unrelated tests (mocked DB rows
+        # are not dict()-able). Patched INSIDE the harness, so callers
+        # needing a row must pass `last_entry`, not an outer patch —
+        # this one starts later and wins.
         patch(
             "gimmes.store.queries.get_last_entry_trade",
-            AsyncMock(return_value=None),
+            AsyncMock(return_value=last_entry),
         ),
     ]
 

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from gimmes.models.error import ErrorCategory, ErrorSeverity
+from gimmes.models.market import Orderbook
 from gimmes.models.order import Order, OrderAction, OrderSide
 from gimmes.models.portfolio import Position
 from gimmes.models.trade import TradeDecision
@@ -141,8 +142,11 @@ def _run_order_cli(
         patch(
             "gimmes.kalshi.markets.get_orderbook",
             AsyncMock(
+                # A real (empty) book by default: a MagicMock would
+                # shunt every unrelated BUY test through the #762
+                # telemetry exception path with logger.error noise.
                 return_value=orderbook if orderbook is not None
-                else MagicMock(),
+                else Orderbook(ticker="TEST-TICKER"),
                 side_effect=orderbook_side_effect,
             ),
         ),

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -95,7 +95,8 @@ def _run_order_cli(
     insert_error_side_effect=None, extra_args=None, market=None,
     snapshot_mock=None, validation=None, cli_args=None,
     last_close=None, last_close_effect=None, config=None,
-    orderbook=None, insert_activity_mock=None,
+    orderbook=None, orderbook_side_effect=None,
+    insert_activity_mock=None,
 ):
     """Invoke the order CLI command with a mocked broker.
 
@@ -142,6 +143,7 @@ def _run_order_cli(
             AsyncMock(
                 return_value=orderbook if orderbook is not None
                 else MagicMock(),
+                side_effect=orderbook_side_effect,
             ),
         ),
         # #762: depth telemetry writes an activity row after placement;
@@ -1381,3 +1383,186 @@ class TestDepthTelemetry:
 
         assert result.exit_code == 0
         assert "Order placed" in _printed(mock_console)
+
+
+class TestDepthTelemetryOutcomes:
+    """#762 review round: canceled no-fills (the headline thin-touch
+    case), the championship arm, resting orders, and env plumbing."""
+
+    @staticmethod
+    def _thin_touch_book():
+        return TestDepthTelemetry._thin_touch_book()
+
+    def test_canceled_order_still_writes_depth_row(self) -> None:
+        """The canceled no-fill IS the thin-touch case the telemetry
+        exists to measure — the row must land before the exit-1."""
+        activity = AsyncMock(return_value=1)
+        canceled = _ok_order(status="canceled")
+        canceled.reason = "not filled"
+        broker = _make_mock_broker(create_order_side_effect=None)
+        broker.create_order = AsyncMock(return_value=canceled)
+
+        result, mock_console, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 1
+        assert "Order NOT placed" in _printed(mock_console)
+        activity.assert_awaited_once()
+        details = json.loads(activity.await_args.kwargs["details"])
+        assert details["order_status"] == "canceled"
+        assert details["order_id"] == "order-123"
+
+    def test_happy_path_details_carry_status_and_order_id(self) -> None:
+        activity = AsyncMock(return_value=1)
+        broker = _make_mock_broker()
+
+        result, _, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        details = json.loads(activity.await_args.kwargs["details"])
+        assert details["order_status"] == "executed"
+        assert details["order_id"] == "order-123"
+
+    def test_championship_buy_writes_depth_row(self) -> None:
+        activity = AsyncMock(return_value=1)
+        champ = _stub_config()
+        champ.is_championship = True
+
+        result, _, _ = _run_order_cli(
+            None, config=champ,
+            championship_create_order=AsyncMock(return_value=_ok_order()),
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        activity.assert_awaited_once()
+        details = json.loads(activity.await_args.kwargs["details"])
+        assert details["touch_qty"] == 1
+
+    def test_championship_fetch_failure_never_blocks_order(self) -> None:
+        """The 2s-bounded snapshot fetch failing must not stop a real
+        order — order places, no depth row."""
+        activity = AsyncMock(return_value=1)
+        champ = _stub_config()
+        champ.is_championship = True
+        create_order = AsyncMock(return_value=_ok_order())
+
+        result, mock_console, _ = _run_order_cli(
+            None, config=champ,
+            championship_create_order=create_order,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook_side_effect=httpx.ConnectError("book down"),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        assert "Order placed" in _printed(mock_console)
+        create_order.assert_awaited_once()
+        activity.assert_not_awaited()
+
+    def test_resting_order_writes_depth_row(self) -> None:
+        """Rest-on-miss shape: touch visible, executable 0 — the row
+        records the miss."""
+        from gimmes.models.market import Orderbook, OrderbookLevel
+
+        activity = AsyncMock(return_value=1)
+        resting = _ok_order(status="resting")
+        broker = _make_mock_broker()
+        broker.create_order = AsyncMock(return_value=resting)
+        # Limit 40 misses the touch (implied NO ask 0.58)
+        missing_book = Orderbook(
+            ticker="TEST-TICKER",
+            yes_bids=[OrderbookLevel(price=0.42, quantity=100)],
+        )
+
+        result, _, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "40", "--yes",
+            ],
+            orderbook=missing_book,
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        details = json.loads(activity.await_args.kwargs["details"])
+        assert details["order_status"] == "resting"
+        assert details["executable_within_limit"] == 0
+        assert details["touch_qty"] == 100
+
+    def test_cycle_and_session_env_reach_activity_row(
+        self, monkeypatch,
+    ) -> None:
+        activity = AsyncMock(return_value=1)
+        monkeypatch.setenv("GIMMES_CYCLE", "7")
+        monkeypatch.setenv("GIMMES_SESSION_ID", "42")
+        broker = _make_mock_broker()
+
+        _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        kwargs = activity.await_args.kwargs
+        assert kwargs["cycle"] == 7
+        assert kwargs["session_id"] == 42
+
+    def test_garbage_env_degrades_field_not_row(self, monkeypatch) -> None:
+        """A bad export is session-wide — it must cost one field, not
+        every depth row of the session (review-found)."""
+        activity = AsyncMock(return_value=1)
+        monkeypatch.setenv("GIMMES_CYCLE", "abc")
+        monkeypatch.setenv("GIMMES_SESSION_ID", "3.0")
+        broker = _make_mock_broker()
+
+        result, _, _ = _run_order_cli(
+            broker,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "no", "--count", "10",
+                "--price", "58", "--yes",
+            ],
+            orderbook=self._thin_touch_book(),
+            insert_activity_mock=activity,
+        )
+
+        assert result.exit_code == 0
+        activity.assert_awaited_once()
+        kwargs = activity.await_args.kwargs
+        assert kwargs["cycle"] == 0
+        assert kwargs["session_id"] is None


### PR DESCRIPTION
Closes #762.

## What

On 2026-08-04 the Closer sized 686 NO contracts against a displayed touch of exactly 1 — 1 filled, 685 rested and expired. Volume (164k) and OI (56k) passed every liquidity gate while saying nothing about the only number that governs the fill: instantaneous displayed depth at the limit. That number was recorded nowhere.

**Telemetry only, per the issue scope** — sizing and reservation policy stay unchanged until data exists (same doctrine as #759: measure first, decide with numbers).

- `Orderbook.depth_snapshot(side, limit_price)` — new model method beside `depth_at_price`, returning `(touch_qty, executable_within_limit, best_implied_ask)` in the order's own side terms. The touch is found by best **price**, not array position: the parser copies API arrays verbatim with no ordering contract, and a best-last book would have inverted the exact thin-touch signal this exists to record (review-found).
- Every BUY logs a `Depth:` console line and an `activity_log` row: greppable message + structured `details` JSON (`ticker, side, sized, limit_price, touch_qty, executable_within_limit, best_implied_ask, order_status, order_id`). `order_id` makes joins to `trades` / `paper_orders` / `paper_fills` exact — including canceled no-fills, which write no trades row and are precisely the thin-touch case.
- Canceled and resting orders get rows too (status included), not just fills.
- Championship path: the book is fetched for telemetry with a **2-second bound** — a slow orderbook endpoint may never delay a real, deadline-sensitive order (the client's own timeout is 30s). Fetch failure skips the row, never the order.
- Telemetry failures degrade to a `logger.error` line; malformed `GIMMES_CYCLE`/`GIMMES_SESSION_ID` costs one field, never the row (a bad export is session-wide).

### Deviation from the issue text, deliberate
The issue asked for columns "in the order/trade row". This ships the activity_log row with details JSON instead — no schema migration for a telemetry experiment whose consumer is a #759-style funnel analysis reading `trades + activity_log`. activity_log is append-only (no pruning exists anywhere in the codebase), so durability is identical. **Note for future maintainers: these depth rows are load-bearing telemetry for the #762 follow-up analysis — any future log-rotation feature must exclude them.** The analysis denominator must come from trades/paper_orders, not from counting depth rows (a failed real-path fetch skips the row).

## Review

Three review agents (correctness / altitude / test-coverage) ran pre-PR. All substantive findings addressed: ordering-independent touch (correctness), helper moved onto `Orderbook` next to its siblings + `order_id` join key + 2s fetch bound (altitude), canceled/championship/resting/env coverage (test-coverage). Verified clean: the broker never mutates the book during `create_order` (snapshot reflects pre-fill depth exactly), and `depth_at_price` counts character-for-character the same levels the paper fill simulator walks.

## Testing

- 7 pure `Orderbook.depth_snapshot` tests (both sides, one-sided, reversed-order array, zero-quantity touch, limit-misses-book)
- 10 CLI-level tests via the order-command harness (happy path, canceled row, championship success + fetch-failure, resting row, sell exclusion, telemetry-failure isolation, env plumbing + garbage env)
- Frozen full unit suite gate: 2308 passed / 1 failed — the failure was test-harness interference (the harness's new inner `get_last_entry_trade` patch overrode the churn tests' outer patch); fixed test-side via a `last_entry` harness param and re-passed the three affected files (109 tests). No source changes after the gate.
- mypy: models/market.py clean; cli.py baseline unchanged

https://claude.ai/code/session_01QfSxxQS6EK455D2WnWSqLY
