### PR TITLE
Position lifecycle: closed reads, settlement sweep, phantom-row repair (#751 family)

### DIFF
--- a/.claude/agents/starter.md
+++ b/.claude/agents/starter.md
@@ -263,7 +263,7 @@ When the user suggests an improvement or says something like "I wish it could...
 
 ## Rules
 
-- You are read-only — command and file restrictions are defined in Safe Demo Commands, Forbidden Commands, and General Bash Restrictions above
+- You are read-only — command and file restrictions are defined in Safe Demo Commands, Forbidden Commands, and General Bash Restrictions above. (Bookkeeping caveat: `risk-check`, `positions`, and `report` may advance settlement bookkeeping for already-resolved markets and record data-integrity observations — that is routine housekeeping the commands perform for any caller, not a trading action by you.)
 - NEVER read, search, or display sensitive files: `.env`, `*.pem`, `*.key`, `private_key*`, `credentials*`, or any file containing API tokens or secrets — this applies to all tools and mechanisms
 - NEVER read or display config values from the database — explain configuration conceptually and point users to `gimmes config`
 - Stay product-focused — deflect code internals, non-GIMMES topics, and trading requests

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -349,8 +349,16 @@ async def _mark_positions_to_market(
     *,
     known_prices: dict[str, float] | None = None,
 ) -> list:
-    """Mark all paper positions to market and return refreshed list."""
+    """Mark all paper positions to market and return refreshed list.
+
+    #751/#720/#635: a DETERMINED/FINALIZED market is settled here, not
+    just marked — previously only the `positions` command settled, so
+    every other consumer (risk-check, the order/validate position
+    load) kept counting a resolved position's cost basis and stale
+    unrealized P&L until the next `gimmes positions` run.
+    """
     from gimmes.kalshi.markets import get_market
+    from gimmes.models.market import MarketStatus
 
     positions = await broker.get_positions()
     prices = dict(known_prices or {})
@@ -362,6 +370,39 @@ async def _mark_positions_to_market(
                 market = await get_market(client, pos.ticker)
                 prices[pos.ticker] = market.midpoint or market.last_price
                 markets[pos.ticker] = market
+            resolved_market = markets.get(pos.ticker)
+            if (
+                resolved_market is not None
+                and resolved_market.status
+                in (MarketStatus.DETERMINED, MarketStatus.FINALIZED)
+                and resolved_market.result in ("yes", "no")
+            ):
+                # Settle instead of marking — marking a determined
+                # market at a stale mid is itself wrong, and settle()
+                # removes the position (and its mirror row, #653) so
+                # the refetch below excludes it. Named loudly: the
+                # position vanishes between two commands otherwise
+                # (review-found); settle() itself writes the durable
+                # settlement close row + position note.
+                try:
+                    await broker.settle(
+                        pos.ticker, resolved_market.result,
+                    )
+                    console.print(
+                        f"[dim]Settled {pos.ticker}"
+                        f" ({resolved_market.result}) — market"
+                        f" {resolved_market.status.value}[/dim]"
+                    )
+                except Exception as exc:
+                    # An accurate diagnosis, not the mark warning: a
+                    # lock-contended settle silently retried-and-
+                    # failed every run would hide behind "could not
+                    # mark" (review-found).
+                    console.print(
+                        f"[yellow]Warning: could not settle"
+                        f" {pos.ticker}: {exc}[/yellow]"
+                    )
+                continue
             await broker.mark_to_market(
                 pos.ticker,
                 prices[pos.ticker],
@@ -2612,8 +2653,14 @@ def positions() -> None:
                             await broker.mark_to_market(
                                 pos.ticker, current_price,
                             )
-                        # Auto-settle if market resolved
-                        if market.status in (MarketStatus.DETERMINED, MarketStatus.FINALIZED):
+                        # Auto-settle if market resolved. Guard on a
+                        # settleable result (#751 review) — an empty
+                        # result would score every side as a loss.
+                        if (
+                            market.status
+                            in (MarketStatus.DETERMINED, MarketStatus.FINALIZED)
+                            and market.result in ("yes", "no")
+                        ):
                             await broker.settle(pos.ticker, market.result)
                     except Exception as exc:
                         # #674: the position keeps its LAST mark — the
@@ -2675,8 +2722,13 @@ def risk_check() -> None:
 
         async with trading_context(config) as (client, broker, db):
             if broker:
-                balance = await broker.get_balance()
+                # #751/#720: mark AND settle before counting — a
+                # resolved-but-unswept position must not inflate the
+                # count, deployed capital, or unrealized P&L. Balance
+                # is read AFTER so the settlement credit and the
+                # position list come from the same snapshot.
                 pos = await _mark_positions_to_market(broker, client)
+                balance = await broker.get_balance()
             else:
                 from gimmes.kalshi.portfolio import get_all_positions, get_balance
                 from gimmes.store.queries import sync_positions
@@ -3259,6 +3311,77 @@ def reconcile() -> None:
     _run(_reconcile())
 
 
+async def _report_consistency_footnote(db, summary) -> None:
+    """#767: name a ledger-vs-positions divergence and leave a durable
+    row — missing tickers in either direction AND per-ticker count
+    drift (a live re-poisoning of the #751 shape is visible while the
+    position is still open, not only after settlement).
+
+    The error row is change-detected: an unchanged divergence across
+    report runs prints the footnote but writes no new row, so a
+    persistent divergence is one Groundskeeper signal per state
+    change, not one per cycle.
+    """
+    import json as _json
+
+    from gimmes.models.error import (
+        ErrorCategory,
+        ErrorLogEntry,
+        ErrorSeverity,
+    )
+
+    cursor = await db.conn.execute(
+        "SELECT ticker, count FROM positions WHERE count > 0"
+    )
+    pos_counts = {
+        row["ticker"]: row["count"] for row in await cursor.fetchall()
+    }
+    ledger = summary.open_residuals
+    only_ledger = sorted(set(ledger) - set(pos_counts))
+    only_pos = sorted(set(pos_counts) - set(ledger))
+    count_drift = sorted(
+        t for t in set(ledger) & set(pos_counts)
+        if ledger[t] != pos_counts[t]
+    )
+    if not (only_ledger or only_pos or count_drift):
+        return
+
+    drift_detail = {
+        t: {"ledger": ledger[t], "positions": pos_counts[t]}
+        for t in count_drift
+    }
+    console.print(
+        f"[dim]Open-count divergence (#767): ledger-only"
+        f" {only_ledger or '—'}, positions-only {only_pos or '—'},"
+        f" count-drift {count_drift or '—'}[/dim]"
+    )
+    payload = {
+        "ledger_only": only_ledger,
+        "positions_only": only_pos,
+        "count_drift": drift_detail,
+    }
+    cursor = await db.conn.execute(
+        "SELECT context FROM error_log"
+        " WHERE error_code = 'position_count_mismatch'"
+        " ORDER BY id DESC LIMIT 1"
+    )
+    last = await cursor.fetchone()
+    if last and last["context"] == _json.dumps(payload):
+        return
+    await _log_cli_error(db, ErrorLogEntry(
+        severity=ErrorSeverity.WARNING,
+        category=ErrorCategory.DATA_INTEGRITY,
+        error_code="position_count_mismatch",
+        component="cli.report",
+        message=(
+            f"Ledger open state diverges from positions table:"
+            f" ledger-only {only_ledger}, positions-only {only_pos},"
+            f" count-drift {count_drift}"
+        ),
+        context=_json.dumps(payload),
+    ))
+
+
 @app.command(rich_help_panel="Portfolio")
 def report() -> None:
     """Generate performance scorecard."""
@@ -3282,6 +3405,22 @@ def report() -> None:
                 trades = opens + closes + size_ups
                 summary = calculate_pnl(trades)
                 format_pnl_summary(summary)
+                # #767: the report's open count comes from ledger
+                # residuals; the positions table is the broker's view.
+                # A divergence — missing ticker OR count drift — means
+                # a poisoned ledger row (the #751 phantom) or a missed
+                # settlement. Own try/except: a failure here must not
+                # fall into the outer catch-all and double-print a
+                # zeroed summary under the real one (review-found).
+                try:
+                    await _report_consistency_footnote(db, summary)
+                except Exception:
+                    import logging
+
+                    logging.getLogger("gimmes").warning(
+                        "report: consistency footnote failed",
+                        exc_info=True,
+                    )
         except Exception as exc:
             import logging
             logging.getLogger("gimmes").warning("report: failed to load trades: %s", exc)
@@ -4141,6 +4280,7 @@ def position_context(
         from gimmes.reporting.formatter import format_local_timestamp
         from gimmes.store.database import Database
         from gimmes.store.queries import (
+            get_last_close_row,
             get_open_trade_for_ticker,
             get_position_notes,
             has_open_position,
@@ -4151,6 +4291,19 @@ def position_context(
             matches = await resolve_ticker(
                 db, ticker, source="open_positions",
             )
+            if not matches:
+                # #751: a just-closed/settled position is a LEGITIMATE
+                # read — agents fetch note history minutes (or a day)
+                # after settlement, and hourly markets settle inside
+                # the cycle that watches them. Fall through to tickers
+                # with POSITION history (opens/closes only — the
+                # known-markets universe would explode into ambiguity
+                # on Scout's sibling-strike candidate rows); only a
+                # ticker with NO trade history is a real
+                # position_not_found.
+                matches = await resolve_ticker(
+                    db, ticker, source="traded",
+                )
             if not matches:
                 await _log_cli_error(db, ErrorLogEntry(
                     severity=ErrorSeverity.WARNING,
@@ -4185,6 +4338,7 @@ def position_context(
             resolved = matches[0]
             trade = await get_open_trade_for_ticker(db, resolved)
             is_open = await has_open_position(db, resolved)
+            last_close = await get_last_close_row(db, resolved)
             notes = await get_position_notes(db, resolved, limit=20)
             # Fetch decisions separately so chatty observations can't
             # evict the CM governance trail (#580).
@@ -4192,45 +4346,67 @@ def position_context(
                 db, resolved, limit=25, note_type="decision",
             )
 
-        if not trade or not is_open:
-            # Another process (clubhouse server, autonomous loop) may
-            # have closed the position between the resolver's read and
-            # the lookups. Treat it the same as no-match.
+        if not trade and not last_close:
+            # Resolved (e.g. a candidates-only ticker) but never
+            # traded — the real position_not_found. This also covers
+            # the old position_closed_during_lookup race: a position
+            # closed mid-lookup now has history and renders below.
             async with Database(config.db_path) as db:
                 await _log_cli_error(db, ErrorLogEntry(
                     severity=ErrorSeverity.WARNING,
                     category=ErrorCategory.DATA_INTEGRITY,
-                    error_code="position_closed_during_lookup",
+                    error_code="position_not_found",
                     component="cli.position-context",
-                    message=(
-                        f"Position {resolved} closed between resolver"
-                        f" and trade lookup"
-                    ),
+                    message=f"No open position found for {ticker}",
                     context=json.dumps({"ticker": ticker, "resolved": resolved}),
                 ))
             console.print(f"[yellow]No open position found for {ticker}[/yellow]")
             return
 
         console.print(f"\n[bold]Position Context: {resolved}[/bold]\n")
-        console.print("[bold]--- OPEN TRADE ---[/bold]")
-        console.print(f"Opened:           {format_local_timestamp(str(trade['timestamp']))}")
-        console.print(
-            f"Side:             {trade['side'].upper()}"
-            f"  Count: {trade['count']}  Entry: ${trade['price']:.2f}"
-        )
-        console.print(
-            f"Model Prob:       {trade['model_probability']:.1%}"
-            f"  Edge: {trade['edge']:+.1%}"
-            f"  GimmeScore: {trade['gimme_score']:.0f}"
-        )
-        console.print(f"Agent:            {trade['agent']}  Order ID: {trade['order_id']}")
-
-        console.print("\n[bold]--- ORIGINAL THESIS ---[/bold]")
-        thesis = trade.get("thesis", "")
-        if thesis:
-            console.print(thesis, markup=False)
+        if not is_open:
+            # #751: closed/settled position — full history renders,
+            # clearly bannered, with NO error row. The console banner
+            # is the observability; a DATA_INTEGRITY row here was the
+            # false-positive noise Groundskeeper kept escalating.
+            if last_close:
+                console.print(
+                    f"[yellow bold]POSITION CLOSED/SETTLED — last close"
+                    f" {format_local_timestamp(str(last_close['timestamp']))}"
+                    f" ({last_close['count']} @"
+                    f" ${last_close['price']:.2f},"
+                    f" {last_close['agent']})[/yellow bold]\n"
+                )
+            else:
+                console.print(
+                    "[yellow bold]POSITION CLOSED/SETTLED — no close"
+                    " row recorded[/yellow bold]\n"
+                )
+        if not trade:
+            console.print(
+                "[dim]No open trade row recorded (legacy close-only"
+                " history).[/dim]"
+            )
         else:
-            console.print("[dim][No thesis stored — position predates v8 migration][/dim]")
+            console.print("[bold]--- OPEN TRADE ---[/bold]")
+            console.print(f"Opened:           {format_local_timestamp(str(trade['timestamp']))}")
+            console.print(
+                f"Side:             {trade['side'].upper()}"
+                f"  Count: {trade['count']}  Entry: ${trade['price']:.2f}"
+            )
+            console.print(
+                f"Model Prob:       {trade['model_probability']:.1%}"
+                f"  Edge: {trade['edge']:+.1%}"
+                f"  GimmeScore: {trade['gimme_score']:.0f}"
+            )
+            console.print(f"Agent:            {trade['agent']}  Order ID: {trade['order_id']}")
+
+            console.print("\n[bold]--- ORIGINAL THESIS ---[/bold]")
+            thesis = trade.get("thesis", "")
+            if thesis:
+                console.print(thesis, markup=False)
+            else:
+                console.print("[dim][No thesis stored — position predates v8 migration][/dim]")
 
         console.print("\n[bold]--- POSITION NOTES (last 20) ---[/bold]")
         if notes:

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3355,18 +3355,24 @@ async def _report_consistency_footnote(db, summary) -> None:
         f" {only_ledger or '—'}, positions-only {only_pos or '—'},"
         f" count-drift {count_drift or '—'}[/dim]"
     )
-    payload = {
-        "ledger_only": only_ledger,
-        "positions_only": only_pos,
-        "count_drift": drift_detail,
-    }
+    # Canonical serialization, computed ONCE and reused for both the
+    # dedup comparison and the insert — key-order or encoding drift
+    # must not defeat the change-detection (Copilot review).
+    payload = _json.dumps(
+        {
+            "ledger_only": only_ledger,
+            "positions_only": only_pos,
+            "count_drift": drift_detail,
+        },
+        sort_keys=True,
+    )
     cursor = await db.conn.execute(
         "SELECT context FROM error_log"
         " WHERE error_code = 'position_count_mismatch'"
         " ORDER BY id DESC LIMIT 1"
     )
     last = await cursor.fetchone()
-    if last and last["context"] == _json.dumps(payload):
+    if last and last["context"] == payload:
         return
     await _log_cli_error(db, ErrorLogEntry(
         severity=ErrorSeverity.WARNING,
@@ -3378,7 +3384,7 @@ async def _report_consistency_footnote(db, summary) -> None:
             f" ledger-only {only_ledger}, positions-only {only_pos},"
             f" count-drift {count_drift}"
         ),
-        context=_json.dumps(payload),
+        context=payload,
     ))
 
 
@@ -4346,11 +4352,14 @@ def position_context(
                 db, resolved, limit=25, note_type="decision",
             )
 
-        if not trade and not last_close:
+        if not is_open and not trade and not last_close:
             # Resolved (e.g. a candidates-only ticker) but never
-            # traded — the real position_not_found. This also covers
-            # the old position_closed_during_lookup race: a position
-            # closed mid-lookup now has history and renders below.
+            # traded and not open — the real position_not_found. This
+            # also covers the old position_closed_during_lookup race:
+            # a position closed mid-lookup now has history and renders
+            # below. An OPEN position with a missing trade log
+            # (imported/synced without an open row) must still render
+            # (Copilot review).
             async with Database(config.db_path) as db:
                 await _log_cli_error(db, ErrorLogEntry(
                     severity=ErrorSeverity.WARNING,
@@ -4384,8 +4393,7 @@ def position_context(
                 )
         if not trade:
             console.print(
-                "[dim]No open trade row recorded (legacy close-only"
-                " history).[/dim]"
+                "[dim]No open trade row recorded.[/dim]"
             )
         else:
             console.print("[bold]--- OPEN TRADE ---[/bold]")

--- a/src/gimmes/paper/broker.py
+++ b/src/gimmes/paper/broker.py
@@ -767,14 +767,6 @@ class PaperBroker:
         NO position + NO result → pays $1/contract
         NO position + YES result → pays $0
         """
-        cursor = await self._conn.execute(
-            "SELECT * FROM paper_positions WHERE ticker = ? AND count > 0",
-            (ticker,),
-        )
-        rows = await cursor.fetchall()
-        if not rows:
-            return
-
         from gimmes.store.queries import (
             count_opened_closed,
             fill_resolved_outcome,
@@ -783,9 +775,24 @@ class PaperBroker:
         )
 
         async with self._db.transaction():
+            # #751 review: read INSIDE the transaction (BEGIN
+            # IMMEDIATE) — with settle now reachable from
+            # risk-check/order/validate (not just `positions`), a
+            # pre-transaction read was a TOCTOU window where a
+            # concurrent settle of the same position could
+            # double-credit the payout.
+            cursor = await self._conn.execute(
+                "SELECT * FROM paper_positions"
+                " WHERE ticker = ? AND count > 0",
+                (ticker,),
+            )
+            rows = await cursor.fetchall()
+            if not rows:
+                return
+
             for row in rows:
-                count = int(row["count"])
                 side = row["side"]
+                count = int(row["count"])
                 cost_basis = float(row["cost_basis"])
 
                 won = (side == result)

--- a/src/gimmes/reporting/pnl.py
+++ b/src/gimmes/reporting/pnl.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from gimmes.strategy.fees import fee_for_order
 
@@ -16,6 +16,11 @@ class PnLSummary:
 
     total_trades: int = 0
     open_trades: int = 0
+    # #767: residual open contracts per ticker in the ledger —
+    # compared against the positions table by the report command so a
+    # ledger/positions divergence (missing ticker OR count drift) is
+    # visible instead of silently skewing the open count.
+    open_residuals: dict[str, int] = field(default_factory=dict)
     winning_trades: int = 0
     losing_trades: int = 0
     scratch_trades: int = 0
@@ -180,6 +185,9 @@ def calculate_pnl(
         if remaining > 0:
             summary.total_trades += 1
             summary.open_trades += 1
+            summary.open_residuals[ticker] = (
+                summary.open_residuals.get(ticker, 0) + remaining
+            )
 
     summary.net_pnl = summary.gross_pnl - summary.total_fees
     return summary

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -7,7 +7,7 @@ from gimmes.store.database import Database
 # The version a fully-migrated DB reports (#680): read-only consumers
 # (the clubhouse) compare against this at startup. Drift-guarded by
 # test_latest_schema_version_constant_matches_migrations.
-LATEST_SCHEMA_VERSION = 18
+LATEST_SCHEMA_VERSION = 19
 
 # Migrations are applied sequentially. Each is a tuple of (version, sql).
 MIGRATIONS: list[tuple[int, str]] = [
@@ -361,5 +361,29 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 18
+
+    # Version 19 (#751/#767): repair the one pre-#743 poisoned ledger
+    # row — order paper-da2137458555 requested 523 contracts but filled
+    # 185; the open row logged 523 while the settlement close logged
+    # the true 185, leaving a permanent 338-contract residual that made
+    # `gimmes report` count a phantom open position forever. #743 fixed
+    # the generator (open rows log filled_now); this retires the sole
+    # surviving pre-fix row. Fingerprinted by order_id (uuid4-derived;
+    # not schema-enforced unique, so the count=523 term is load-
+    # bearing) + action, idempotent and a no-op on any other database.
+    if current < 19:
+        await db.conn.execute(
+            "UPDATE trades SET count = 185,"
+            " rationale = rationale ||"
+            " ' — count corrected 523→185 (order filled 185;"
+            " pre-#743 open row, #751)'"
+            " WHERE order_id = 'paper-da2137458555'"
+            " AND action = 'open' AND count = 523"
+        )
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (19,)
+        )
+        await db.conn.commit()
+        current = 19
 
     return current

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -1257,6 +1257,25 @@ async def get_last_entry_trade(
     return dict(row) if row else None
 
 
+async def get_last_close_row(
+    db: Database, ticker: str,
+) -> dict | None:  # type: ignore[type-arg]
+    """The ticker's most recent close row from ANY agent, or None.
+
+    Unlike get_last_close_trade (#661, decision closes only), this
+    includes settlement and reconcile closes — it answers "did this
+    position ever close?" for the closed-position context read (#751).
+    """
+    cursor = await db.conn.execute(
+        "SELECT price, timestamp, count, agent, side FROM trades"
+        " WHERE ticker = ? AND action = 'close'"
+        " ORDER BY replace(timestamp, ' ', 'T') DESC, id DESC LIMIT 1",
+        (ticker,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
 async def get_last_close_trade(
     db: Database, ticker: str,
 ) -> dict | None:  # type: ignore[type-arg]

--- a/src/gimmes/store/ticker_resolver.py
+++ b/src/gimmes/store/ticker_resolver.py
@@ -29,7 +29,7 @@ from typing import Literal
 
 from gimmes.store.database import Database
 
-TickerSource = Literal["open_positions", "known_markets"]
+TickerSource = Literal["open_positions", "known_markets", "traded"]
 
 
 # Kalshi tickers are canonical uppercase alphanumerics with ``-`` and
@@ -53,6 +53,18 @@ _KNOWN_MARKETS_SQL = (
     "WHERE ticker LIKE ? || '%' "
     "UNION SELECT ticker FROM trades "
     "WHERE ticker LIKE ? || '%' "
+    "ORDER BY ticker"
+)
+
+# #751: tickers with actual POSITION history (opens/closes/size-ups).
+# The closed-position context fallback must not resolve against
+# candidates or skip rows — Scout logs sibling strikes every hour, so
+# a prefix read after settlement would explode into ambiguity on
+# research noise that was never a position.
+_TRADED_TICKERS_SQL = (
+    "SELECT DISTINCT ticker FROM trades "
+    "WHERE ticker LIKE ? || '%' "
+    "AND action IN ('open', 'close', 'size_up') "
     "ORDER BY ticker"
 )
 
@@ -103,6 +115,10 @@ async def resolve_ticker(
             - ``"known_markets"``: distinct tickers from any of
               ``positions``, ``candidates``, ``trades``. Use for
               ``gimmes market-info``.
+            - ``"traded"``: distinct tickers with open/close/size_up
+              trade rows — position history only, excluding candidate
+              and skip noise. Use for the closed-position context
+              fallback (#751).
 
     Returns:
         Sorted list of matching tickers (deduplicated). If the cleaned
@@ -114,6 +130,8 @@ async def resolve_ticker(
 
     if source == "open_positions":
         cursor = await db.conn.execute(_OPEN_POSITIONS_SQL, (cleaned,))
+    elif source == "traded":
+        cursor = await db.conn.execute(_TRADED_TICKERS_SQL, (cleaned,))
     else:
         cursor = await db.conn.execute(
             _KNOWN_MARKETS_SQL, (cleaned, cleaned, cleaned),

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -697,15 +697,13 @@ class TestErrorLogging:
             for e in errors
         ), errors
 
-    def test_position_context_race_condition_logs_error(
+    def test_position_context_race_renders_closed_context(
         self, seeded_db: Path,
     ) -> None:
-        # Resolver returns a match (position exists at first read),
-        # but `has_open_position` returns False (another process
-        # closed it between reads). This is the race-condition branch
-        # at the bottom of position-context; it must log a distinct
-        # error_code so Groundskeeper can distinguish it from a plain
-        # no-match miss.
+        # #751: the old race branch (position closed between resolver
+        # read and trade lookup) now renders the closed-position
+        # context — history exists, so this is a legitimate read, not
+        # a data-integrity fault. No error row of any kind.
         with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
              patch(
                 "gimmes.store.queries.has_open_position",
@@ -715,13 +713,13 @@ class TestErrorLogging:
                 app,
                 ["position-context", "KXJOBLESSCLAIMS-26MAY14-210000"],
             )
-        # The user-facing path treats this as no-match (exit 0, yellow).
         assert result.exit_code == 0, result.output
+        assert "POSITION CLOSED/SETTLED" in result.output
+        assert "Position Context:" in result.output
         errors = _read_error_log(seeded_db)
-        assert any(
-            e["category"] == "data_integrity"
-            and e["error_code"] == "position_closed_during_lookup"
-            and e["component"] == "cli.position-context"
+        assert not any(
+            e["error_code"]
+            in ("position_closed_during_lookup", "position_not_found")
             for e in errors
         ), errors
 

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -1,0 +1,459 @@
+"""#751/#720/#639/#635/#767: the position-lifecycle family.
+
+Three root causes, one fix:
+- RC-1: position-context treated a just-closed/settled position as a
+  DATA_INTEGRITY fault — every position_not_found row in the live DB
+  fired seconds-to-hours AFTER the ticker's own close trade.
+- RC-2: only the `positions` command settled DETERMINED markets;
+  risk-check and the order/validate position load kept counting a
+  resolved position's cost basis and stale unrealized P&L.
+- RC-3: `gimmes report` counts ledger residuals; one pre-#743 poisoned
+  open row (523 logged vs 185 filled) made it report a phantom open
+  position forever. Migration v19 repairs the row; the report gains a
+  ledger-vs-positions consistency footnote + durable row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from gimmes.cli import _mark_positions_to_market, app
+from gimmes.models.market import MarketStatus
+from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
+from gimmes.reporting.pnl import calculate_pnl
+from gimmes.store.database import Database
+from gimmes.store.migrations import run_migrations
+from gimmes.store.queries import insert_candidate, insert_trade
+
+runner = CliRunner()
+
+TICKER = "KXBTCD-26AUG1118-T63599.99"
+
+
+def _db_run(db_path: Path, fn):
+    async def _go():
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await fn(db)
+        finally:
+            await db.close()
+
+    return asyncio.run(_go())
+
+
+def _config(db_path: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.strategy.side = "no"
+    return cfg
+
+
+def _read_errors(db_path: Path) -> list[dict]:
+    async def _q(db):
+        cursor = await db.conn.execute(
+            "SELECT error_code, category, component, message, context"
+            " FROM error_log"
+        )
+        return [dict(r) for r in await cursor.fetchall()]
+
+    return _db_run(db_path, _q)
+
+
+async def _seed_closed_position(db) -> None:
+    await insert_trade(db, TradeDecision(
+        ticker=TICKER, action=TradeDecision.Action.OPEN,
+        side="no", count=733, price=0.54,
+        model_probability=0.70, agent="caddie-master",
+        thesis="Shadow: WOULD-PASS | strike=$63599.99 ...",
+    ))
+    await insert_trade(db, TradeDecision(
+        ticker=TICKER, action=TradeDecision.Action.CLOSE,
+        side="no", count=733, price=0.0,
+        model_probability=0.70, agent="settlement",
+    ))
+
+
+class TestClosedPositionContext:
+    """RC-1: a settled position is a legitimate read."""
+
+    def test_settled_position_renders_with_banner_no_error(
+        self, tmp_path,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed_closed_position)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["position-context", TICKER])
+        assert result.exit_code == 0, result.output
+        assert "POSITION CLOSED/SETTLED" in result.output
+        assert "settlement" in result.output
+        assert "--- OPEN TRADE ---" in result.output
+        assert _read_errors(db_path) == []
+
+    def test_settled_position_via_prefix(self, tmp_path) -> None:
+        """The pass-2 traded resolution finds closed tickers by
+        prefix — the exact Caddie Master step-2a read that produced
+        every live position_not_found row."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed_closed_position)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(
+                app, ["position-context", "KXBTCD-26AUG1118"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "POSITION CLOSED/SETTLED" in result.output
+        assert _read_errors(db_path) == []
+
+    def test_sibling_candidate_and_skip_noise_does_not_ambiguate(
+        self, tmp_path,
+    ) -> None:
+        """Review-found: pass 2 resolves against POSITION history only.
+        Scout's sibling-strike candidate rows and Closer skip rows for
+        the same event prefix must not explode the read into an
+        ambiguous_ticker exit 1."""
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            await _seed_closed_position(db)
+            await insert_candidate(
+                db, "KXBTCD-26AUG1118-T64099.99", "sibling", 0.4,
+                0.7, 0.3, 60.0, "memo",
+            )
+            await insert_trade(db, TradeDecision(
+                ticker="KXBTCD-26AUG1118-T64299.99",
+                action=TradeDecision.Action.SKIP,
+                side="no", count=0, price=0.2,
+                model_probability=0.7, agent="caddie-master",
+            ))
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(
+                app, ["position-context", "KXBTCD-26AUG1118"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "POSITION CLOSED/SETTLED" in result.output
+        assert _read_errors(db_path) == []
+
+    def test_candidates_only_ticker_still_logs_not_found(
+        self, tmp_path,
+    ) -> None:
+        """Resolvable in pass 2 but never traded — the REAL
+        position_not_found survives."""
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            await insert_candidate(
+                db, "KXNEVER-26AUG-T1", "never traded", 0.5, 0.7,
+                0.2, 60.0, "memo",
+            )
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(
+                app, ["position-context", "KXNEVER-26AUG-T1"],
+            )
+        assert result.exit_code == 0, result.output
+        codes = [e["error_code"] for e in _read_errors(db_path)]
+        assert codes == ["position_not_found"]
+
+    def test_unknown_ticker_still_logs_not_found(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed_closed_position)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["position-context", "ZZZ"])
+        assert result.exit_code == 0, result.output
+        codes = [e["error_code"] for e in _read_errors(db_path)]
+        assert codes == ["position_not_found"]
+
+
+class TestMarkToMarketSettles:
+    """RC-2: _mark_positions_to_market settles DETERMINED/FINALIZED
+    markets instead of marking them at a stale mid."""
+
+    @staticmethod
+    def _market(status, result):
+        market = MagicMock()
+        market.status = status
+        market.midpoint = 0.5
+        market.last_price = 0.5
+        market.close_time = None
+        market.result = result
+        return market
+
+    def _run_mark(self, market):
+        pos = Position(
+            ticker=TICKER, side="no", count=733, avg_price=0.54,
+            market_price=0.5, cost_basis=395.82, unrealized_pnl=0.0,
+        )
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(side_effect=[[pos], []])
+        client = AsyncMock()
+        with patch(
+            "gimmes.kalshi.markets.get_market",
+            AsyncMock(return_value=market),
+        ):
+            asyncio.run(_mark_positions_to_market(broker, client))
+        return broker
+
+    def test_determined_market_settles_not_marks(self) -> None:
+        broker = self._run_mark(
+            self._market(MarketStatus.DETERMINED, "yes"),
+        )
+        broker.settle.assert_awaited_once_with(TICKER, "yes")
+        broker.mark_to_market.assert_not_awaited()
+
+    def test_finalized_market_settles(self) -> None:
+        broker = self._run_mark(
+            self._market(MarketStatus.FINALIZED, "no"),
+        )
+        broker.settle.assert_awaited_once_with(TICKER, "no")
+
+    def test_determined_without_result_marks_not_settles(self) -> None:
+        """An unsettleable result must never reach settle() — it would
+        score every side as a loss."""
+        broker = self._run_mark(
+            self._market(MarketStatus.DETERMINED, ""),
+        )
+        broker.settle.assert_not_awaited()
+        broker.mark_to_market.assert_awaited_once()
+
+    def test_active_market_marks_not_settles(self) -> None:
+        broker = self._run_mark(self._market(MarketStatus.ACTIVE, ""))
+        broker.settle.assert_not_awaited()
+        broker.mark_to_market.assert_awaited_once()
+
+
+class TestMigrationV19:
+    """RC-3: the poisoned pre-#743 ledger row is repaired in place."""
+
+    POISONED_ORDER = "paper-da2137458555"
+
+    def _seed_and_remigrate(self, db_path, *, count=523):
+        async def _go(db):
+            await insert_trade(db, TradeDecision(
+                ticker="KXBTCD-26JUL1801-T63999.99",
+                action=TradeDecision.Action.OPEN,
+                side="no", count=count, price=0.945,
+                model_probability=0.70, agent="closer",
+                order_id=self.POISONED_ORDER,
+                rationale="hourly entry",
+            ))
+            # Rewind the version stamp so the v19 block re-runs against
+            # the newly-seeded row.
+            await db.conn.execute(
+                "DELETE FROM schema_version WHERE version = 19"
+            )
+            await db.conn.commit()
+            await run_migrations(db)
+            cursor = await db.conn.execute(
+                "SELECT count, rationale FROM trades WHERE order_id = ?"
+                " AND action = 'open'",
+                (self.POISONED_ORDER,),
+            )
+            return dict(await cursor.fetchone())
+
+        return _db_run(db_path, _go)
+
+    def test_poisoned_row_corrected(self, tmp_path) -> None:
+        row = self._seed_and_remigrate(tmp_path / "gimmes.db")
+        assert row["count"] == 185
+        assert "count corrected 523→185" in row["rationale"]
+
+    def test_idempotent_and_fingerprinted(self, tmp_path) -> None:
+        """A row with the same order_id but a different count (already
+        corrected, or never poisoned) is untouched."""
+        row = self._seed_and_remigrate(
+            tmp_path / "gimmes.db", count=185,
+        )
+        assert row["count"] == 185
+        assert "count corrected" not in row["rationale"]
+
+
+class TestReportConsistencyFootnote:
+    """RC-3: report names a ledger-vs-positions divergence and leaves a
+    durable position_count_mismatch row."""
+
+    def test_divergence_prints_footnote_and_row(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            # Ledger residual: open 523, close 185 — phantom open.
+            await insert_trade(db, TradeDecision(
+                ticker="KXGHOST-26JUL-T1",
+                action=TradeDecision.Action.OPEN,
+                side="no", count=523, price=0.9,
+                model_probability=0.7, agent="closer",
+            ))
+            await insert_trade(db, TradeDecision(
+                ticker="KXGHOST-26JUL-T1",
+                action=TradeDecision.Action.CLOSE,
+                side="no", count=185, price=1.0,
+                model_probability=0.7, agent="settlement",
+            ))
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["report"])
+        assert result.exit_code == 0, result.output
+        assert "Open-count divergence (#767)" in result.output
+        rows = [
+            e for e in _read_errors(db_path)
+            if e["error_code"] == "position_count_mismatch"
+        ]
+        assert len(rows) == 1
+        ctx = json.loads(rows[0]["context"])
+        assert ctx["ledger_only"] == ["KXGHOST-26JUL-T1"]
+        assert ctx["positions_only"] == []
+        assert ctx["count_drift"] == {}
+
+        # Change-detection (review-found): an unchanged divergence on
+        # the next report run prints the footnote but writes NO second
+        # row — one Groundskeeper signal per state change, not per
+        # cycle.
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["report"])
+        assert "Open-count divergence (#767)" in result.output
+        rows = [
+            e for e in _read_errors(db_path)
+            if e["error_code"] == "position_count_mismatch"
+        ]
+        assert len(rows) == 1
+
+    def test_count_drift_detected_while_open(self, tmp_path) -> None:
+        """Review-found: a live re-poisoning (ledger residual != broker
+        count on the SAME ticker) is visible while the position is
+        still open, not only after settlement."""
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            await insert_trade(db, TradeDecision(
+                ticker="KXDRIFT-26AUG-T1",
+                action=TradeDecision.Action.OPEN,
+                side="no", count=523, price=0.9,
+                model_probability=0.7, agent="closer",
+            ))
+            await db.conn.execute(
+                "INSERT INTO positions"
+                " (ticker, side, count, avg_price, cost_basis)"
+                " VALUES ('KXDRIFT-26AUG-T1', 'no', 185, 0.9, 166.5)"
+            )
+            await db.conn.commit()
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["report"])
+        assert result.exit_code == 0, result.output
+        assert "count-drift" in result.output
+        rows = [
+            e for e in _read_errors(db_path)
+            if e["error_code"] == "position_count_mismatch"
+        ]
+        assert len(rows) == 1
+        ctx = json.loads(rows[0]["context"])
+        assert ctx["count_drift"] == {
+            "KXDRIFT-26AUG-T1": {"ledger": 523, "positions": 185}
+        }
+
+    def test_consistent_state_stays_quiet(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            await insert_trade(db, TradeDecision(
+                ticker="KXCLEAN-26AUG-T1",
+                action=TradeDecision.Action.OPEN,
+                side="no", count=100, price=0.5,
+                model_probability=0.7, agent="closer",
+            ))
+            await db.conn.execute(
+                "INSERT INTO positions"
+                " (ticker, side, count, avg_price, cost_basis)"
+                " VALUES ('KXCLEAN-26AUG-T1', 'no', 100, 0.5, 50.0)"
+            )
+            await db.conn.commit()
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["report"])
+        assert result.exit_code == 0, result.output
+        assert "Open-count divergence" not in result.output
+        assert _read_errors(db_path) == []
+
+
+class TestPnlOpenResiduals:
+    def test_residual_populates_open_tickers(self) -> None:
+        summary = calculate_pnl([
+            {
+                "ticker": "KXOPEN-26AUG-T1", "side": "no",
+                "action": "open", "count": 100, "price": 0.5,
+                "timestamp": "2026-08-01T10:00:00+00:00",
+            },
+        ])
+        assert summary.open_trades == 1
+        assert summary.open_residuals == {"KXOPEN-26AUG-T1": 100}
+
+    def test_fully_closed_ticker_absent(self) -> None:
+        summary = calculate_pnl([
+            {
+                "ticker": "KXDONE-26AUG-T1", "side": "no",
+                "action": "open", "count": 100, "price": 0.5,
+                "timestamp": "2026-08-01T10:00:00+00:00",
+            },
+            {
+                "ticker": "KXDONE-26AUG-T1", "side": "no",
+                "action": "close", "count": 100, "price": 1.0,
+                "timestamp": "2026-08-01T11:00:00+00:00",
+            },
+        ])
+        assert summary.open_trades == 0
+        assert summary.open_residuals == {}
+
+
+class TestLegacyAndOrdering:
+    def test_close_only_history_renders(self, tmp_path) -> None:
+        """Legacy shape: a close row with no open row still renders
+        the closed context (not position_not_found)."""
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                side="no", count=100, price=0.5,
+                model_probability=0.7, agent="reconcile",
+            ))
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["position-context", TICKER])
+        assert result.exit_code == 0, result.output
+        assert "POSITION CLOSED/SETTLED" in result.output
+        assert "No open trade row recorded" in result.output
+        assert _read_errors(db_path) == []
+
+    def test_last_close_row_picks_newest(self, tmp_path) -> None:
+        from gimmes.store.queries import get_last_close_row
+
+        db_path = tmp_path / "gimmes.db"
+
+        async def _go(db):
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                side="no", count=50, price=0.8,
+                model_probability=0.7, agent="closer",
+            ))
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                side="no", count=683, price=0.0,
+                model_probability=0.7, agent="settlement",
+            ))
+            return await get_last_close_row(db, TICKER)
+
+        row = _db_run(db_path, _go)
+        assert row["agent"] == "settlement"
+        assert row["count"] == 683

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -312,6 +312,9 @@ class TestReportConsistencyFootnote:
         assert ctx["ledger_only"] == ["KXGHOST-26JUL-T1"]
         assert ctx["positions_only"] == []
         assert ctx["count_drift"] == {}
+        # Canonical serialization pin (second-review-found): the dedup
+        # depends on a stable byte form.
+        assert rows[0]["context"] == json.dumps(ctx, sort_keys=True)
 
         # Change-detection (review-found): an unchanged divergence on
         # the next report run prints the footnote but writes NO second

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -457,3 +457,30 @@ class TestLegacyAndOrdering:
         row = _db_run(db_path, _go)
         assert row["agent"] == "settlement"
         assert row["count"] == 683
+
+
+class TestOpenPositionMissingTradeLog:
+    def test_open_position_without_trade_rows_renders(
+        self, tmp_path,
+    ) -> None:
+        """Copilot review: a positions row with no trade log (imported/
+        synced) must render context, not claim position_not_found."""
+        db_path = tmp_path / "gimmes.db"
+
+        async def _seed(db):
+            await db.conn.execute(
+                "INSERT INTO positions"
+                " (ticker, side, count, avg_price, cost_basis)"
+                " VALUES (?, 'no', 100, 0.5, 50.0)",
+                (TICKER,),
+            )
+            await db.conn.commit()
+
+        _db_run(db_path, _seed)
+        with patch("gimmes.cli.load_config", return_value=_config(db_path)):
+            result = runner.invoke(app, ["position-context", TICKER])
+        assert result.exit_code == 0, result.output
+        assert "Position Context:" in result.output
+        assert "No open trade row recorded" in result.output
+        assert "POSITION CLOSED/SETTLED" not in result.output
+        assert _read_errors(db_path) == []


### PR DESCRIPTION
## Summary

One fix for five issues — the research showed three root causes explain the entire position-lifecycle family (#751, #720, #639, #635, #767):

**RC-1 — closed positions are a legitimate read.** Every `position_not_found` row in the live DB fired seconds-to-hours *after* the ticker's own close trade: Caddie Master and Monitor reading a just-settled position's note history (hourly markets settle inside the cycle that watches them, so KXBTCD recurred every morning). `position-context` now falls through to tickers with **position history** (opens/closes only — resolving against the known-markets universe would explode into `ambiguous_ticker` failures on Scout's sibling-strike candidate rows, review-found) and renders the full context under a `POSITION CLOSED/SETTLED` banner with no error row. `position_not_found` survives for never-traded tickers — the real Groundskeeper signal keeps its meaning. Fixes #751's errors, #639, and #720's log noise.

**RC-2 — settlements sweep everywhere, not just `gimmes positions`.** `_mark_positions_to_market` now settles DETERMINED/FINALIZED markets (guarded on a settleable result — an empty `result` must never score every side as a loss), loudly, with an accurate settle-failure warning. Review-found: `risk-check` never called the marking helper at all — it now does, reading the balance afterward so the snapshot is coherent. `broker.settle` reads inside its BEGIN IMMEDIATE transaction (review-found TOCTOU: with settle now multi-caller, a concurrent settle could double-credit the payout). Fixes #720's $988 double-count and #635's ghost.

**RC-3 — the phantom ledger row is repaired and recurrence is instrumented.** One pre-#743 poisoned row (order `paper-da2137458555`: 523 logged, 185 filled) made `gimmes report` count a phantom open position forever — this is #767's 4-vs-3 and #751's report discrepancy. Migration v19 repairs it (fingerprinted by order_id + poisoned count, idempotent, no-op elsewhere). The report now compares ledger residuals against the positions table — missing tickers in either direction **and per-ticker count drift**, so a live re-poisoning is visible while the position is still open — printing a footnote and writing a change-detected `position_count_mismatch` row (one Groundskeeper signal per state change, not one per cycle; crash-isolated so a footnote failure can't double-print a zeroed summary).

**Accepted residuals (documented):** a wrongful-but-consistent close (bug closes a position through sanctioned machinery) has no automatic detector — Scorecard P&L review is the remaining net; a SIGKILLed process can still orphan state (#638, separate fix); delisted-market stranded positions still can't auto-settle (pre-existing). starter.md's read-only note gains a bookkeeping caveat since risk-check/report now perform routine settlement housekeeping.

Closes #751, Closes #720, Closes #639, Closes #635, Closes #767

## Test plan

- 18 tests in `tests/unit/test_position_lifecycle.py`: closed-context renders (exact ticker, prefix, sibling-noise non-ambiguity, candidates-only and unknown tickers still log `position_not_found`, legacy close-only history, newest-close selection), `_mark_positions_to_market` settle semantics (DETERMINED/FINALIZED settle, empty-result guard, ACTIVE marks), migration v19 (repair, idempotence, fingerprint), report footnote (divergence row + context, change-detection across runs, count-drift while open, consistent-state silence), `PnLSummary.open_residuals`.
- Reworked pin: the old `position_closed_during_lookup` race test now asserts the closed render with zero error rows.
- Frozen full unit suite: **2411 passed** in 16:16. Lint clean.

Note: pr-review-toolkit not installed; equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit (risk-check wiring, resolver ambiguity, footnote isolation/count-drift/dedup, settle TOCTOU + mislabeled failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r