### PR TITLE
Closer-only order placement + terminal failed attempts (#768)

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -287,7 +287,7 @@ If Monitor flags a position where the current edge has *increased* since entry (
 2. **Dispatch Closer** to execute the buy with `--size-up`:
    - Closer runs `gimmes validate TICKER --prob P --size-up`
    - If validation passes, `gimmes size TICKER --prob P`
-   - Place order: `gimmes order TICKER --prob P --size-up --yes`
+   - Place order: `gimmes order TICKER --prob P --size-up --yes --agent closer`
    - **HOURLY tickers (#743):** include `Approved price: XX¢` in the dispatch — the side-relative price you verified during THIS size-up review (from `gimmes market-info`, fetched this cycle), same contract as the Step 5 open dispatch. The Closer passes it as `--price XX --rest-on-miss`.
 
 ### Step 3: Scout
@@ -516,12 +516,14 @@ For each APPROVED candidate from Step 4c, dispatch the **Closer** agent.
 Launch the Closer agent (`closer.md`) to:
 1. Run `gimmes validate TICKER --prob P` for each candidate
 2. If validation passes, run `gimmes size TICKER --prob P`
-3. Place the order: `gimmes order TICKER --prob P --yes`
+3. Place the order: `gimmes order TICKER --prob P --yes --agent closer`
    (The order command logs the trade and syncs positions atomically — no separate log-trade needed.)
 
 **HOURLY candidates — approval price snapshot (#743).** For each approved HOURLY candidate, your dispatch prompt to the Closer MUST include the line `Approved price: XX¢` — the side-relative price (for a NO candidate, the NO price) you verified during the Step 4c review, in whole cents. This is the price your edge citation was computed against; the Closer passes it as `--price XX --rest-on-miss` so execution is capped at the price the review approved instead of chasing a market that moved during dispatch. Use the freshest price YOU verified (from `gimmes market-info` during review) — never Caddie's research-time price, and never a price you did not personally fetch this cycle.
 
 **Safety**: The Closer MUST pass all validation checks before any trade. NEVER override risk limits.
+
+**Closer outcomes are final (#768).** If the Closer reports 0 trades, order failures, or rejections, accept the outcome: record it in your cycle report and proceed to Step 6. The Step 2a crash-recovery scan and dispatches for *different* candidates are the only legitimate re-dispatches — never re-dispatch the Closer for the same candidate in the same cycle after a failure.
 
 ### Step 6: Scorecard
 
@@ -584,5 +586,6 @@ No special recovery logic needed — the state machine is the database.
 - All market interaction through CLI commands only
 - NEVER modify source code
 - Respect all risk limits unconditionally — NEVER override or bypass
+- NEVER run `gimmes order` — order placement is EXCLUSIVELY the Closer's job (#768). A Closer order failure — an `order_failed`/`order_canceled` skip, a permission-denied order command, or a "Closer executed 0 trades" report — is FINAL for that candidate this cycle: NEVER place the order yourself and NEVER re-dispatch the Closer for the same candidate in the same cycle. Reasoning of the form "the Closer's failure was procedural, so I'll save the trade by placing it myself" is FORBIDDEN.
 - MUST log every decision (trades, skips, closes) to the database
 - MUST complete exactly one cycle per invocation — NEVER run multiple cycles

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -122,6 +122,8 @@ No validate or size step is needed — the order command validates that the posi
 
 ## Order Failure Protocol
 
+A permission-denied `gimmes order` (the command was blocked and never ran) counts as an order failure: log the `order_failed` skip exactly as below. That skip arms a CLI gate (#768) making the failure terminal for every session this cycle.
+
 If the order command fails (non-zero exit code or error output), MUST:
 1. Log the failure via the `--rationale-file` heredoc pattern — captured CLI output may contain `$` or backticks (#589):
    ```bash

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -122,7 +122,7 @@ No validate or size step is needed — the order command validates that the posi
 
 ## Order Failure Protocol
 
-A permission-denied `gimmes order` (the command was blocked and never ran) counts as an order failure: log the `order_failed` skip exactly as below. That skip arms a CLI gate (#768) making the failure terminal for every session this cycle.
+A permission-denied `gimmes order` (the command was blocked and never ran) counts as an order failure: log the `order_failed` skip exactly as below. That skip arms a CLI gate (#768) making the failure terminal for every session this cycle — CLI-enforced for BUY retries; SELL/CLOSE retries are not CLI-blocked (the close_failed backstop governs those) but remain forbidden by this protocol.
 
 If the order command fails (non-zero exit code or error output), MUST:
 1. Log the failure via the `--rationale-file` heredoc pattern — captured CLI output may contain `$` or backticks (#589):

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -899,6 +899,7 @@ def order(
 
         import json
         import logging
+        import os
         import sqlite3
         import traceback
 
@@ -908,7 +909,16 @@ def order(
         from gimmes.models.error import ErrorCategory, ErrorLogEntry, ErrorSeverity
         from gimmes.models.order import CreateOrderParams, OrderAction, OrderSide
         from gimmes.risk.validator import validate_trade
-        from gimmes.store.queries import get_daily_pnl, get_deployed_cost_basis, insert_error
+        from gimmes.store.queries import (
+            _cycle_from_env,
+            _session_id_from_env,
+            get_daily_pnl,
+            get_deployed_cost_basis,
+            has_terminal_order_attempt,
+            insert_activity,
+            insert_error,
+            order_terminal_marker,
+        )
         from gimmes.strategy.fee_cache import get_multipliers
         from gimmes.strategy.fees import fee_for_order
         from gimmes.strategy.kelly import apply_base_rate_floor, position_size
@@ -924,6 +934,166 @@ def order(
                     await insert_error(db, entry)
                 except Exception:
                     logger.error(fail_msg, exc_info=True)
+
+            # #768: in-cycle gates. Both are inert outside the autonomous
+            # loop (GIMMES_CYCLE unset/malformed -> 0) so manual operator
+            # orders are untouched. Neither --force nor --force-reopen
+            # bypasses either gate.
+            gate_cycle = _cycle_from_env()
+            is_buy = action.lower() == "buy"
+            if gate_cycle == 0 and os.environ.get("GIMMES_SESSION_ID"):
+                # A loop session without a resolvable cycle number means
+                # the env propagation broke — the #768 gates are silently
+                # inert in exactly the context they exist for.
+                console.print(
+                    "[yellow]Warning: GIMMES_SESSION_ID is set but"
+                    " GIMMES_CYCLE resolved to 0 — the #768 order gates"
+                    " are inactive for this invocation.[/yellow]"
+                )
+            if gate_cycle > 0 and agent != "closer":
+                console.print(
+                    f"[red]Order agent gate (#768): in-cycle order"
+                    f" placement is restricted to the Closer"
+                    f" (--agent closer); got {rich_escape(repr(agent))}."
+                    f" A Closer order failure is final for this"
+                    f" cycle.[/red]"
+                )
+                await _audit_row(
+                    ErrorLogEntry(
+                        severity=ErrorSeverity.ERROR,
+                        category=ErrorCategory.RISK_BREACH,
+                        error_code="order_agent_denied",
+                        component="cli.order",
+                        agent=agent,
+                        cycle=gate_cycle,
+                        message=(
+                            f"In-cycle order for {ticker} denied:"
+                            f" agent {agent!r} is not the Closer (#768)"
+                        ),
+                        context=json.dumps(
+                            {
+                                "ticker": ticker,
+                                "side": side,
+                                "action": action,
+                                "cycle": gate_cycle,
+                            }
+                        ),
+                    ),
+                    "Failed to record order_agent_denied audit row",
+                )
+                raise typer.Exit(1)
+            if gate_cycle > 0 and is_buy:
+                try:
+                    terminal = await has_terminal_order_attempt(
+                        db, ticker, gate_cycle
+                    )
+                except Exception:
+                    # Fail open (#661 pattern): a DB blip must not halt
+                    # all cycle trading, but the miss is made visible.
+                    logger.error(
+                        "Terminal order-attempt lookup failed for %s",
+                        ticker,
+                        exc_info=True,
+                    )
+                    terminal = False
+                    console.print(
+                        f"[yellow]Warning: terminal-attempt lookup"
+                        f" failed for {rich_escape(ticker)} — the #768"
+                        f" gate failed open for this order.[/yellow]"
+                    )
+                    await _audit_row(
+                        ErrorLogEntry(
+                            severity=ErrorSeverity.WARNING,
+                            category=ErrorCategory.DATA_INTEGRITY,
+                            error_code="order_terminal_lookup_failed",
+                            component="cli.order",
+                            agent=agent,
+                            cycle=gate_cycle,
+                            message=(
+                                f"Terminal-attempt lookup failed for"
+                                f" {ticker} — gate failed open (#768)"
+                            ),
+                            context=json.dumps(
+                                {"ticker": ticker, "cycle": gate_cycle}
+                            ),
+                        ),
+                        "Failed to record order_terminal_lookup_failed audit row",
+                    )
+                if terminal:
+                    console.print(
+                        f"[red]Order terminal gate (#768): a failed order"
+                        f" attempt for {rich_escape(ticker)} was already"
+                        f" recorded in cycle {gate_cycle} — the failure"
+                        f" is final for this cycle for every agent; do"
+                        f" not retry.[/red]"
+                    )
+                    await _audit_row(
+                        ErrorLogEntry(
+                            severity=ErrorSeverity.WARNING,
+                            category=ErrorCategory.RISK_BREACH,
+                            error_code="order_terminal_retry_blocked",
+                            component="cli.order",
+                            agent=agent,
+                            cycle=gate_cycle,
+                            message=(
+                                f"Blocked retry of terminal order attempt"
+                                f" for {ticker} in cycle {gate_cycle} (#768)"
+                            ),
+                            context=json.dumps(
+                                {"ticker": ticker, "cycle": gate_cycle}
+                            ),
+                        ),
+                        "Failed to record order_terminal_retry_blocked audit row",
+                    )
+                    raise typer.Exit(1)
+
+            async def _mark_terminal(context: dict) -> None:
+                """Best-effort terminal marker on a failed BUY (#768).
+
+                Never masks the original failure — a marker write error
+                degrades to a log line.
+                """
+                if not (is_buy and gate_cycle > 0):
+                    return
+                try:
+                    await insert_activity(
+                        db,
+                        cycle=gate_cycle,
+                        agent=agent,
+                        phase="guard",
+                        message=order_terminal_marker(ticker),
+                        details=json.dumps(context),
+                        session_id=_session_id_from_env(),
+                    )
+                except Exception:
+                    # A lost marker disarms the gate — same consequence
+                    # as a failed lookup, so it gets the same durable
+                    # audit trail (review-found).
+                    logger.error(
+                        "Failed to write terminal order-attempt marker"
+                        " for %s",
+                        ticker,
+                        exc_info=True,
+                    )
+                    await _audit_row(
+                        ErrorLogEntry(
+                            severity=ErrorSeverity.WARNING,
+                            category=ErrorCategory.DATA_INTEGRITY,
+                            error_code="order_terminal_marker_failed",
+                            component="cli.order",
+                            agent=agent,
+                            cycle=gate_cycle,
+                            message=(
+                                f"Terminal-attempt marker write failed"
+                                f" for {ticker} — same-cycle retries are"
+                                f" NOT blocked (#768)"
+                            ),
+                            context=json.dumps(
+                                {"ticker": ticker, "cycle": gate_cycle}
+                            ),
+                        ),
+                        "Failed to record order_terminal_marker_failed audit row",
+                    )
 
             market = await get_market(client, ticker)
             raw_price = market.midpoint or market.last_price
@@ -1355,6 +1525,10 @@ def order(
                     f"[red bold]Order FAILED"
                     f" ({exc.response.status_code}): {detail}[/red bold]"
                 )
+                await _mark_terminal({
+                    "error_code": "http_status_error",
+                    "status_code": exc.response.status_code,
+                })
                 raise typer.Exit(1)
             except httpx.TimeoutException as exc:
                 logger.debug("Order placement timed out", exc_info=True)
@@ -1380,6 +1554,9 @@ def order(
                         " by Kalshi before the timeout.[/red]"
                     )
                 console.print(_RECONCILE_HINT)
+                # Terminal is safer here: retrying after an ambiguous
+                # timeout risks a double fill.
+                await _mark_terminal({"error_code": "timeout"})
                 raise typer.Exit(1)
             except (sqlite3.Error, ValueError, RuntimeError) as exc:
                 logger.debug("Order placement failed", exc_info=True)
@@ -1403,6 +1580,7 @@ def order(
                 except Exception:
                     logger.error("Failed to log error to DB", exc_info=True)
                 console.print(f"[red bold]Order FAILED: {exc}[/red bold]")
+                await _mark_terminal({"error_code": error_code})
                 raise typer.Exit(1)
 
             # #762: record displayed depth for every BUY — including
@@ -1498,6 +1676,10 @@ def order(
                     f"[red bold]Order NOT placed:"
                     f" {rich_escape(reason)}[/red bold]"
                 )
+                await _mark_terminal({
+                    "error_code": "order_canceled",
+                    "reason": reason,
+                })
                 raise typer.Exit(1)
             console.print(
                 f"[green]{label}Order placed:[/green] {result.order_id}"
@@ -3265,6 +3447,82 @@ def log_trade(
                 )
             row_id = await insert_trade(db, trade)
             console.print(f"[green]Logged trade #{row_id}: {action} {ticker}[/green]")
+            # #768: an order_failed/order_canceled skip arms the CLI's
+            # terminal-attempt gate for this ticker for the rest of the
+            # cycle. This is the ONLY trace a permission-classifier
+            # denial leaves (the order command never ran), so the
+            # marker is machine-written here, post-insert. Best-effort:
+            # log-trade is the logger of last resort and must never
+            # exit nonzero because of the marker.
+            if action == "skip" and reason in ("order_failed", "order_canceled"):
+                from gimmes.store.queries import (
+                    _cycle_from_env,
+                    _session_id_from_env,
+                    insert_activity,
+                    order_terminal_marker,
+                )
+                marker_cycle = _cycle_from_env()
+                if marker_cycle > 0:
+                    try:
+                        import json
+
+                        await insert_activity(
+                            db,
+                            cycle=marker_cycle,
+                            agent=agent,
+                            phase="guard",
+                            message=order_terminal_marker(ticker),
+                            details=json.dumps(
+                                {"reason": reason, "source": "log-trade"}
+                            ),
+                            session_id=_session_id_from_env(),
+                        )
+                    except Exception:
+                        # The skip row landed (same connection, two
+                        # statements ago), so the DB is up — a marker
+                        # failure here is marker-specific and the gate
+                        # is disarmed. Leave a durable trace for
+                        # Groundskeeper (review-found).
+                        logging.getLogger(__name__).error(
+                            "Failed to write terminal order-attempt"
+                            " marker for %s (#768)",
+                            ticker,
+                            exc_info=True,
+                        )
+                        try:
+                            from gimmes.models.error import (
+                                ErrorCategory,
+                                ErrorLogEntry,
+                                ErrorSeverity,
+                            )
+                            from gimmes.store.queries import insert_error
+
+                            await insert_error(db, ErrorLogEntry(
+                                severity=ErrorSeverity.WARNING,
+                                category=ErrorCategory.DATA_INTEGRITY,
+                                error_code="order_terminal_marker_failed",
+                                component="cli.log-trade",
+                                agent=agent,
+                                cycle=marker_cycle,
+                                message=(
+                                    f"Terminal-attempt marker write"
+                                    f" failed for {ticker} — same-cycle"
+                                    f" retries are NOT blocked (#768)"
+                                ),
+                                context=json.dumps(
+                                    {"ticker": ticker,
+                                     "cycle": marker_cycle,
+                                     "reason": reason},
+                                ),
+                            ))
+                        except Exception:
+                            logging.getLogger(__name__).error(
+                                "Failed to record"
+                                " order_terminal_marker_failed audit"
+                                " row for %s (#768)",
+                                ticker,
+                                exc_info=True,
+                            )
             if action == "skip" and not reason:
                 # #710: entry-type skip with no structured cause — the
                 # #657 skip analytics and #707 EV audit can't classify

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -437,6 +437,14 @@ def _cycle_from_env() -> int:
         return 0
 
 
+def _session_id_from_env() -> int | None:
+    """Session ID from GIMMES_SESSION_ID (None if unset or invalid)."""
+    try:
+        return int(os.environ["GIMMES_SESSION_ID"])
+    except (KeyError, ValueError):
+        return None
+
+
 def settlement_outcome(side: str, won: bool) -> str:
     """Resolution outcome implied by a settlement result (#653).
 
@@ -1060,6 +1068,32 @@ async def get_recent_activity(db: Database, limit: int = 50) -> list[dict]:
     )
     rows = await cursor.fetchall()
     return [dict(row) for row in rows]
+
+
+# #768: a failed BUY attempt is terminal for its candidate for the rest of
+# the cycle — for every agent session, not just the one that failed. The
+# marker lives in activity_log because trades has no cycle column.
+ORDER_TERMINAL_MARKER_PREFIX = "Order attempt terminal:"
+
+
+def order_terminal_marker(ticker: str) -> str:
+    """Activity-log message marking a terminal order attempt (#768)."""
+    return f"{ORDER_TERMINAL_MARKER_PREFIX} {ticker}"
+
+
+async def has_terminal_order_attempt(db: Database, ticker: str, cycle: int) -> bool:
+    """True if a terminal order-attempt marker exists for ticker+cycle (#768).
+
+    Bounded to 24h so a same-numbered cycle from an earlier loop run
+    (fresh-DB restart) can never match — same bounding as #761.
+    """
+    cursor = await db.conn.execute(
+        "SELECT 1 FROM activity_log"
+        " WHERE cycle = ? AND message = ?"
+        " AND timestamp >= datetime('now', '-1 day') LIMIT 1",
+        (cycle, order_terminal_marker(ticker)),
+    )
+    return await cursor.fetchone() is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,15 @@ from gimmes.models.market import Market, MarketStatus, Orderbook, OrderbookLevel
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_cycle_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#768: the in-cycle order gates key on GIMMES_CYCLE. A pytest run
+    from an in-cycle shell (the loop exports it) would mass-fail every
+    order test that doesn't pass --agent closer — isolate the suite."""
+    monkeypatch.delenv("GIMMES_CYCLE", raising=False)
+    monkeypatch.delenv("GIMMES_SESSION_ID", raising=False)
+
+
 @pytest.fixture
 def config() -> GimmesConfig:
     """Default test config (driving range, side=yes pinned for test stability)."""

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3075,3 +3075,68 @@ def test_clamp_kill_classification_markers_pinned() -> None:
     assert "Closer executed N trades".startswith(
         CLOSER_CONCLUDED_MARKER_PREFIX,
     )
+
+
+# ---------------------------------------------------------------------------
+# #768: order placement is Closer-only; failures are terminal
+# ---------------------------------------------------------------------------
+
+
+def test_caddie_master_never_places_orders(caddie_master_text: str) -> None:
+    """The c2212 breach: CM placed the order itself after the Closer's
+    attempt was classifier-denied. The rule and its anti-rationalization
+    sentence must stay pinned."""
+    assert "NEVER run `gimmes order`" in caddie_master_text
+    assert "EXCLUSIVELY the Closer's job (#768)" in caddie_master_text
+    assert "FINAL for that candidate this cycle" in caddie_master_text
+    assert "Closer executed 0 trades" in caddie_master_text
+    assert (
+        "I'll save the trade by placing it myself" in caddie_master_text
+    )
+    assert "is FORBIDDEN" in caddie_master_text
+
+
+def test_caddie_master_closer_outcomes_final(caddie_master_text: str) -> None:
+    assert "Closer outcomes are final (#768)" in caddie_master_text
+    assert (
+        "never re-dispatch the Closer for the same candidate in the"
+        " same cycle after a failure" in caddie_master_text
+    )
+
+
+def test_caddie_master_dispatch_templates_carry_agent_closer(
+    caddie_master_text: str,
+) -> None:
+    """Both order literals in the CM prompt must carry --agent closer —
+    a copy-pasted command without it now trips the #768 identity gate."""
+    assert (
+        "`gimmes order TICKER --prob P --yes --agent closer`"
+        in caddie_master_text
+    )
+    assert (
+        "`gimmes order TICKER --prob P --size-up --yes --agent closer`"
+        in caddie_master_text
+    )
+
+
+def test_closer_permission_denial_is_order_failure() -> None:
+    closer_text = _CLOSER.read_text()
+    assert "permission-denied `gimmes order`" in closer_text
+    assert "counts as an order failure" in closer_text
+    assert "arms a CLI gate (#768)" in closer_text
+
+
+def test_every_order_literal_carries_agent_closer() -> None:
+    """#768 identity gate: any in-cycle `gimmes order` command whose
+    template omits --agent closer would trip the gate at runtime. Pin
+    every order template in both execution prompts (prose mentions of
+    the bare command are exempt — only TICKER templates get copied)."""
+    for path in (_CLOSER, CADDIE_MASTER):
+        for i, line in enumerate(path.read_text().splitlines(), 1):
+            if "gimmes order TICKER" not in line:
+                continue
+            assert "--agent closer" in line, (
+                f"{path.name}:{i} has a `gimmes order` template without"
+                f" --agent closer — it would trip the #768 identity"
+                f" gate in-cycle: {line.strip()!r}"
+            )

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3124,6 +3124,12 @@ def test_closer_permission_denial_is_order_failure() -> None:
     assert "permission-denied `gimmes order`" in closer_text
     assert "counts as an order failure" in closer_text
     assert "arms a CLI gate (#768)" in closer_text
+    # BUY-only CLI scoping + the protocol prohibition that backstops
+    # the unenforced SELL/CLOSE side — dropping either re-broadens or
+    # weakens the claim (Copilot review on #770).
+    assert "CLI-enforced for BUY retries" in closer_text
+    assert "SELL/CLOSE retries are not CLI-blocked" in closer_text
+    assert "remain forbidden by this protocol" in closer_text
 
 
 def test_every_order_literal_carries_agent_closer() -> None:

--- a/tests/unit/test_order_agent_gate.py
+++ b/tests/unit/test_order_agent_gate.py
@@ -1,0 +1,590 @@
+"""#768: in-cycle order gates.
+
+Cycle 2212: the Closer's order was classifier-denied; 73 seconds later
+the Caddie Master placed the order itself (733 NO @ $0.54, settled YES,
+-$395.82). Two CLI gates close that path, both active only when
+GIMMES_CYCLE is set so manual operator orders are untouched:
+
+- identity gate: in-cycle `gimmes order` requires --agent closer;
+- terminal gate: a recorded failed BUY attempt (activity_log marker,
+  armed by the Closer's order_failed/order_canceled skip or by the
+  order command's own failure exits) blocks same-ticker same-cycle
+  retries for every agent.
+
+Harness reuse follows test_churn_guard.py; gate asserts follow
+TestOrderReopenGate (exit code, message, no broker call, audit row).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.store.database import Database
+from gimmes.store.queries import (
+    has_terminal_order_attempt,
+    insert_activity,
+    order_terminal_marker,
+)
+from tests.unit import test_order_error_handling as h
+
+
+def _error_codes(insert_error) -> list[str]:
+    return [
+        c.args[1].error_code
+        for c in insert_error.await_args_list
+        if len(c.args) > 1
+    ]
+
+
+def _marker_calls(insert_activity_mock) -> list[dict]:
+    return [
+        c.kwargs
+        for c in insert_activity_mock.await_args_list
+        if c.kwargs.get("message", "").startswith("Order attempt terminal:")
+    ]
+
+
+class TestCloserOnlyGate:
+    """In-cycle placement is restricted to --agent closer."""
+
+    def _run(self, monkeypatch, *, cycle="42", extra_args=None,
+             cli_args=None):
+        if cycle is None:
+            monkeypatch.delenv("GIMMES_CYCLE", raising=False)
+        else:
+            monkeypatch.setenv("GIMMES_CYCLE", cycle)
+        broker = h._make_mock_broker()
+        self._last_broker = broker
+        result, console, insert_error = h._run_order_cli(
+            broker, extra_args=extra_args, cli_args=cli_args,
+        )
+        return result, h._printed(console), insert_error
+
+    def test_default_cli_agent_blocked_in_cycle(self, monkeypatch) -> None:
+        result, out, insert_error = self._run(monkeypatch)
+        assert result.exit_code == 1, out
+        assert "Order agent gate (#768)" in out
+        assert self._last_broker.create_order.await_count == 0
+        assert "order_agent_denied" in _error_codes(insert_error)
+
+    def test_caddie_master_blocked_in_cycle(self, monkeypatch) -> None:
+        """The c2212 command shape: an in-cycle CM-attributed buy."""
+        result, out, insert_error = self._run(
+            monkeypatch, extra_args=["--agent", "caddie-master"],
+        )
+        assert result.exit_code == 1, out
+        assert "Order agent gate (#768)" in out
+        assert self._last_broker.create_order.await_count == 0
+
+    def test_sell_also_blocked_in_cycle(self, monkeypatch) -> None:
+        result, out, _ = self._run(
+            monkeypatch,
+            cli_args=[
+                "order", "TEST-TICKER", "--action", "sell",
+                "--side", "yes", "--count", "10", "--yes",
+                "--agent", "caddie-master",
+            ],
+        )
+        assert result.exit_code == 1, out
+        assert "Order agent gate (#768)" in out
+        assert self._last_broker.create_order.await_count == 0
+
+    def test_closer_allowed_in_cycle(self, monkeypatch) -> None:
+        result, out, _ = self._run(
+            monkeypatch, extra_args=["--agent", "closer"],
+        )
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+
+    def test_inert_without_cycle_env(self, monkeypatch) -> None:
+        result, out, _ = self._run(monkeypatch, cycle=None)
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+
+    def test_inert_with_malformed_cycle_env(self, monkeypatch) -> None:
+        result, out, _ = self._run(monkeypatch, cycle="not-a-number")
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+
+    def test_audit_row_context_carries_cycle(self, monkeypatch) -> None:
+        _, _, insert_error = self._run(monkeypatch, cycle="77")
+        contexts = [
+            json.loads(c.args[1].context)
+            for c in insert_error.await_args_list
+            if len(c.args) > 1
+            and c.args[1].error_code == "order_agent_denied"
+        ]
+        assert len(contexts) == 1
+        assert contexts[0]["cycle"] == 77
+
+
+class TestOrderTerminalGate:
+    """A recorded failed attempt is terminal for ticker+cycle — for
+    every agent, the Closer included."""
+
+    def _run(self, monkeypatch, *, terminal=True, lookup_effect=None,
+             cycle="42", extra_args=None, cli_args=None):
+        if cycle is None:
+            monkeypatch.delenv("GIMMES_CYCLE", raising=False)
+        else:
+            monkeypatch.setenv("GIMMES_CYCLE", cycle)
+        self._lookup = AsyncMock(
+            return_value=terminal, side_effect=lookup_effect,
+        )
+        broker = h._make_mock_broker()
+        self._last_broker = broker
+        args = ["--agent", "closer"] + (extra_args or [])
+        result, console, insert_error = h._run_order_cli(
+            broker,
+            extra_args=None if cli_args else args,
+            cli_args=cli_args,
+            terminal_attempt_mock=self._lookup,
+        )
+        return result, h._printed(console), insert_error
+
+    def test_marker_blocks_in_cycle_buy(self, monkeypatch) -> None:
+        result, out, insert_error = self._run(monkeypatch)
+        assert result.exit_code == 1, out
+        assert "Order terminal gate (#768)" in out
+        assert self._last_broker.create_order.await_count == 0
+        assert "order_terminal_retry_blocked" in _error_codes(insert_error)
+        # The lookup must be keyed on THIS ticker and THIS cycle — a
+        # hardcoded cycle or wrong ticker would survive pure
+        # return-value mocking (review-found).
+        assert self._lookup.await_args.args[1:] == ("TEST-TICKER", 42)
+
+    def test_identity_gate_fires_before_terminal_gate(
+        self, monkeypatch,
+    ) -> None:
+        """Both gates armed: the agent gate wins and the terminal
+        lookup is never consulted."""
+        result, out, _ = self._run(
+            monkeypatch,
+            cli_args=[
+                "order", "TEST-TICKER",
+                "--side", "yes", "--count", "10",
+                "--price", "40", "--prob", "0.55", "--yes",
+                "--agent", "caddie-master",
+            ],
+        )
+        assert result.exit_code == 1, out
+        assert "Order agent gate (#768)" in out
+        assert "Order terminal gate (#768)" not in out
+        assert self._lookup.await_count == 0
+
+    def test_terminal_gate_fires_before_reopen_churn_gate(
+        self, monkeypatch,
+    ) -> None:
+        """Terminal marker + fresh same-price close both armed: the
+        terminal gate wins (it sits before any market fetch)."""
+        monkeypatch.setenv("GIMMES_CYCLE", "42")
+        self._lookup = AsyncMock(return_value=True)
+        broker = h._make_mock_broker()
+        result, console, _ = h._run_order_cli(
+            broker, extra_args=["--agent", "closer"],
+            terminal_attempt_mock=self._lookup,
+            last_close={
+                "price": 0.40, "timestamp": "2026-01-01T00:00:00+00:00",
+                "agent": "closer",
+            },
+        )
+        out = h._printed(console)
+        assert result.exit_code == 1, out
+        assert "Order terminal gate (#768)" in out
+        assert "Reopen churn gate (#661)" not in out
+
+    def test_force_does_not_bypass(self, monkeypatch) -> None:
+        result, out, _ = self._run(monkeypatch, extra_args=["--force"])
+        assert result.exit_code == 1, out
+        assert self._last_broker.create_order.await_count == 0
+
+    def test_force_reopen_does_not_bypass(self, monkeypatch) -> None:
+        result, out, _ = self._run(
+            monkeypatch, extra_args=["--force-reopen"],
+        )
+        assert result.exit_code == 1, out
+        assert self._last_broker.create_order.await_count == 0
+
+    def test_sell_not_gated(self, monkeypatch) -> None:
+        """Terminal markers are entry-side only — a failed CLOSE must
+        remain retryable (the close_failed backstop depends on it)."""
+        result, out, _ = self._run(
+            monkeypatch,
+            cli_args=[
+                "order", "TEST-TICKER", "--action", "sell",
+                "--side", "yes", "--count", "10", "--yes",
+                "--agent", "closer",
+            ],
+        )
+        assert "Order terminal gate (#768)" not in out
+        assert self._lookup.await_count == 0
+
+    def test_inert_without_cycle_env(self, monkeypatch) -> None:
+        result, out, _ = self._run(monkeypatch, cycle=None)
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+        assert self._lookup.await_count == 0
+
+    def test_lookup_failure_fails_open(self, monkeypatch) -> None:
+        result, out, insert_error = self._run(
+            monkeypatch,
+            lookup_effect=sqlite3.OperationalError("locked"),
+        )
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+        assert "order_terminal_lookup_failed" in _error_codes(insert_error)
+
+
+class TestTerminalMarkerWrites:
+    """The order command's own BUY failure exits arm the gate."""
+
+    def _run(self, monkeypatch, *, broker, cycle="42"):
+        if cycle is None:
+            monkeypatch.delenv("GIMMES_CYCLE", raising=False)
+        else:
+            monkeypatch.setenv("GIMMES_CYCLE", cycle)
+        activity = AsyncMock(return_value=1)
+        result, console, _ = h._run_order_cli(
+            broker, extra_args=["--agent", "closer"],
+            insert_activity_mock=activity,
+        )
+        return result, h._printed(console), activity
+
+    def test_http_error_writes_marker(self, monkeypatch) -> None:
+        broker = h._make_mock_broker(
+            create_order_side_effect=httpx.HTTPStatusError(
+                "boom",
+                request=httpx.Request("POST", "https://x"),
+                response=h._make_response(500, text="server error"),
+            ),
+        )
+        result, out, activity = self._run(monkeypatch, broker=broker)
+        assert result.exit_code == 1, out
+        markers = _marker_calls(activity)
+        assert len(markers) == 1
+        assert markers[0]["message"] == order_terminal_marker("TEST-TICKER")
+        assert markers[0]["cycle"] == 42
+        assert markers[0]["phase"] == "guard"
+
+    def test_timeout_writes_marker(self, monkeypatch) -> None:
+        broker = h._make_mock_broker(
+            create_order_side_effect=httpx.TimeoutException("slow"),
+        )
+        result, out, activity = self._run(monkeypatch, broker=broker)
+        assert result.exit_code == 1, out
+        markers = _marker_calls(activity)
+        assert len(markers) == 1
+        assert markers[0]["message"] == order_terminal_marker("TEST-TICKER")
+        assert json.loads(markers[0]["details"])["error_code"] == "timeout"
+
+    def test_runtime_error_writes_marker(self, monkeypatch) -> None:
+        broker = h._make_mock_broker(
+            create_order_side_effect=RuntimeError("bad state"),
+        )
+        result, out, activity = self._run(monkeypatch, broker=broker)
+        assert result.exit_code == 1, out
+        markers = _marker_calls(activity)
+        assert len(markers) == 1
+        assert markers[0]["message"] == order_terminal_marker("TEST-TICKER")
+        assert json.loads(markers[0]["details"])["error_code"] == (
+            "runtime_error"
+        )
+
+    def test_canceled_order_writes_marker(self, monkeypatch) -> None:
+        canceled = h._ok_order(status="canceled")
+        canceled.remaining_count = 10
+        broker = h._make_mock_broker()
+        broker.create_order = AsyncMock(return_value=canceled)
+        result, out, activity = self._run(monkeypatch, broker=broker)
+        assert result.exit_code == 1, out
+        markers = _marker_calls(activity)
+        assert len(markers) == 1
+        assert json.loads(markers[0]["details"])["error_code"] == (
+            "order_canceled"
+        )
+
+    def test_no_marker_out_of_cycle(self, monkeypatch) -> None:
+        broker = h._make_mock_broker(
+            create_order_side_effect=RuntimeError("bad state"),
+        )
+        result, out, activity = self._run(
+            monkeypatch, broker=broker, cycle=None,
+        )
+        assert result.exit_code == 1, out
+        assert _marker_calls(activity) == []
+
+    def test_marker_write_failure_keeps_original_exit(
+        self, monkeypatch,
+    ) -> None:
+        broker = h._make_mock_broker(
+            create_order_side_effect=RuntimeError("bad state"),
+        )
+        monkeypatch.setenv("GIMMES_CYCLE", "42")
+        activity = AsyncMock(side_effect=sqlite3.OperationalError("locked"))
+        result, console, _ = h._run_order_cli(
+            broker, extra_args=["--agent", "closer"],
+            insert_activity_mock=activity,
+        )
+        out = h._printed(console)
+        assert result.exit_code == 1, out
+        assert "Order FAILED" in out
+
+
+runner = CliRunner()
+
+
+def _db_run(db_path: Path, fn):
+    async def _go():
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await fn(db)
+        finally:
+            await db.close()
+
+    return asyncio.run(_go())
+
+
+def _patch_config(monkeypatch, db_path: Path) -> None:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.strategy.side = "no"
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+
+class TestLogTradeTerminalMarker:
+    """The Closer's order_failed skip is the ONLY trace a classifier
+    denial leaves — log-trade machine-writes the marker from it."""
+
+    def _log_skip(self, monkeypatch, tmp_path, *, reason, cycle="42"):
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, self._noop)
+        _patch_config(monkeypatch, db_path)
+        if cycle is None:
+            monkeypatch.delenv("GIMMES_CYCLE", raising=False)
+        else:
+            monkeypatch.setenv("GIMMES_CYCLE", cycle)
+        args = [
+            "log-trade", "KXTEST-26AUG-T1", "--action", "skip",
+            "--agent", "closer",
+        ]
+        if reason:
+            args += ["--reason", reason]
+        result = runner.invoke(app, args)
+        return result, db_path
+
+    @staticmethod
+    async def _noop(db):
+        pass
+
+    def _markers(self, db_path: Path) -> list[dict]:
+        async def _q(db):
+            cursor = await db.conn.execute(
+                "SELECT cycle, agent, phase, message FROM activity_log"
+                " WHERE message LIKE 'Order attempt terminal:%'"
+            )
+            return [dict(r) for r in await cursor.fetchall()]
+
+        return _db_run(db_path, _q)
+
+    def test_order_failed_skip_writes_marker(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        result, db_path = self._log_skip(
+            monkeypatch, tmp_path, reason="order_failed",
+        )
+        assert result.exit_code == 0, result.output
+        markers = self._markers(db_path)
+        assert len(markers) == 1
+        assert markers[0]["message"] == order_terminal_marker(
+            "KXTEST-26AUG-T1"
+        )
+        assert markers[0]["cycle"] == 42
+        assert markers[0]["agent"] == "closer"
+        assert markers[0]["phase"] == "guard"
+
+    def test_order_canceled_skip_writes_marker(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        result, db_path = self._log_skip(
+            monkeypatch, tmp_path, reason="order_canceled",
+        )
+        assert result.exit_code == 0, result.output
+        assert len(self._markers(db_path)) == 1
+
+    def test_other_reason_writes_no_marker(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        result, db_path = self._log_skip(
+            monkeypatch, tmp_path, reason="cooldown",
+        )
+        assert result.exit_code == 0, result.output
+        assert self._markers(db_path) == []
+
+    def test_no_cycle_env_writes_no_marker(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        result, db_path = self._log_skip(
+            monkeypatch, tmp_path, reason="order_failed", cycle=None,
+        )
+        assert result.exit_code == 0, result.output
+        assert self._markers(db_path) == []
+
+    def test_marker_failure_still_logs_skip(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """log-trade is the logger of last resort — the skip row must
+        land and the command exit 0 even if the marker write fails."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, self._noop)
+        _patch_config(monkeypatch, db_path)
+        monkeypatch.setenv("GIMMES_CYCLE", "42")
+        monkeypatch.setattr(
+            "gimmes.store.queries.insert_activity",
+            AsyncMock(side_effect=sqlite3.OperationalError("locked")),
+        )
+        result = runner.invoke(app, [
+            "log-trade", "KXTEST-26AUG-T1", "--action", "skip",
+            "--reason", "order_failed", "--agent", "closer",
+        ])
+        assert result.exit_code == 0, result.output
+
+        async def _rows(db):
+            cursor = await db.conn.execute(
+                "SELECT ticker FROM trades WHERE action = 'skip'"
+            )
+            return [dict(r) for r in await cursor.fetchall()]
+
+        assert len(_db_run(db_path, _rows)) == 1
+
+
+class TestHasTerminalOrderAttempt:
+    """Round-trip on a real DB, including the 24h restart bound."""
+
+    def test_round_trip(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+
+        async def _go(db):
+            await insert_activity(
+                db, cycle=42, agent="closer", phase="guard",
+                message=order_terminal_marker("KXTEST-26AUG-T1"),
+            )
+            hit = await has_terminal_order_attempt(
+                db, "KXTEST-26AUG-T1", 42,
+            )
+            other_cycle = await has_terminal_order_attempt(
+                db, "KXTEST-26AUG-T1", 43,
+            )
+            other_ticker = await has_terminal_order_attempt(
+                db, "KXOTHER-26AUG-T1", 42,
+            )
+            return hit, other_cycle, other_ticker
+
+        hit, other_cycle, other_ticker = _db_run(db_path, _go)
+        assert hit is True
+        assert other_cycle is False
+        assert other_ticker is False
+
+    def test_stale_marker_ignored(self, tmp_path) -> None:
+        """A same-numbered cycle from an earlier loop run (fresh-DB
+        restart) never matches — markers older than 24h are dead."""
+        db_path = tmp_path / "gimmes.db"
+
+        async def _go(db):
+            await insert_activity(
+                db, cycle=42, agent="closer", phase="guard",
+                message=order_terminal_marker("KXTEST-26AUG-T1"),
+            )
+            await db.conn.execute(
+                "UPDATE activity_log SET timestamp ="
+                " datetime('now', '-2 days')"
+            )
+            await db.conn.commit()
+            return await has_terminal_order_attempt(
+                db, "KXTEST-26AUG-T1", 42,
+            )
+
+        assert _db_run(db_path, _go) is False
+
+
+class TestC2212RoundTrip:
+    """The incident shape, end-to-end on a real DB: the Closer's
+    order_failed skip (the only trace a classifier denial leaves) must
+    block a second same-cycle order attempt through the real
+    marker-write -> marker-read wiring, with no #768 mocks."""
+
+    def test_skip_then_order_blocked(self, monkeypatch, tmp_path) -> None:
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        db_path = tmp_path / "gimmes.db"
+        monkeypatch.setenv("GIMMES_CYCLE", "2212")
+
+        cfg = MagicMock()
+        cfg.is_championship = False
+        cfg.db_path = db_path
+        cfg.strategy.side = "no"
+
+        monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+        # Step 1: the Closer logs the denial as an order_failed skip.
+        result = runner.invoke(app, [
+            "log-trade", "KXBTCD-26AUG1118-T63599.99",
+            "--action", "skip", "--reason", "order_failed",
+            "--agent", "closer",
+        ])
+        assert result.exit_code == 0, result.output
+
+        # Step 2: a second placement attempt in the same cycle — even
+        # a correctly-attributed Closer one — is refused by the real
+        # activity_log marker.
+        broker = h._make_mock_broker()
+        mock_client = AsyncMock()
+
+        @asynccontextmanager
+        async def _real_db_ctx(config):
+            db = Database(db_path)
+            await db.connect()
+            try:
+                yield mock_client, broker, db
+            finally:
+                await db.close()
+
+        mock_fees = MagicMock()
+        mock_fees.taker_fee = 0.07
+        mock_fees.maker_fee = 0.03
+
+        async def _passthrough_mtm(b, c, **kw):
+            return await b.get_positions()
+
+        with (
+            patch("gimmes.cli.trading_context", _real_db_ctx),
+            patch("gimmes.cli._mode_banner"),
+            patch("gimmes.cli._mark_positions_to_market", _passthrough_mtm),
+            patch(
+                "gimmes.kalshi.markets.get_market",
+                AsyncMock(return_value=h._stub_market()),
+            ),
+            patch(
+                "gimmes.strategy.fee_cache.get_multipliers",
+                MagicMock(return_value=mock_fees),
+            ),
+        ):
+            result = runner.invoke(app, [
+                "order", "KXBTCD-26AUG1118-T63599.99",
+                "--side", "no", "--count", "733",
+                "--price", "54", "--prob", "0.70", "--yes",
+                "--agent", "closer",
+            ])
+
+        assert result.exit_code == 1, result.output
+        assert broker.create_order.await_count == 0

--- a/tests/unit/test_order_error_handling.py
+++ b/tests/unit/test_order_error_handling.py
@@ -98,6 +98,7 @@ def _run_order_cli(
     last_close=None, last_close_effect=None, config=None,
     orderbook=None, orderbook_side_effect=None,
     insert_activity_mock=None, last_entry=None,
+    terminal_attempt_mock=None,
 ):
     """Invoke the order CLI command with a mocked broker.
 
@@ -156,6 +157,14 @@ def _run_order_cli(
             "gimmes.store.queries.insert_activity",
             insert_activity_mock if insert_activity_mock is not None
             else AsyncMock(return_value=1),
+        ),
+        # #768: the terminal-attempt gate reads activity_log; against
+        # the mocked DB the real query returns a truthy AsyncMock and
+        # would spuriously block every in-cycle buy.
+        patch(
+            "gimmes.store.queries.has_terminal_order_attempt",
+            terminal_attempt_mock if terminal_attempt_mock is not None
+            else AsyncMock(return_value=False),
         ),
         patch("gimmes.strategy.fee_cache.get_multipliers", MagicMock(return_value=mock_fees)),
         patch(
@@ -1538,7 +1547,7 @@ class TestDepthTelemetryOutcomes:
             cli_args=[
                 "order", "TEST-TICKER",
                 "--side", "no", "--count", "10",
-                "--price", "58", "--yes",
+                "--price", "58", "--yes", "--agent", "closer",
             ],
             orderbook=self._thin_touch_book(),
             insert_activity_mock=activity,


### PR DESCRIPTION
## Summary

Cycle 2212 (2026-08-11): the Closer's `gimmes order` was denied by the permission classifier; 73 seconds later Caddie Master placed the order itself (733 NO @ $0.54 on KXBTCD-26AUG1118-T63599.99 — settled YES, −$395.82). This PR makes that path structurally impossible instead of prompt-forbidden-only.

**Two CLI gates in `gimmes order`, active only when `GIMMES_CYCLE` is set** (manual operator orders untouched; neither `--force` nor `--force-reopen` bypasses):

1. **Identity gate** — in-cycle placement requires `--agent closer` (buy and sell). Hard `Exit(1)` + `order_agent_denied` audit row (RISK_BREACH, so Groundskeeper escalation sees illegal attempts).
2. **Terminal gate** — an in-cycle BUY is refused when an `Order attempt terminal: TICKER` marker exists in `activity_log` for the same cycle (24h-bounded against fresh-DB cycle-number collisions, per the #761 pattern). Terminal means terminal for **every** agent session, the Closer included — enforcing closer.md's existing "NEVER retry in this cycle" as CLI law.

**Marker writers:**
- `log-trade --action skip --reason order_failed|order_canceled` (the ONLY trace a classifier denial leaves — in c2212 this row existed 107 s before the CM's placement, so this alone would have blocked the incident);
- the order command's own four BUY failure exits (HTTP error, timeout, sqlite/Value/Runtime, canceled #690).

**Failure honesty:** terminal-gate lookup errors fail open (#661 pattern) with an `order_terminal_lookup_failed` audit row *and* a console notice; a failed marker write leaves a durable `order_terminal_marker_failed` row (a lost marker disarms the gate — it gets the same visibility as a failed lookup); a loop session whose `GIMMES_CYCLE` env got lost prints a warning that the gates are inert.

**Prompt law to match (drift-guard pinned):** Caddie Master gains the `NEVER run \`gimmes order\`` rule every other non-Closer agent already had, plus "Closer outcomes are final (#768)" and an explicit ban on the "I'll save the trade by placing it myself" rationalization (revoking the #645 precedent where a CM re-place was treated as a good save). Both CM order templates now carry `--agent closer`. closer.md names permission denial as an order failure.

**Known limitation (by design):** `--agent` is caller-declared and the Closer/CM share one process env, so no cryptographic identity exists at placement time. The gate catches honest misuse (c2212's CM honestly passed `--agent caddie-master`); a deliberate lie is prompt-forbidden and auditable. Same threat model as the #661 churn gate.

Closes #768

## Test plan

- 29 new tests in `tests/unit/test_order_agent_gate.py`: both gates (block/allow/inert/malformed-env), gate ordering (identity → terminal → churn), no-broker-call asserts, all four marker-write sites, marker-failure never masks the original error, log-trade marker round-trip on a real DB, `has_terminal_order_attempt` round-trip incl. the 24h stale bound, and an end-to-end replay of the c2212 shape (real DB: order_failed skip → second same-cycle attempt refused).
- Drift guards in `test_agent_prompts.py` pin the new prompt literals and assert every `gimmes order TICKER` template in both prompts carries `--agent closer`.
- Suite-wide isolation: autouse fixture deletes ambient `GIMMES_CYCLE`/`GIMMES_SESSION_ID` (a pytest run from an in-cycle shell previously mass-failed 58 order tests).
- Frozen full unit suite: **2343 passed** in 16:17. Lint clean.

Note: the pr-review-toolkit plugin is not installed in this environment; the equivalent three-role review (code review, silent-failure hunt, test-coverage analysis) + simplifier pass ran via general-purpose agents, and all findings at confidence ≥80 were addressed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r