### PR TITLE
Session mutex + SIGTERM cleanup: one loop at a time (#638)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -6981,7 +6981,35 @@ def _autonomous_loop(
             f"[dim]Closed {orphans} orphan activity entries[/dim]"
         )
 
-    session_id = create_session(config.db_path, mode, os.getpid())
+    from gimmes.store.session import SessionConflictError
+
+    try:
+        session_id = create_session(config.db_path, mode, os.getpid())
+    except SessionConflictError as conflict:
+        live = conflict.session
+        console.print(
+            f"[red bold]Error: an active {live.get('mode')} session"
+            f" (id {live.get('id')}) is already running"
+            f" (PID {live.get('pid')}, started"
+            f" {live.get('started_at')})."
+            f" Refusing to start a second loop (#638).[/red bold]"
+        )
+        console.print(
+            f"  Verify first: ps -o command= -p {live.get('pid')}"
+            f"    (should show a gimmes loop — if it shows an"
+            f" unrelated process, the row is stale from PID reuse:"
+            f" do NOT kill it; end the row instead)"
+        )
+        console.print(
+            f"  Stop it:      kill -TERM {live.get('pid')}"
+            f"    (the loop cleans up its agent and session)"
+        )
+        # Deliberately NOT recommending `launchctl kickstart -k`
+        # here: the launchd job's main process is the wrapper script,
+        # which has no signal trap — kickstart's kill escalates to a
+        # SIGKILL of the process group, which bypasses this cleanup
+        # and orphans the agent (the #638 incident shape).
+        raise typer.Exit(1)
 
     # Set mode and session ID in process env for subprocesses
     os.environ["GIMMES_MODE"] = mode
