### PR TITLE
market-info 404 recovery: list the event's real tickers (#778)

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -306,6 +306,8 @@ For all other skips (PASS on research grounds, NEEDS MORE RESEARCH after re-scor
 
 If a `log-trade` skip command fails, note the failure in your output and continue. Do not retry failed log commands.
 
+**Ticker discipline (#778):** copy tickers EXACTLY as printed in your assignment/scan/candidates output — strike decimals included (`-T63399.99`, never `-T63399`). If `market-info` prints "The event ... EXISTS" with a market list, take exactly ONE printed suggestion matching your assigned strike and retry ONCE; if that retry fails or no suggestion matches your assignment, fall through to the failure rule below. NEVER manufacture date-format or strike-format variants — eight guessed variants in cycle 2232 produced eight error escalations and filed #778.
+
 If `market-info` fails for a candidate, log the candidate with `--price 0 --prob 0` and log the skip with the failure in the rationale.
 
 ## Activity Logging (REQUIRED — you are not done until this runs)
@@ -330,6 +332,7 @@ Substitute actual values: number of candidates researched and number with recomm
 
 - NEVER place orders — that's the Closer's job
 - NEVER modify code
+- NEVER guess ticker format variants — copy tickers verbatim; one corrected retry max on "unknown ticker" output (#778)
 - MUST produce a GimmeScore for every candidate — NEVER recommend PROCEED/PASS without a numeric score
 - MUST be explicit about uncertainty in probability estimates
 - MUST flag any settlement concerns prominently

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -79,6 +79,8 @@ If a `log-trade` skip command fails, note the failure in the Scout output and co
 
 ## Output Format
 
+Tickers in your report MUST be transcribed verbatim from `gimmes scan` output — strike decimals included (`-T63399.99`, never `-T63399`). Downstream agents copy your tickers exactly; a dropped suffix here becomes their 404 (#778).
+
 MUST produce a structured shortlist in this exact format. When multiple candidates share the same Event (shown in the scan results), group them together so Caddie can research the underlying event once:
 
 ```

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -263,6 +263,48 @@ def _print_ambiguous_ticker(prefix: str, matches: list[str]) -> None:
     )
 
 
+async def _recover_unknown_ticker(
+    client, resolved: str,
+) -> tuple[str, list[str]]:
+    """Best-effort 404 recovery for `market-info` (#778): derive the
+    event ticker from a strike ticker and list the event's open
+    markets, longest-common-prefix first so the intended correction
+    survives any display cap. Returns ("", []) when not applicable or
+    on ANY failure — the caller degrades to the plain
+    http_status_error path; the recovery must never mask the original
+    404. The derived event ticker is returned alongside so the caller
+    prints exactly what was queried.
+    """
+    import logging
+    import os.path
+
+    if "-T" not in resolved:
+        # Range shape (-B7737), bare garbage ("00"), hyphenless typos.
+        return "", []
+    # rsplit, not split: the LAST '-T' is the strike separator, which
+    # keeps negative thresholds (KXCPI-26JUN-T-0.2 -> KXCPI-26JUN)
+    # and mid-event '-T' shapes correct.
+    event_ticker = resolved.rsplit("-T", 1)[0]
+    if not event_ticker:
+        return "", []
+    try:
+        from gimmes.kalshi.markets import list_markets
+
+        markets, _ = await list_markets(
+            client, event_ticker=event_ticker, limit=200,
+        )
+    except Exception:
+        logging.getLogger("gimmes.cli").debug(
+            "ticker recovery failed for %s", resolved, exc_info=True,
+        )
+        return "", []
+    tickers = [m.ticker for m in markets]
+    tickers.sort(
+        key=lambda t: (-len(os.path.commonprefix([t, resolved])), t),
+    )
+    return event_ticker, tickers
+
+
 def _run(coro):  # type: ignore[no-untyped-def]
     """Run an async coroutine from sync CLI context with error handling."""
     import logging
@@ -3494,6 +3536,78 @@ def market_info(
                 orderbook = await get_orderbook(client, resolved)
             except httpx.HTTPStatusError as exc:
                 detail = _api_error_detail(exc)
+                # #778: a 404 on a strike-shaped ticker is usually an
+                # agent transcription error (cycle 2232: the .99 strike
+                # suffix dropped, then five guessed format variants =
+                # eight ERROR rows in a minute). If the EVENT exists,
+                # hand back its real tickers and log a distinct
+                # WARNING code — the API is provably healthy, and
+                # Groundskeeper's (error_code, component) dedup must
+                # not conflate agent typos with real API failures.
+                suggestions: list[str] = []
+                event_ticker = ""
+                failing_url = str(
+                    getattr(exc.request, "url", "") or ""
+                )
+                if (
+                    exc.response.status_code == 404
+                    and "orderbook" not in failing_url
+                ):
+                    # The orderbook guard matters (review-found): a
+                    # market that 404s its ORDERBOOK after get_market
+                    # succeeded is a real API partial failure — calling
+                    # it an unknown ticker would both hide it from
+                    # ERROR escalation and tell the agent to retry a
+                    # DIFFERENT strike.
+                    event_ticker, suggestions = (
+                        await _recover_unknown_ticker(client, resolved)
+                    )
+                if suggestions:
+                    shown = suggestions[:_AMBIGUOUS_MATCH_DISPLAY_LIMIT]
+                    async with Database(config.db_path) as db:
+                        await _log_cli_error(db, ErrorLogEntry(
+                            severity=ErrorSeverity.WARNING,
+                            category=ErrorCategory.CONFIG_ERROR,
+                            error_code="ticker_not_found",
+                            component="cli.market-info",
+                            message=(
+                                f"Unknown ticker '{resolved}' (404) —"
+                                f" event '{event_ticker}' exists with"
+                                f" {len(suggestions)} open markets"
+                            ),
+                            context=json.dumps({
+                                "ticker": ticker,
+                                "resolved": resolved,
+                                "event_ticker": event_ticker,
+                                "suggestions": shown,
+                                "suggestions_total": len(suggestions),
+                                "status_code": 404,
+                            }),
+                        ))
+                    console.print(
+                        f"[red bold]Market lookup FAILED (404):"
+                        f" unknown ticker"
+                        f" '{rich_escape(resolved)}'[/red bold]"
+                    )
+                    console.print(
+                        f"The event {rich_escape(event_ticker)} EXISTS."
+                        f" Its open markets are:"
+                    )
+                    for t in shown:
+                        console.print(f"  {rich_escape(t)}")
+                    if len(suggestions) > len(shown):
+                        console.print(
+                            f"  [dim]... and"
+                            f" {len(suggestions) - len(shown)}"
+                            f" more[/dim]"
+                        )
+                    console.print(
+                        "[yellow]Copy tickers EXACTLY from"
+                        " scan/candidates output — strikes keep their"
+                        " decimals. NEVER guess format variants. One"
+                        " corrected retry max (#778).[/yellow]"
+                    )
+                    raise typer.Exit(1)
                 async with Database(config.db_path) as db:
                     await _log_cli_error(db, ErrorLogEntry(
                         severity=ErrorSeverity.ERROR,

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3189,3 +3189,30 @@ def test_closer_cap_sizing_note_pinned() -> None:
     assert "not a failure" in closer_text
     assert "Sized to zero contracts" in closer_text
     assert "that IS an order failure" in closer_text
+
+
+def test_caddie_ticker_discipline_rule(caddie_text: str) -> None:
+    """#778: eight guessed ticker variants in one minute — the
+    discipline rule and its adjacency to the failure rule must hold."""
+    assert "Ticker discipline (#778)" in caddie_text
+    assert "strike decimals included" in caddie_text
+    assert "retry ONCE" in caddie_text
+    assert (
+        "NEVER manufacture date-format or strike-format variants"
+        in caddie_text
+    )
+    # Adjacent to the market-info failure rule so the fallthrough
+    # reads as one flow
+    start = caddie_text.index("Ticker discipline (#778)")
+    assert (
+        "If `market-info` fails for a candidate"
+        in caddie_text[start:start + 900]
+    )
+    assert "NEVER guess ticker format variants" in caddie_text
+    # The quoted trigger matches the console's actual casing
+    assert 'on "unknown ticker" output (#778)' in caddie_text
+
+
+def test_scout_verbatim_ticker_rule(scout_text: str) -> None:
+    assert "transcribed verbatim from `gimmes scan` output" in scout_text
+    assert "a dropped suffix here becomes their 404 (#778)" in scout_text

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -469,14 +469,9 @@ class TestMarketInfo:
         # the literal input. Preserves first-time-lookup behavior.
         get_market = AsyncMock(return_value=_stub_market("KXBRANDNEW-26MAY-T1.0"))
         get_orderbook = AsyncMock(return_value=_stub_orderbook())
-        # #778: pin the empty-recovery branch deterministically — an
-        # unpatched list_markets against the mocked client degrades
-        # through the recovery helper's except by accident.
         with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
              patch("gimmes.kalshi.markets.get_market", get_market), \
              patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
-             patch("gimmes.kalshi.markets.list_markets",
-                   AsyncMock(return_value=([], None))), \
              patch("gimmes.kalshi.client.KalshiClient"):
             result = runner.invoke(app, ["market-info", "KXBRANDNEW-26MAY-T1.0"])
         assert result.exit_code == 0, result.output
@@ -783,14 +778,9 @@ class TestErrorLogging:
             side_effect=httpx.ConnectError("connection refused"),
         )
         get_orderbook = AsyncMock(return_value=_stub_orderbook())
-        # #778: pin the empty-recovery branch deterministically — an
-        # unpatched list_markets against the mocked client degrades
-        # through the recovery helper's except by accident.
         with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
              patch("gimmes.kalshi.markets.get_market", get_market), \
              patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
-             patch("gimmes.kalshi.markets.list_markets",
-                   AsyncMock(return_value=([], None))), \
              patch("gimmes.kalshi.client.KalshiClient"):
             result = runner.invoke(app, ["market-info", "KXBRANDNEW-26MAY-T1.0"])
         assert result.exit_code == 1, result.output

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -469,9 +469,14 @@ class TestMarketInfo:
         # the literal input. Preserves first-time-lookup behavior.
         get_market = AsyncMock(return_value=_stub_market("KXBRANDNEW-26MAY-T1.0"))
         get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        # #778: pin the empty-recovery branch deterministically — an
+        # unpatched list_markets against the mocked client degrades
+        # through the recovery helper's except by accident.
         with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
              patch("gimmes.kalshi.markets.get_market", get_market), \
              patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.markets.list_markets",
+                   AsyncMock(return_value=([], None))), \
              patch("gimmes.kalshi.client.KalshiClient"):
             result = runner.invoke(app, ["market-info", "KXBRANDNEW-26MAY-T1.0"])
         assert result.exit_code == 0, result.output
@@ -616,7 +621,8 @@ def _read_error_log(db_path: Path) -> list[dict]:
     try:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
-            "SELECT severity, category, error_code, component, message"
+            "SELECT severity, category, error_code, component, message,"
+            " context"
             " FROM error_log ORDER BY id DESC",
         ).fetchall()
     finally:
@@ -654,9 +660,14 @@ class TestErrorLogging:
             ),
         )
         get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        # #778: pin the empty-recovery branch deterministically — an
+        # unpatched list_markets against the mocked client degrades
+        # through the recovery helper's except by accident.
         with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
              patch("gimmes.kalshi.markets.get_market", get_market), \
              patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.markets.list_markets",
+                   AsyncMock(return_value=([], None))), \
              patch("gimmes.kalshi.client.KalshiClient"):
             result = runner.invoke(app, ["market-info", "KXBRANDNEW-26MAY-T1.0"])
         assert result.exit_code == 1, result.output
@@ -772,9 +783,14 @@ class TestErrorLogging:
             side_effect=httpx.ConnectError("connection refused"),
         )
         get_orderbook = AsyncMock(return_value=_stub_orderbook())
+        # #778: pin the empty-recovery branch deterministically — an
+        # unpatched list_markets against the mocked client degrades
+        # through the recovery helper's except by accident.
         with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
              patch("gimmes.kalshi.markets.get_market", get_market), \
              patch("gimmes.kalshi.markets.get_orderbook", get_orderbook), \
+             patch("gimmes.kalshi.markets.list_markets",
+                   AsyncMock(return_value=([], None))), \
              patch("gimmes.kalshi.client.KalshiClient"):
             result = runner.invoke(app, ["market-info", "KXBRANDNEW-26MAY-T1.0"])
         assert result.exit_code == 1, result.output
@@ -785,3 +801,187 @@ class TestErrorLogging:
             and e["component"] == "cli.market-info"
             for e in errors
         ), errors
+
+
+class TestMarketInfo404Recovery:
+    """#778: a 404 on a strike-shaped ticker triggers event-listing
+    recovery — real tickers printed, distinct WARNING error code —
+    while genuine unknowns keep the ERROR http_status_error path."""
+
+    @staticmethod
+    def _mk(ticker):
+        m = MagicMock()
+        m.ticker = ticker
+        return m
+
+    def _run(self, seeded_db, ticker, *, list_markets=None,
+             list_markets_effect=None, status=404):
+        response = MagicMock(status_code=status, text="err")
+        get_market = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "err", request=MagicMock(), response=response,
+            ),
+        )
+        lm = AsyncMock(
+            return_value=(list_markets or [], None),
+            side_effect=list_markets_effect,
+        )
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.markets.get_orderbook",
+                   AsyncMock(return_value=_stub_orderbook())), \
+             patch("gimmes.kalshi.markets.list_markets", lm), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(app, ["market-info", ticker])
+        return result, lm
+
+    def test_404_with_event_recovery_suggests_real_tickers(
+        self, seeded_db: Path,
+    ) -> None:
+        result, _ = self._run(
+            seeded_db, "KXBTCD-26AUG1313-T63399",
+            list_markets=[
+                self._mk("KXBTCD-26AUG1313-T63899.99"),
+                self._mk("KXBTCD-26AUG1313-T63399.99"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "The event KXBTCD-26AUG1313 EXISTS" in result.output
+        assert "KXBTCD-26AUG1313-T63399.99" in result.output
+        assert "NEVER guess format variants" in result.output
+        errors = _read_error_log(seeded_db)
+        row = [e for e in errors if e["error_code"] == "ticker_not_found"]
+        assert len(row) == 1
+        assert row[0]["severity"] == "warning"
+        assert row[0]["category"] == "config_error"
+        import json
+
+        ctx = json.loads(row[0]["context"])
+        assert ctx["event_ticker"] == "KXBTCD-26AUG1313"
+        assert ctx["suggestions_total"] == 2
+        # Longest-common-prefix first: the intended correction leads
+        assert ctx["suggestions"][0] == "KXBTCD-26AUG1313-T63399.99"
+        assert not any(
+            e["error_code"] == "http_status_error"
+            and "KXBTCD" in (e["context"] or "")
+            for e in errors
+        )
+
+    def test_404_recovery_empty_falls_back_to_error(
+        self, seeded_db: Path,
+    ) -> None:
+        result, _ = self._run(seeded_db, "KXBTCD-26AUG1313-T63399")
+        assert result.exit_code == 1
+        assert "EXISTS" not in result.output
+        errors = _read_error_log(seeded_db)
+        assert any(
+            e["error_code"] == "http_status_error" for e in errors
+        )
+        assert not any(
+            e["error_code"] == "ticker_not_found" for e in errors
+        )
+
+    def test_404_recovery_failure_degrades(self, seeded_db: Path) -> None:
+        result, _ = self._run(
+            seeded_db, "KXBTCD-26AUG1313-T63399",
+            list_markets_effect=RuntimeError("api down"),
+        )
+        assert result.exit_code == 1
+        errors = _read_error_log(seeded_db)
+        assert any(
+            e["error_code"] == "http_status_error" for e in errors
+        )
+
+    def test_404_without_dash_t_skips_recovery(
+        self, seeded_db: Path,
+    ) -> None:
+        result, lm = self._run(seeded_db, "KXINX-26AUG14H1600-B7737")
+        assert result.exit_code == 1
+        lm.assert_not_awaited()
+        errors = _read_error_log(seeded_db)
+        assert any(
+            e["error_code"] == "http_status_error" for e in errors
+        )
+
+    def test_non_404_skips_recovery(self, seeded_db: Path) -> None:
+        result, lm = self._run(
+            seeded_db, "KXBTCD-26AUG1313-T63399", status=500,
+        )
+        assert result.exit_code == 1
+        lm.assert_not_awaited()
+
+    def test_suggestions_capped_and_prefix_sorted(
+        self, seeded_db: Path,
+    ) -> None:
+        markets = [
+            self._mk(f"KXBTCD-26AUG1313-T{60000 + i * 100}.99")
+            for i in range(24)
+        ] + [self._mk("KXBTCD-26AUG1313-T63399.99")]
+        result, _ = self._run(
+            seeded_db, "KXBTCD-26AUG1313-T63399",
+            list_markets=markets,
+        )
+        assert result.exit_code == 1
+        assert "... and 5 more" in result.output
+        # The correction shares the longest prefix — it must lead the
+        # list and survive the cap.
+        lines = [ln.strip() for ln in result.output.splitlines()]
+        first = next(
+            ln for ln in lines if ln.startswith("KXBTCD-26AUG1313-T")
+        )
+        assert first == "KXBTCD-26AUG1313-T63399.99"
+        # The stored context is capped too — unbounded ladders must
+        # not bloat error_log rows (review-found)
+        import json
+
+        ctx = json.loads(_read_error_log(seeded_db)[0]["context"])
+        assert len(ctx["suggestions"]) == 20
+        assert ctx["suggestions_total"] == 25
+
+    def test_negative_threshold_event_derivation(
+        self, seeded_db: Path,
+    ) -> None:
+        """rsplit on the LAST '-T' keeps negative strikes correct —
+        KXCPI-26JUN-T-0.2 derives event KXCPI-26JUN (review-found
+        pin: a regex or split() refactor would silently break this)."""
+        result, _ = self._run(
+            seeded_db, "KXCPI-26JUN-T-0.2",
+            list_markets=[self._mk("KXCPI-26JUN-T-0.1")],
+        )
+        assert "The event KXCPI-26JUN EXISTS" in result.output
+
+    def test_orderbook_404_not_misclassified(
+        self, seeded_db: Path,
+    ) -> None:
+        """A 404 whose failing request is the ORDERBOOK endpoint is a
+        real API partial failure, never an unknown ticker
+        (review-found)."""
+        request = MagicMock()
+        request.url = "https://api.example.com/markets/X/orderbook"
+        response = MagicMock(status_code=404, text="not found")
+        lm = AsyncMock(return_value=([self._mk("X-T1.99")], None))
+        with patch("gimmes.cli.load_config", return_value=_config(seeded_db)), \
+             patch("gimmes.kalshi.markets.get_market",
+                   AsyncMock(
+                       return_value=_stub_market(
+                           "KXBTCD-26AUG1313-T63399.99",
+                       ),
+                   )), \
+             patch(
+                 "gimmes.kalshi.markets.get_orderbook",
+                 AsyncMock(side_effect=httpx.HTTPStatusError(
+                     "404", request=request, response=response,
+                 )),
+             ), \
+             patch("gimmes.kalshi.markets.list_markets", lm), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            result = runner.invoke(
+                app, ["market-info", "KXBTCD-26AUG1313-T63399.99"],
+            )
+        assert result.exit_code == 1
+        lm.assert_not_awaited()
+        assert "EXISTS" not in result.output
+        errors = _read_error_log(seeded_db)
+        assert any(
+            e["error_code"] == "http_status_error" for e in errors
+        )


### PR DESCRIPTION
## Summary

Issue #778's "recurring market lookup 404s" were **agent transcription errors, not expired markets**: cycle 2232's Caddie dropped a strike's `.99` suffix, 404'd, then brute-forced five date-format variants — eight ERROR rows in a minute that Groundskeeper rightly escalated. The correct ticker existed only in Scout's text output at research time, so the local prefix resolver had nothing to match against.

**CLI recovery (the fix that makes the mistake self-correcting):** on a 404 for a strike-shaped ticker, `market-info` derives the event ticker (`rsplit` on the *last* `-T` — negative thresholds like `KXCPI-26JUN-T-0.2` derive correctly, test-pinned) and lists the event's real open markets, longest-common-prefix first so the intended correction leads the list and survives the 20-row display cap. The agent gets the exact right ticker in one step instead of guessing. When the event exists, the row logs **WARNING/`ticker_not_found`** — a distinct code so Groundskeeper's `(error_code, component)` dedup never conflates agent typos with real API trouble; genuine unknowns and non-404s keep the ERROR `http_status_error` path byte-identical. Guards (review-found): a 404 from the *orderbook* endpoint after `get_market` succeeded is a real API partial failure and never triggers recovery; recovery is fully best-effort (any failure degrades to the old path, never masking the original 404, with a debug trace).

**Prompt law:** caddie.md gains a ticker-discipline rule (copy EXACTLY, decimals included; take ONE printed suggestion matching the assigned strike and retry ONCE; NEVER manufacture date/strike-format variants) placed directly above the existing market-info failure rule so the fallthrough reads as one flow, plus a Rules bullet; scout.md requires verbatim transcription from `gimmes scan` output since downstream agents copy its text. Both drift-guard pinned.

Closes #778

## Test plan

- 8 tests in `TestMarketInfo404Recovery`: recovery with suggestions (WARNING row content + prefix-sorted, capped suggestions in both display and context JSON), empty-recovery fallback, recovery-failure degradation, no-`-T` skip, non-404 skip, cap/sort behavior on a 25-market ladder, negative-threshold event derivation, orderbook-404 non-misclassification.
- Existing 404 test updated to pin the empty-recovery branch deterministically (it was passing by accident through the helper's except).
- Prompt pins for both caddie.md rules and scout.md's verbatim rule.
- Frozen full unit suite: **2430 passed** in 16:15. Lint clean.

Note: pr-review-toolkit not installed; equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r