### PR TITLE
Auto-size at the worst-case price: the approval cap governs sizing (#766)

### DIFF
--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -50,7 +50,7 @@ gimmes order TICKER --prob P --price XX --taker --rest-on-miss --yes --agent clo
 
 If the dispatch has no `Approved price` line, omit `--price` (the order uses the live price) but still pass `--rest-on-miss`. NEVER invent a price the dispatch didn't give you.
 
-The order command is the binding risk check: with an approval-price cap it auto-sizes at the cap (the worst-case fill price, #766), so its contract count may be smaller than the validate/size preview showed — that is expected sizing discipline, not a failure. The exception is a count of ZERO: `Sized to zero contracts` exits 1 — that IS an order failure (no positive edge at the worst-case price); follow the Order Failure Protocol and never retry this cycle.
+The order command is the binding risk check: with an approval-price cap it auto-sizes at the worst-case fill price — the HIGHER of the live effective price and the cap (#766) — so its contract count may be smaller than the validate/size preview showed — that is expected sizing discipline, not a failure. (A cap below the live price changes nothing: sizing stays at the live price.) The exception is a count of ZERO: `Sized to zero contracts` exits 1 — that IS an order failure (no positive edge at the worst-case price); follow the Order Failure Protocol and never retry this cycle.
 
 **Closes** are unchanged — taker only, never rest-on-miss (a missed close must fail loudly so Caddie Master can escalate, #659):
 

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -50,6 +50,8 @@ gimmes order TICKER --prob P --price XX --taker --rest-on-miss --yes --agent clo
 
 If the dispatch has no `Approved price` line, omit `--price` (the order uses the live price) but still pass `--rest-on-miss`. NEVER invent a price the dispatch didn't give you.
 
+The order command is the binding risk check: with an approval-price cap it auto-sizes at the cap (the worst-case fill price, #766), so its contract count may be smaller than the validate/size preview showed — that is expected sizing discipline, not a failure. The exception is a count of ZERO: `Sized to zero contracts` exits 1 — that IS an order failure (no positive edge at the worst-case price); follow the Order Failure Protocol and never retry this cycle.
+
 **Closes** are unchanged — taker only, never rest-on-miss (a missed close must fail loudly so Caddie Master can escalate, #659):
 
 ```bash
@@ -66,7 +68,7 @@ When Caddie Master dispatches you for a SIZE UP (adding to an existing position)
 
 1. **Validate**: `gimmes validate TICKER --prob P --size-up` — MUST pass all checks. The `--size-up` flag allows the duplicate position check to pass. A `Reopen churn gate (#661)` rejection from the subsequent order applies here too: FINAL for this cycle, log the skip, NEVER pass `--force-reopen`.
 2. **Size**: `gimmes size TICKER --prob P`
-3. **Order**: `gimmes order TICKER --prob P --size-up --yes --agent closer`
+3. **Order**: `gimmes order TICKER --prob P --size-up --yes --agent closer` (hourly tickers: additionally pass `--price XX --taker --rest-on-miss` per the Hourly Tickers section — SIZE UPs get the approval-price cap exactly like opens)
 4. **Log success**: The order command logs the trade atomically.
 5. **Log rejection** (if steps 1-2 failed): use the `--rationale-file` heredoc pattern (see "Writing rationale prose" above):
    ```bash

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1234,10 +1234,26 @@ def order(
 
             bankroll = config.bankroll
             true_prob = probability
-            if is_buy and count <= 0 and probability is not None:
+            # #766: with a #743 approval-price cap, the worst-case fill
+            # cost is count × cap (the broker reserves at the limit), so
+            # auto-sizing must use the worst-case price. Sizing at the
+            # live mid while costing at the cap deterministically
+            # overshot the position/event caps whenever cap > mid
+            # (trades 31268/31431/31513: validator approved at mid,
+            # order rejected at cap).
+            cap_price = price / 100.0 if price > 0 else None
+            auto_sized = is_buy and count <= 0 and probability is not None
+            if auto_sized:
                 true_prob = apply_base_rate_floor(probability, ticker, side=config.strategy.side)
+                # A degenerate quote (dead book, eff_price 0) must not
+                # let the cap alone produce a positive size.
+                sizing_price = (
+                    max(eff_price, cap_price)
+                    if cap_price is not None and eff_price > 0
+                    else eff_price
+                )
                 final_count = position_size(
-                    bankroll, eff_price, true_prob,
+                    bankroll, sizing_price, true_prob,
                     is_taker=is_taker,
                     fraction=config.sizing.kelly_fraction,
                     max_position_pct=config.sizing.max_position_pct, fees=fees,
@@ -1247,6 +1263,45 @@ def order(
                 final_count = count
 
             if final_count <= 0:
+                if auto_sized:
+                    # #766: sizing at the worst-case cap can honestly
+                    # produce zero — the entry could only fill at
+                    # negative edge. That is a REJECTION of an approved
+                    # candidate, not a missing-input error: exit 1 so
+                    # the Closer's Order Failure Protocol fires, and
+                    # leave a durable row so a re-dispatch loop is
+                    # visible to Groundskeeper.
+                    console.print(
+                        f"[red]Sized to zero contracts: no positive"
+                        f" edge at the worst-case price"
+                        f" (prob {true_prob:.2f} vs sizing price"
+                        f" ${sizing_price:.2f})."
+                        f" The order is refused (#766).[/red]"
+                    )
+                    await _audit_row(
+                        ErrorLogEntry(
+                            severity=ErrorSeverity.ERROR,
+                            category=ErrorCategory.ORDER_FAILURE,
+                            error_code="sized_zero",
+                            component="cli.order",
+                            agent=agent,
+                            cycle=gate_cycle,
+                            message=(
+                                f"Auto-size returned 0 contracts for"
+                                f" {ticker} — no positive edge at the"
+                                f" worst-case price (#766)"
+                            ),
+                            context=json.dumps({
+                                "ticker": ticker,
+                                "side": side,
+                                "probability": true_prob,
+                                "eff_price": eff_price,
+                                "cap_price": cap_price,
+                            }),
+                        ),
+                        "Failed to record sized_zero audit row",
+                    )
+                    raise typer.Exit(1)
                 hint = (
                     " Provide --count N or --prob P for auto-sizing."
                     if is_buy else " Provide --count N."
@@ -1254,7 +1309,7 @@ def order(
                 console.print(f"[red]No contracts to order (count=0).{hint}[/red]")
                 return
 
-            final_price = price / 100.0 if price > 0 else eff_price
+            final_price = cap_price if cap_price is not None else eff_price
             trade_dollars = final_count * final_price
 
             # --- Sell validation: check position exists and count ---
@@ -1524,6 +1579,39 @@ def order(
                         console.print(
                             "[dim]Use --force to override"
                             " (not recommended)[/dim]"
+                        )
+                        # #766: an order-time rejection previously left
+                        # no error_log trail — only the Closer's
+                        # voluntary skip row. The context carries both
+                        # price bases so a validator/order divergence
+                        # is diagnosable from the row alone. No #768
+                        # terminal marker: a validation rejection
+                        # placed nothing and is price-dependent —
+                        # next-cycle re-dispatch at fresh prices is
+                        # legitimate.
+                        await _audit_row(
+                            ErrorLogEntry(
+                                severity=ErrorSeverity.ERROR,
+                                category=ErrorCategory.ORDER_FAILURE,
+                                error_code="validation_failed",
+                                component="cli.order",
+                                agent=agent,
+                                cycle=gate_cycle,
+                                message=(
+                                    f"Order-time validation rejected"
+                                    f" {ticker}: {validation.summary}"
+                                ),
+                                context=json.dumps({
+                                    "ticker": ticker,
+                                    "side": side,
+                                    "count": final_count,
+                                    "eff_price": eff_price,
+                                    "limit_price": final_price,
+                                    "trade_dollars": trade_dollars,
+                                    "failures": validation.failures,
+                                }),
+                            ),
+                            "Failed to record validation_failed audit row",
                         )
                         return
                 else:

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3169,3 +3169,18 @@ def test_every_order_literal_carries_agent_closer() -> None:
                 f" --agent closer — it would trip the #768 identity"
                 f" gate in-cycle: {line.strip()!r}"
             )
+
+
+def test_closer_cap_sizing_note_pinned() -> None:
+    """#766: the order command sizes at the approval-price cap and a
+    zero count is an order FAILURE (exit 1). Dropping either half would
+    make the Closer misread cap-shrunk fills as failures or a silent
+    zero as success."""
+    closer_text = _CLOSER.read_text()
+    assert "auto-sizes at the cap" in closer_text
+    assert (
+        "may be smaller than the validate/size preview" in closer_text
+    )
+    assert "not a failure" in closer_text
+    assert "Sized to zero contracts" in closer_text
+    assert "that IS an order failure" in closer_text

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3172,12 +3172,17 @@ def test_every_order_literal_carries_agent_closer() -> None:
 
 
 def test_closer_cap_sizing_note_pinned() -> None:
-    """#766: the order command sizes at the approval-price cap and a
-    zero count is an order FAILURE (exit 1). Dropping either half would
-    make the Closer misread cap-shrunk fills as failures or a silent
-    zero as success."""
+    """#766: the order command sizes at the worst-case fill price
+    (max of live price and approval cap) and a zero count is an order
+    FAILURE (exit 1). Dropping either half would make the Closer
+    misread cap-shrunk fills as failures or a silent zero as
+    success."""
     closer_text = _CLOSER.read_text()
-    assert "auto-sizes at the cap" in closer_text
+    assert "auto-sizes at the worst-case fill price" in closer_text
+    assert (
+        "the HIGHER of the live effective price and the cap"
+        in closer_text
+    )
     assert (
         "may be smaller than the validate/size preview" in closer_text
     )

--- a/tests/unit/test_cap_sizing.py
+++ b/tests/unit/test_cap_sizing.py
@@ -1,0 +1,363 @@
+"""#766: auto-sizing uses the worst-case (cap) price.
+
+With a #743 approval-price cap, the worst-case fill cost is
+count × cap (the broker reserves at the limit), but sizing at the live
+mid clamped count × mid to the $-cap — so any cap above the mid
+deterministically overshot the position/event caps at the order
+command's validate_trade call while the Closer's standalone
+`gimmes validate` (mid-based, no --price) had approved. Trades
+31268/31431/31513. The fix sizes at max(mid, cap); the rejection path
+also gains a durable validation_failed error row.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gimmes.config import (
+    GimmesConfig,
+    Mode,
+    PaperTradingConfig,
+    RiskConfig,
+    ScannerConfig,
+    SizingConfig,
+    StrategyConfig,
+)
+from gimmes.models.market import Market, MarketStatus
+from gimmes.risk.validator import validate_trade
+from gimmes.strategy.kelly import position_size
+from tests.unit import test_order_error_handling as h
+
+
+def _config() -> GimmesConfig:
+    return GimmesConfig(
+        mode=Mode.DRIVING_RANGE,
+        strategy=StrategyConfig(
+            side="no",
+            min_true_probability=0.90,
+            min_edge_after_fees=0.05,
+        ),
+        sizing=SizingConfig(kelly_fraction=0.25, max_position_pct=0.1),
+        risk=RiskConfig(bankroll_paper=5000.0, max_event_exposure_pct=0.1),
+        scanner=ScannerConfig(hourly_series=["KXBTCD"]),
+        paper=PaperTradingConfig(starting_balance=5000.0),
+    )
+
+
+def _market(yes_mid: float) -> Market:
+    spread = 0.02
+    return Market(
+        ticker="KXBTCD-26AUG0612-T64799.99",
+        event_ticker="KXBTCD-26AUG0612",
+        series_ticker="KXBTCD",
+        title="BTC hourly",
+        status=MarketStatus.ACTIVE,
+        yes_bid=yes_mid - spread / 2,
+        yes_ask=yes_mid + spread / 2,
+        last_price=yes_mid,
+        volume=5000,
+        volume_24h=1200,
+        open_interest=800,
+        close_time=datetime(2026, 8, 6, 17, 0, tzinfo=UTC),
+        rules_primary="Resolves YES if BTC is above the strike.",
+    )
+
+
+class TestWorstCaseSizing:
+    """Real position_size + validate_trade — the incident replays."""
+
+    def test_incident_31268_cap_above_mid_now_approves(self) -> None:
+        """Mid $0.66, cap $0.85: sized at the cap, count × cap fits the
+        $500 caps and validate_trade approves — the trade executes at a
+        compliant size instead of being rejected."""
+        cfg = _config()
+        eff_mid, cap = 0.66, 0.85
+        prob = 0.95
+        contracts = position_size(
+            5000.0, max(eff_mid, cap), prob,
+            is_taker=True, fraction=cfg.sizing.kelly_fraction,
+            max_position_pct=cfg.sizing.max_position_pct,
+        )
+        # A real, near-cap-utilization trade — not a token position
+        assert contracts * cap >= 400.0
+        assert contracts * cap <= 500.0 + 1e-9
+
+        result = validate_trade(
+            _market(1 - eff_mid), contracts * cap, prob, 5000.0,
+            0.0, 0, [], cfg, is_taker=True,
+        )
+        assert result.approved, result.failures
+
+    def test_cap_sized_dollars_hit_event_cap(self) -> None:
+        """Cap-sized dollars flow into check_event_exposure: with $250
+        already deployed on the event, ~$494 more rejects at the $500
+        event cap."""
+        cfg = _config()
+        eff_mid, cap = 0.66, 0.85
+        contracts = position_size(
+            5000.0, max(eff_mid, cap), 0.95,
+            is_taker=True, fraction=cfg.sizing.kelly_fraction,
+            max_position_pct=cfg.sizing.max_position_pct,
+        )
+        result = validate_trade(
+            _market(1 - eff_mid), contracts * cap, 0.95, 5000.0,
+            0.0, 0, [], cfg, is_taker=True,
+            event_exposure=250.0,
+        )
+        assert not result.approved
+        assert any("Event exposure" in f for f in result.failures)
+
+    def test_old_mid_sizing_overshot_the_cap(self) -> None:
+        """The pre-fix arithmetic: sized at the mid, costed at the cap
+        — deterministic overshoot (documents why the fix exists)."""
+        eff_mid, cap = 0.66, 0.85
+        contracts = position_size(
+            5000.0, eff_mid, 0.95,
+            is_taker=True, fraction=0.25, max_position_pct=0.1,
+        )
+        assert contracts * cap > 500.0
+
+    def test_market_moved_shape_31431(self) -> None:
+        """Mid moved to $0.70 with cap $0.85: still sized at the cap,
+        still fits."""
+        cfg = _config()
+        eff_mid, cap = 0.70, 0.85
+        contracts = position_size(
+            5000.0, max(eff_mid, cap), 0.95,
+            is_taker=True, fraction=cfg.sizing.kelly_fraction,
+            max_position_pct=cfg.sizing.max_position_pct,
+        )
+        assert contracts > 0
+        assert contracts * cap <= 500.0 + 1e-9
+
+    def test_cap_below_mid_sizes_at_mid(self) -> None:
+        """max() selects the mid; cost at the (lower) cap is smaller
+        than the mid notional and passes trivially."""
+        eff_mid, cap = 0.66, 0.60
+        at_worst = position_size(
+            5000.0, max(eff_mid, cap), 0.95,
+            is_taker=True, fraction=0.25, max_position_pct=0.1,
+        )
+        at_mid = position_size(
+            5000.0, eff_mid, 0.95,
+            is_taker=True, fraction=0.25, max_position_pct=0.1,
+        )
+        assert at_worst == at_mid
+        assert at_worst * cap <= 500.0 + 1e-9
+
+    def test_negative_edge_at_cap_sizes_zero(self) -> None:
+        """prob at/below cap + fee → zero contracts: a resting order
+        that can only fill at negative edge should not exist."""
+        assert (
+            position_size(
+                5000.0, 0.85, 0.80,
+                is_taker=True, fraction=0.25, max_position_pct=0.1,
+            )
+            == 0
+        )
+
+
+class TestCliSizingWiring:
+    """The order command passes the worst-case price to position_size."""
+
+    def _run(self, cli_args):
+        sized = MagicMock(return_value=100)
+        broker = h._make_mock_broker()
+        with patch("gimmes.strategy.kelly.position_size", sized):
+            result, console, insert_error = h._run_order_cli(
+                broker, cli_args=cli_args,
+            )
+        return result, sized, insert_error
+
+    def test_cap_above_mid_sizes_at_cap(self) -> None:
+        # Harness market: YES mid 0.40 → side yes eff price 0.40.
+        _, sized, _ = self._run([
+            "order", "TEST-TICKER",
+            "--side", "yes", "--price", "85", "--prob", "0.95", "--yes",
+        ])
+        assert sized.call_args.args[1] == 0.85
+
+    def test_no_cap_sizes_at_mid(self) -> None:
+        _, sized, _ = self._run([
+            "order", "TEST-TICKER",
+            "--side", "yes", "--prob", "0.95", "--yes",
+        ])
+        assert sized.call_args.args[1] == 0.40
+
+    def test_cap_below_mid_sizes_at_mid(self) -> None:
+        _, sized, _ = self._run([
+            "order", "TEST-TICKER",
+            "--side", "yes", "--price", "20", "--prob", "0.95", "--yes",
+        ])
+        assert sized.call_args.args[1] == 0.40
+
+    def test_size_up_with_cap_sizes_at_cap(self) -> None:
+        _, sized, _ = self._run([
+            "order", "TEST-TICKER",
+            "--side", "yes", "--size-up", "--price", "85",
+            "--prob", "0.95", "--yes",
+        ])
+        assert sized.call_args.args[1] == 0.85
+
+
+class TestSizedZeroIsFailure:
+    """#766 review-found: an approved candidate sizing to zero at the
+    cap must fail LOUDLY (exit 1 + durable row), never exit-0 no-op —
+    the Closer's protocol keys on the exit code."""
+
+    def _run_zero(self, cli_args):
+        broker = h._make_mock_broker()
+        with patch(
+            "gimmes.strategy.kelly.position_size",
+            MagicMock(return_value=0),
+        ):
+            result, console, insert_error = h._run_order_cli(
+                broker, cli_args=cli_args,
+            )
+        return result, h._printed(console), broker, insert_error
+
+    def test_auto_sized_zero_exits_one_with_row(self) -> None:
+        result, out, broker, insert_error = self._run_zero([
+            "order", "TEST-TICKER",
+            "--side", "yes", "--price", "85", "--prob", "0.95", "--yes",
+        ])
+        assert result.exit_code == 1, out
+        assert "Sized to zero contracts" in out
+        assert broker.create_order.await_count == 0
+        rows = [
+            c.args[1]
+            for c in insert_error.await_args_list
+            if len(c.args) > 1 and c.args[1].error_code == "sized_zero"
+        ]
+        assert len(rows) == 1
+        ctx = json.loads(rows[0].context)
+        assert ctx["cap_price"] == 0.85
+        assert ctx["eff_price"] == 0.40
+
+    def test_missing_inputs_keep_old_exit_zero(self) -> None:
+        """No --prob and no --count is operator error, not a sized-zero
+        rejection — the old message and exit stay."""
+        result, out, broker, insert_error = self._run_zero([
+            "order", "TEST-TICKER", "--side", "yes", "--yes",
+        ])
+        assert result.exit_code == 0, out
+        assert "No contracts to order" in out
+        codes = [
+            c.args[1].error_code
+            for c in insert_error.await_args_list
+            if len(c.args) > 1
+        ]
+        assert "sized_zero" not in codes
+
+    def test_degenerate_quote_does_not_size_from_cap(self) -> None:
+        """Dead book (eff price 0): the cap alone must not produce a
+        positive size — sizing sees the degenerate price and returns
+        0 via the kelly guard, landing in the loud sized-zero exit."""
+        market = h._stub_market()
+        market.midpoint = 0.0
+        market.last_price = 0.0
+        broker = h._make_mock_broker()
+        sized = MagicMock(return_value=0)
+        with patch("gimmes.strategy.kelly.position_size", sized):
+            result, console, _ = h._run_order_cli(
+                broker, market=market,
+                cli_args=[
+                    "order", "TEST-TICKER",
+                    "--side", "yes", "--price", "85",
+                    "--prob", "0.95", "--yes",
+                ],
+            )
+        assert sized.call_args.args[1] == 0.0
+        assert result.exit_code == 1
+
+
+class TestValidationFailedAuditRow:
+    """An order-time validation rejection leaves a durable error row
+    carrying both price bases; no #768 terminal marker is armed."""
+
+    def _run_rejected(self, extra_args=None, monkeypatch=None):
+        broker = h._make_mock_broker()
+        activity = AsyncMock(return_value=1)
+        validation = MagicMock(
+            approved=False,
+            failures=["Position $638.95 exceeds max $500.00"],
+            summary="Validation failed with 1 check",
+        )
+        # Arm the #768 marker machinery for real (in-cycle + closer
+        # agent) so the no-marker assertion is not vacuous.
+        if monkeypatch is not None:
+            monkeypatch.setenv("GIMMES_CYCLE", "42")
+        args = list(extra_args or [])
+        if monkeypatch is not None:
+            args += ["--agent", "closer"]
+        result, console, insert_error = h._run_order_cli(
+            broker,
+            extra_args=args,
+            validation=validation,
+            insert_activity_mock=activity,
+        )
+        return result, broker, insert_error, activity
+
+    def test_rejection_writes_validation_failed_row(
+        self, monkeypatch,
+    ) -> None:
+        result, broker, insert_error, activity = self._run_rejected(
+            monkeypatch=monkeypatch,
+        )
+        assert broker.create_order.await_count == 0
+        rows = [
+            c.args[1]
+            for c in insert_error.await_args_list
+            if len(c.args) > 1
+            and c.args[1].error_code == "validation_failed"
+        ]
+        assert len(rows) == 1
+        ctx = json.loads(rows[0].context)
+        assert ctx["ticker"] == "TEST-TICKER"
+        assert ctx["count"] == 10
+        assert ctx["eff_price"] == 0.40
+        assert ctx["limit_price"] == 0.40
+        assert ctx["trade_dollars"] == 4.0
+        assert ctx["failures"] == [
+            "Position $638.95 exceeds max $500.00"
+        ]
+        # No #768 terminal marker: next-cycle re-dispatch at fresh
+        # prices must stay possible.
+        markers = [
+            c.kwargs
+            for c in activity.await_args_list
+            if c.kwargs.get("message", "").startswith(
+                "Order attempt terminal:"
+            )
+        ]
+        assert markers == []
+
+    def test_context_carries_cap_price_basis(self) -> None:
+        result, _, insert_error, _ = self._run_rejected(
+            extra_args=["--price", "85"],
+        )
+        rows = [
+            c.args[1]
+            for c in insert_error.await_args_list
+            if len(c.args) > 1
+            and c.args[1].error_code == "validation_failed"
+        ]
+        assert len(rows) == 1
+        ctx = json.loads(rows[0].context)
+        assert ctx["eff_price"] == 0.40
+        assert ctx["limit_price"] == 0.85
+        assert ctx["trade_dollars"] == 8.5
+
+    def test_force_overrides_without_error_row(self) -> None:
+        result, broker, insert_error, _ = self._run_rejected(
+            extra_args=["--force"],
+        )
+        assert broker.create_order.await_count == 1
+        codes = [
+            c.args[1].error_code
+            for c in insert_error.await_args_list
+            if len(c.args) > 1
+        ]
+        assert "validation_failed" not in codes


### PR DESCRIPTION
## Summary

Three approved hourly entries (trades 31268/31431/31513) were rejected at the order command's own `validate_trade` because auto-sizing priced at the live mid (Kelly-clamped so count × mid ≈ \$500) while `trade_dollars` used the #743 `--price` cap — any cap above the mid overshot the position/event caps deterministically, after the Closer's mid-based `gimmes validate` (which has no `--price` option) had approved.

**Fix: auto-sized BUYs size at `max(live mid, cap)`.** count × cap then fits the caps by construction, so the trade executes at a compliant size; a fill below the cap deploys less capital. The alternative — letting the validator use mid-based dollars — was rejected: the paper broker reserves resting BUYs at the limit price, so count × cap is the *real* worst-case cost and weakening the check would tolerate genuine breaches.

**Loud failures where there was silence (review-found):**
- An approved candidate sizing to **zero** at the cap (no positive edge at the worst-case price) now exits 1 with a durable `sized_zero` ORDER_FAILURE row — previously a silent exit-0 no-op the Closer's protocol read as success, allowing an every-cycle re-dispatch loop invisible to Groundskeeper.
- An order-time validation rejection now writes a `validation_failed` row carrying both price bases (`eff_price` + `limit_price`), count, dollars, and the failure list — the issue's "no actionable error entry" complaint. No #768 terminal marker: a validation rejection placed nothing and next-cycle re-dispatch at fresh prices stays legitimate.
- A degenerate quote (dead book, eff price 0) can no longer produce a positive size from the cap alone.

**Prompts:** closer.md documents that the order command is the binding risk check (cap-shrunk counts are expected; count **zero** is an order failure), and the SIZE-UP step now names the hourly cap flags it was always supposed to carry. Drift-guard pinned.

Untouched: explicit `--count` orders (operator instruction — loud rejection is correct), sells, the churn gate's deliberate mid basis, `gimmes validate`/`size` (advisory; documented).

Closes #766

## Test plan

- 16 tests in `tests/unit/test_cap_sizing.py`: real position_size + validate_trade incident replays (31268 approves at ~99% cap utilization — asserted ≥\$400, not just >0; market-moved shape; cap-below-mid; negative-edge-at-cap → 0; event-cap interaction), CLI wiring (cap/no-cap/below-mid/size-up sizing price asserted on the real call), sized-zero loud failure (exit 1 + row; missing-inputs path keeps old behavior; degenerate quote), validation-rejection rows (both price bases; `--force` override unaffected; no-terminal-marker assertion armed for real with in-cycle env + closer agent).
- closer.md note pinned in `test_agent_prompts.py`.
- Frozen full unit suite: **2393 passed** in 16:16. Lint clean.

Note: pr-review-toolkit is not installed; the equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r