@@ -7108,17 +7136,31 @@ def _autonomous_loop(
     # CPython.  Assignment is atomic under the GIL.
     _active_proc: subprocess.Popen[bytes] | None = None
 
-    def _sigint_handler(signum: int, frame: object) -> None:
+    _shutting_down = False
+
+    def _shutdown_handler(signum: int, frame: object) -> None:
+        # #638: shared by SIGINT and SIGTERM — the launchd wrapper's
+        # deadline watchdog SIGTERMs the loop, which previously died
+        # WITHOUT killing the agent process group or ending its
+        # session, leaving an orphan agent trading alongside the
+        # replacement loop. Idempotent (review-found): a second
+        # signal during _kill_process_group's escalation wait must
+        # not raise again and abort the TERM->KILL escalation.
+        nonlocal _shutting_down
         p = _active_proc
         if p is not None:
             try:
                 os.killpg(p.pid, signal.SIGTERM)
             except OSError:
                 pass
+        if _shutting_down:
+            return
+        _shutting_down = True
         raise KeyboardInterrupt
 
     proc = None
-    old_handler = signal.signal(signal.SIGINT, _sigint_handler)
+    old_handler = signal.signal(signal.SIGINT, _shutdown_handler)
+    old_term_handler = signal.signal(signal.SIGTERM, _shutdown_handler)
     try:
         from datetime import UTC, datetime
 
@@ -7666,6 +7708,7 @@ def _autonomous_loop(
         raise
     finally:
         signal.signal(signal.SIGINT, old_handler)
+        signal.signal(signal.SIGTERM, old_term_handler)
         end_session(config.db_path, session_id, session_status)
 
     console.print("\n[yellow]Autonomous loop stopped.[/yellow]")

--- a/src/gimmes/store/session.py
+++ b/src/gimmes/store/session.py
@@ -106,10 +106,45 @@ def get_latest_session(db_path: Path) -> dict | None:
         return None
 
 
+class SessionConflictError(Exception):
+    """An active session with a live PID already exists (#638)."""
+
+    def __init__(self, session: dict) -> None:
+        self.session = session
+        super().__init__(
+            f"active {session.get('mode')} session"
+            f" {session.get('id')} already running"
+            f" (PID {session.get('pid')})"
+        )
+
+
 def create_session(db_path: Path, mode: str, pid: int) -> int:
-    """Create a new active session. Returns the session ID."""
+    """Create a new active session. Returns the session ID.
+
+    #638: exclusive — two loop processes deployed conflicting capital
+    (an orphaned session's Closer executed a trade 22 minutes after
+    its replacement started). BEGIN IMMEDIATE serializes simultaneous
+    starters; an active row with a LIVE pid raises
+    SessionConflictError, a dead-pid row is inline-reclaimed as
+    crashed. Manual CLI commands never call this — only the loop.
+    """
     conn = sqlite3.connect(str(db_path))
     try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        rows = conn.execute(
+            "SELECT * FROM sessions WHERE status = 'active'"
+        ).fetchall()
+        for row in rows:
+            if pid_alive(int(row["pid"])):
+                # close() in the finally rolls back the open
+                # transaction — no explicit rollback needed.
+                raise SessionConflictError(dict(row))
+            conn.execute(
+                "UPDATE sessions SET status = 'crashed',"
+                " ended_at = datetime('now') WHERE id = ?",
+                (row["id"],),
+            )
         cursor = conn.execute(
             "INSERT INTO sessions (mode, pid) VALUES (?, ?)",
             (mode, pid),

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -3034,6 +3034,39 @@ class TestHourlyLadder:
 class TestCycleDeadlineEnv:
     """#746: the loop tells the subprocess when it will be killed."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_sessions(self, tmp_path, monkeypatch):
+        """#638 review-found: this class ran the loop with the REAL
+        load_config (it model_copies the real config to pin
+        cycle_timeout) and NO session patches — every full-suite run
+        wrote a real sessions row to the live DB (rows 175-178,
+        2026-08-12), and the new session mutex correctly refuses that
+        whenever the real loop is running. Session functions are
+        patched; the real load_config stays (its model_copy is the
+        point of the class). GIMMES_HOME is redirected too
+        (review-found: the class was rewriting the LIVE budget.json
+        and truncating the live cycle-001.json every suite run)."""
+        monkeypatch.setenv("GIMMES_MODE", "driving_range")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+        with (
+            patch("gimmes.store.session.create_session", return_value=1),
+            patch("gimmes.store.session.end_session"),
+            patch(
+                "gimmes.store.session.mark_stale_sessions",
+                return_value=0,
+            ),
+            patch(
+                "gimmes.store.session.close_orphan_activities",
+                return_value=0,
+            ),
+            patch("gimmes.store.session.update_session_cycle"),
+            patch(
+                "gimmes.store.session.get_max_global_cycle",
+                return_value=0,
+            ),
+        ):
+            yield
+
     @staticmethod
     def _pinned_timeout_config():
         """load_config side_effect pinning strategy.cycle_timeout=2700
@@ -3255,3 +3288,278 @@ class TestPositionYieldsToHourly:
         env = mock_popen.call_args.kwargs["env"]
         assert env["GIMMES_CYCLE_TYPE"] == "full"
         assert mock_comm.call_args.kwargs["timeout"] == 2700
+
+
+class TestSessionMutexLoop:
+    """#638: the loop refuses to start over a live session and cleans
+    up on SIGTERM exactly as on SIGINT."""
+
+    def test_refuses_startup_on_conflict(self, tmp_path, monkeypatch) -> None:
+        from gimmes.store.session import SessionConflictError
+
+        monkeypatch.setenv("GIMMES_MODE", "driving_range")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+        conflict = SessionConflictError({
+            "id": 7, "mode": "driving_range", "pid": 12345,
+            "started_at": "2026-08-12 08:00:00",
+        })
+        popen = MagicMock()
+        with (
+            patch(
+                "gimmes.store.session.create_session",
+                side_effect=conflict,
+            ),
+            patch("gimmes.store.session.end_session") as end,
+            patch(
+                "gimmes.store.session.mark_stale_sessions",
+                return_value=0,
+            ),
+            patch("gimmes.store.session.close_orphan_activities",
+                  return_value=0),
+            patch("subprocess.Popen", popen),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+        ):
+            with pytest.raises(ClickExit) as exc:
+                _autonomous_loop("driving_range")
+        assert exc.value.exit_code == 1
+        popen.assert_not_called()
+        end.assert_not_called()
+
+    def test_refusal_output_names_pid_and_kill_command(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """The refusal hints are operator-facing contract: the PID,
+        the verification step, and the kill command — and NO
+        kickstart advice (it SIGKILLs the pgroup and recreates the
+        incident)."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        from gimmes.store.session import SessionConflictError
+
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+        conflict = SessionConflictError({
+            "id": 7, "mode": "driving_range", "pid": 12345,
+            "started_at": "2026-08-12 08:00:00",
+        })
+        buf = StringIO()
+        with (
+            patch(
+                "gimmes.store.session.create_session",
+                side_effect=conflict,
+            ),
+            patch("gimmes.store.session.mark_stale_sessions",
+                  return_value=0),
+            patch("gimmes.store.session.close_orphan_activities",
+                  return_value=0),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("gimmes.cli.console", Console(file=buf, width=200)),
+        ):
+            with pytest.raises(ClickExit):
+                _autonomous_loop("driving_range")
+        out = buf.getvalue()
+        assert "PID 12345" in out
+        assert "kill -TERM 12345" in out
+        assert "ps -o command= -p 12345" in out
+        assert "kickstart" not in out
+
+    def test_both_signals_share_the_shutdown_handler(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """SIGINT and SIGTERM must register the SAME handler, and both
+        old handlers must be restored in the finally."""
+        import signal as signal_mod
+
+        monkeypatch.setenv("GIMMES_MODE", "driving_range")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+        # asyncio.run registers its own transient SIGINT handler, so
+        # record EVERY call and identify the loop's handler by name.
+        calls: list[tuple[int, object]] = []
+        originals = {
+            signal_mod.SIGINT: object(),
+            signal_mod.SIGTERM: object(),
+        }
+
+        def _fake_signal(signum, handler):
+            calls.append((signum, handler))
+            return originals.get(signum)
+
+        with (
+            patch("gimmes.store.session.create_session", return_value=1),
+            patch("gimmes.store.session.end_session"),
+            patch(
+                "gimmes.store.session.mark_stale_sessions",
+                return_value=0,
+            ),
+            patch(
+                "gimmes.store.session.close_orphan_activities",
+                return_value=0,
+            ),
+            # Review-found: without these, this test started a REAL
+            # uvicorn dashboard and ran a REAL `git ls-remote`.
+            patch(
+                "gimmes.clubhouse.server.start_background",
+                return_value=None,
+            ),
+            patch(
+                "gimmes.cli._check_code_staleness",
+                return_value=("abc123", False, None),
+            ),
+            patch("gimmes.cli._check_remote_staleness", return_value=None),
+            patch("signal.signal", side_effect=_fake_signal),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "gimmes.strategy.calendar.is_in_trade_window",
+                return_value=(False, "", 0),
+            ),
+            patch(
+                "gimmes.strategy.calendar.next_trade_window",
+                side_effect=KeyboardInterrupt,
+            ),
+        ):
+            try:
+                _autonomous_loop("driving_range")
+            except (KeyboardInterrupt, ClickExit, Exception):
+                pass
+
+        def _shutdown_regs(signum):
+            return [
+                h for (sn, h) in calls
+                if sn == signum
+                and getattr(h, "__name__", "") == "_shutdown_handler"
+            ]
+
+        int_regs = _shutdown_regs(signal_mod.SIGINT)
+        term_regs = _shutdown_regs(signal_mod.SIGTERM)
+        assert int_regs, "no _shutdown_handler registered for SIGINT"
+        assert term_regs, "no _shutdown_handler registered for SIGTERM"
+        assert int_regs[0] is term_regs[0]
+        # Both original handlers restored in the finally
+        assert (signal_mod.SIGINT, originals[signal_mod.SIGINT]) in calls
+        assert (signal_mod.SIGTERM, originals[signal_mod.SIGTERM]) in calls
+
+
+class TestShutdownHandlerBody:
+    """#638 review-found: the handler BODY was untested — signal
+    delivery is synchronous on the main thread, so a real SIGTERM to
+    self exercises it end-to-end. Standalone class (subclassing
+    TestAutonomousLoop would inherit and re-run its ~40 tests) with
+    its own isolation fixture."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_session_funcs(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GIMMES_MODE", "driving_range")
+        monkeypatch.setattr("gimmes.config.GIMMES_HOME", tmp_path)
+        with (
+            patch("gimmes.store.session.create_session", return_value=1),
+            patch("gimmes.store.session.mark_stale_sessions", return_value=0),
+            patch("gimmes.store.session.close_orphan_activities",
+                  return_value=0),
+            patch("gimmes.store.session.update_session_cycle"),
+            patch("asyncio.run", side_effect=lambda coro: coro.close()),
+            patch(
+                "gimmes.strategy.calendar.is_in_trade_window",
+                return_value=(True, "Index contracts", 3600),
+            ),
+            patch(
+                "gimmes.strategy.calendar.next_trade_window",
+                return_value=(_make_future_dt(), "Index contracts"),
+            ),
+            patch(
+                "gimmes.strategy.calendar.seconds_until_next_window",
+                return_value=3600,
+            ),
+            patch(
+                "gimmes.cli._check_code_staleness",
+                return_value=("abc123", False, None),
+            ),
+            patch(
+                "gimmes.cli._check_remote_staleness",
+                return_value=None,
+            ),
+        ):
+            yield
+
+    def test_sigterm_kills_agent_group_and_stops_cleanly(
+        self,
+    ) -> None:
+        import os
+        import signal as signal_mod
+
+        def _comm(*args, **kwargs):
+            os.kill(os.getpid(), signal_mod.SIGTERM)
+            return b""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.clubhouse.server.start_background",
+                return_value=None,
+            ),
+            patch("gimmes.cli._communicate_interruptible",
+                  side_effect=_comm),
+            patch("os.killpg") as mock_killpg,
+            patch("gimmes.store.session.end_session") as end,
+        ):
+            _autonomous_loop("driving_range", pause_seconds=0)
+
+        # The handler killpg'd the agent group with SIGTERM, and the
+        # loop ended its session as 'stopped' — the full #638 cleanup.
+        assert any(
+            c.args == (12345, signal_mod.SIGTERM)
+            for c in mock_killpg.call_args_list
+        ), mock_killpg.call_args_list
+        end.assert_called_once()
+        assert end.call_args.args[2] == "stopped"
+
+    def test_second_signal_does_not_reraise(self) -> None:
+        """Idempotence: a second SIGTERM during the escalation wait
+        must not raise a second KeyboardInterrupt (it would abort the
+        TERM->KILL escalation)."""
+        import signal as signal_mod
+
+        captured: dict[str, object] = {}
+
+        real_signal = signal_mod.signal
+
+        def _capture(signum, handler):
+            if getattr(handler, "__name__", "") == "_shutdown_handler":
+                captured[signum] = handler
+            return real_signal(signum, handler)
+
+        def _comm(*args, **kwargs):
+            handler = captured[signal_mod.SIGTERM]
+            try:
+                handler(signal_mod.SIGTERM, None)
+            except KeyboardInterrupt:
+                # First delivery raised; the second must NOT.
+                handler(signal_mod.SIGTERM, None)
+                raise
+            raise AssertionError("first delivery did not raise")
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "subprocess.Popen",
+                side_effect=lambda *a, **kw: _mock_popen(),
+            ),
+            patch(
+                "gimmes.clubhouse.server.start_background",
+                return_value=None,
+            ),
+            patch("signal.signal", side_effect=_capture),
+            patch("gimmes.cli._communicate_interruptible",
+                  side_effect=_comm),
+            patch("os.killpg") as mock_killpg,
+        ):
+            _autonomous_loop("driving_range", pause_seconds=0)
+
+        # Both deliveries killpg'd (the second still re-kills), plus
+        # the except-block's escalation kill.
+        assert mock_killpg.call_count >= 2
+

--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -3523,7 +3523,7 @@ class TestShutdownHandlerBody:
         TERM->KILL escalation)."""
         import signal as signal_mod
 
-        captured: dict[str, object] = {}
+        captured: dict[int, object] = {}
 
         real_signal = signal_mod.signal
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -135,7 +135,10 @@ class TestGetLatestSession:
         db_path = tmp_path / "test.db"
         _init_db(db_path)
 
-        create_session(db_path, "driving_range", os.getpid())
+        sid1 = create_session(db_path, "driving_range", os.getpid())
+        # #638: create_session is exclusive — end the first before
+        # starting the second.
+        end_session(db_path, sid1, "stopped")
         sid2 = create_session(db_path, "championship", os.getpid())
 
         latest = get_latest_session(db_path)
@@ -202,9 +205,17 @@ class TestMarkStaleSessions:
         db_path = tmp_path / "test.db"
         _init_db(db_path)
 
-        # One alive, one dead
+        # One alive, one dead. The dead row is seeded directly —
+        # create_session is exclusive since #638 and would refuse a
+        # second active session (or inline-reclaim the dead one).
         create_session(db_path, "driving_range", os.getpid())
-        create_session(db_path, "championship", 999999)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO sessions (mode, pid) VALUES (?, ?)",
+            ("championship", 999999),
+        )
+        conn.commit()
+        conn.close()
 
         count = mark_stale_sessions(db_path)
         assert count == 1
@@ -242,6 +253,7 @@ class TestGetMaxGlobalCycle:
         _init_db(db_path)
         sid1 = create_session(db_path, "driving_range", os.getpid())
         update_session_cycle(db_path, sid1, 5)
+        end_session(db_path, sid1, "stopped")  # #638: exclusive
         sid2 = create_session(db_path, "driving_range", os.getpid())
         update_session_cycle(db_path, sid2, 12)
         assert get_max_global_cycle(db_path) == 12
@@ -320,3 +332,60 @@ class TestCloseOrphanActivities:
         assert row["agent"] == "scout"
         assert row["cycle"] == 1
         assert row["session_id"] == sid
+
+
+class TestSessionMutex:
+    """#638: create_session is exclusive — two loop processes deployed
+    conflicting capital (an orphaned session's Closer traded 22 min
+    after its replacement started)."""
+
+    def test_live_pid_active_session_refuses(self, tmp_path: Path) -> None:
+        from gimmes.store.session import SessionConflictError
+
+        db_path = tmp_path / "test.db"
+        _init_db(db_path)
+        first = create_session(db_path, "driving_range", os.getpid())
+
+        import pytest
+
+        with pytest.raises(SessionConflictError) as exc:
+            create_session(db_path, "driving_range", os.getpid())
+        assert exc.value.session["id"] == first
+        assert exc.value.session["pid"] == os.getpid()
+
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM sessions"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1  # no second row inserted
+
+    def test_dead_pid_active_session_reclaimed(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.db"
+        _init_db(db_path)
+        stale = create_session(db_path, "driving_range", 999999)
+
+        sid = create_session(db_path, "driving_range", os.getpid())
+        assert sid > stale
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        rows = {
+            r["id"]: dict(r)
+            for r in conn.execute("SELECT * FROM sessions").fetchall()
+        }
+        conn.close()
+        assert rows[stale]["status"] == "crashed"
+        assert rows[stale]["ended_at"] is not None
+        assert rows[sid]["status"] == "active"
+
+    def test_stopped_and_crashed_rows_do_not_block(
+        self, tmp_path: Path,
+    ) -> None:
+        db_path = tmp_path / "test.db"
+        _init_db(db_path)
+        old = create_session(db_path, "driving_range", os.getpid())
+        end_session(db_path, old, "stopped")
+
+        sid = create_session(db_path, "driving_range", os.getpid())
+        assert sid > old


### PR DESCRIPTION
## Summary

Concurrent loop execution was verified live three times (Jul 20, Jul 21, Aug 5): no session mutex existed and the loop had no SIGTERM handler, so a terminated loop died without killing its agent process group or ending its session — on Jul 21 an orphaned session's Closer executed a 719-contract trade 22 minutes after the replacement loop started.

**The fix:**
1. **`create_session` is exclusive** — `BEGIN IMMEDIATE` serializes simultaneous starters; an active row with a live PID raises `SessionConflictError`; dead-PID rows are inline-reclaimed as crashed. The PID column and liveness helpers already existed, so no migration. Only the loop calls `create_session`; manual CLI use is untouched.
2. **SIGTERM shares the SIGINT cleanup path** (kill the agent process group, end the session as `stopped`), idempotently — a second signal re-kills the group but cannot raise a second KeyboardInterrupt and abort the TERM→KILL escalation (review-found).
3. **A refused start prints operator guidance**: the live session/PID, a `ps` verification step *first* (PID reuse can leave a stale row naming an innocent process — kill advice without verification would be dangerous), then `kill -TERM <pid>`. It deliberately does **not** recommend `launchctl kickstart -k`: the launchd job's main process is the wrapper script, which has no trap — kickstart's kill escalates to a SIGKILL of the process group, bypassing all cleanup and recreating the exact orphan-agent incident (review-found; this also means the ops runbook's restart command needs updating, flagged separately).

**Test-isolation fallout (review-found, fixed here):** the new mutex exposed `TestCycleDeadlineEnv` writing REAL session rows to the live DB on every full-suite run (live rows 175–178 are this pollution) and rewriting the live `budget.json` / truncating `cycle-001.json` — the class is now fully isolated; the new signal test was also starting a real uvicorn dashboard and running a real `git ls-remote` — patched.

**Known residuals (documented):** SIGKILL of the loop still orphans the agent for up to one cycle deadline (full closure needs `agent_pgid` tracking — deferred with rationale); PID reuse can wedge startup closed until the recycled PID exits (fails closed — no double trading — and the refusal message carries the diagnosis step).

Closes #638

## Test plan

- Session mutex: live-PID refusal (exception carries the session dict, no row inserted), dead-PID inline reclaim, stopped/crashed rows don't block; three pre-existing tests updated for the exclusive contract (dead-row seeding now via raw INSERT where the unit under test is `mark_stale_sessions`).
- Loop level: startup refusal (exit 1, no Popen, no end_session), refusal-output pins (PID, kill command, verification step, **no kickstart**), dual-signal registration + restoration (name-based — asyncio registers its own transient SIGINT handler), real-SIGTERM handler-body end-to-end (killpg with SIGTERM + session ended `stopped`), second-signal idempotence.
- Mutation-verified: each behavior has exactly one killing test (live-PID check, SIGTERM registration, refusal catch, inline reclaim).
- Frozen full unit suite: **2420 passed** in 16:15. Lint clean.

Note: pr-review-toolkit not installed; equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r