### PR TITLE
Settled-event recovery + held-ticker settle check (#782)

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -77,7 +77,7 @@ For candidates in backtested gimme categories (KXCPICORE, KXCPIYOY, KXCPICOREYOY
 
 **Hourly-series substitution (#721/#739 — series in `scanner.hourly_series`, e.g. KXBTCD):** hourly BTC ladders are price markets, not scheduled data releases — the macro-release framing above does not map. Keep the three-check shape but substitute:
 
-1. **Shadow distance analysis** (#739/#769 — records AND gates; replaces the extraordinary-event check): look up current BTC spot and compare the strike-to-spot distance against how far BTC actually moved over the past ~30 minutes (realized-move sanity). Do NOT run the macro playbooks, bank enumeration, or base-effect arithmetic — there is no forecast consensus for an hourly BTC close; the category base rate plus this distance arithmetic IS the analysis. The verdict is applied mechanically per the verdict rule below (#769). Record it as the FIRST line of the research memo, exactly one line in this format (real numbers, no thousands separators; the single-quoted heredoc keeps the `$` amounts literal — #589):
+1. **Shadow distance analysis** (#739/#769 — records AND gates; replaces the extraordinary-event check): look up current BTC spot (web sources ONLY — CoinDesk, Yahoo Finance, the CF BRTI page; NEVER Kalshi ladder prices, open or settled, #782) and compare the strike-to-spot distance against how far BTC actually moved over the past ~30 minutes (realized-move sanity). Do NOT run the macro playbooks, bank enumeration, or base-effect arithmetic — there is no forecast consensus for an hourly BTC close; the category base rate plus this distance arithmetic IS the analysis. The verdict is applied mechanically per the verdict rule below (#769). Record it as the FIRST line of the research memo, exactly one line in this format (real numbers, no thousands separators; the single-quoted heredoc keeps the `$` amounts literal — #589):
 
    `Shadow: WOULD-PASS | strike=$X spot=$Y distance=$Z move30m=$W`
 
@@ -306,7 +306,7 @@ For all other skips (PASS on research grounds, NEEDS MORE RESEARCH after re-scor
 
 If a `log-trade` skip command fails, note the failure in your output and continue. Do not retry failed log commands.
 
-**Ticker discipline (#778):** copy tickers EXACTLY as printed in your assignment/scan/candidates output — strike decimals included (`-T63399.99`, never `-T63399`). If `market-info` prints "The event ... EXISTS" with a market list, take exactly ONE printed suggestion matching your assigned strike and retry ONCE; if that retry fails or no suggestion matches your assignment, fall through to the failure rule below. NEVER manufacture date-format or strike-format variants — eight guessed variants in cycle 2232 produced eight error escalations and filed #778.
+**Ticker discipline (#778/#782):** copy tickers EXACTLY as printed in your assignment/scan/candidates output — strike decimals included (`-T63399.99`, never `-T63399`). If `market-info` prints "The event ... EXISTS" with a market list, take exactly ONE printed suggestion matching your assigned strike and retry ONCE; if that retry fails or no suggestion matches your assignment, fall through to the failure rule below. NEVER manufacture date-format or strike-format variants — eight guessed variants in cycle 2232 produced eight error escalations and filed #778. NEVER run `market-info` on tickers outside your assignment/shortlist, and NEVER probe a settled ladder to triangulate spot or realized price — cycle 2259 invented $25-increment midpoint strikes against the settled 9 AM ladder to bisect BTC's close, producing three fabricated-ticker 404s (#782). If `market-info` says the event "is ALREADY SETTLED", you are researching the wrong hour: return to your current shortlist.
 
 If `market-info` fails for a candidate, log the candidate with `--price 0 --prob 0` and log the skip with the failure in the rationale.
 
@@ -332,7 +332,7 @@ Substitute actual values: number of candidates researched and number with recomm
 
 - NEVER place orders — that's the Closer's job
 - NEVER modify code
-- NEVER guess ticker format variants — copy tickers verbatim; one corrected retry max on "unknown ticker" output (#778)
+- NEVER guess ticker format variants — copy tickers verbatim; one corrected retry max on "unknown ticker" output (#778); market-info ONLY on shortlist tickers, never on settled ladders (#782)
 - MUST produce a GimmeScore for every candidate — NEVER recommend PROCEED/PASS without a numeric score
 - MUST be explicit about uncertainty in probability estimates
 - MUST flag any settlement concerns prominently

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -302,6 +302,8 @@ MUST check every open position's market for settlement status. For each resolved
 gimmes log-outcome TICKER --outcome yes   # or --outcome no
 ```
 
+`gimmes log-outcome` records the resolution but does NOT settle or remove the position — do not report a position as settled until the settlement sweep's close row exists (#781: a "settled this cycle" claim based on log-outcome alone triggered a false stale-position escalation).
+
 NEVER skip this step — missing outcome data degrades all Pro analyses. If the log-outcome command fails, note the failure prominently in your output so the outcome can be recorded on the next cycle. Do not retry.
 
 ## Activity Logging (REQUIRED — you are not done until this runs)

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, TypeVar
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from gimmes.models.market import Market
+
 import click
 import typer
 from rich.console import Console
@@ -305,6 +307,11 @@ async def _recover_unknown_ticker(
                 status="settled", limit=200,
             )
             state = "settled" if markets else ""
+        if not markets:
+            # Both lookups empty: the documented not-applicable shape
+            # — a partially-filled tuple would mislead future callers
+            # into thinking the event was validated (Copilot review).
+            return "", [], ""
     except Exception:
         logging.getLogger("gimmes.cli").debug(
             "ticker recovery failed for %s", resolved, exc_info=True,
@@ -401,7 +408,7 @@ async def _mark_positions_to_market(
     broker,   # PaperBroker
     client,   # KalshiClient
     *,
-    known_markets: dict | None = None,
+    known_markets: dict[str, Market] | None = None,
 ) -> list:
     """Mark all paper positions to market and return refreshed list.
 
@@ -421,7 +428,7 @@ async def _mark_positions_to_market(
 
     positions = await broker.get_positions()
 
-    markets: dict = dict(known_markets or {})
+    markets: dict[str, Market] = dict(known_markets or {})
     for pos in positions:
         try:
             if pos.ticker not in markets:
@@ -463,8 +470,9 @@ async def _mark_positions_to_market(
                 continue
             await broker.mark_to_market(
                 pos.ticker,
-                resolved_market.midpoint or resolved_market.last_price,
-                close_time=getattr(resolved_market, "close_time", None),
+                # Market.midpoint already falls back to last_price
+                resolved_market.midpoint,
+                close_time=resolved_market.close_time,
             )
         except Exception as exc:
             console.print(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -265,44 +265,56 @@ def _print_ambiguous_ticker(prefix: str, matches: list[str]) -> None:
 
 async def _recover_unknown_ticker(
     client, resolved: str,
-) -> tuple[str, list[str]]:
-    """Best-effort 404 recovery for `market-info` (#778): derive the
-    event ticker from a strike ticker and list the event's open
+) -> tuple[str, list[str], str]:
+    """Best-effort 404 recovery for `market-info` (#778/#782): derive
+    the event ticker from a strike ticker and list the event's open
     markets, longest-common-prefix first so the intended correction
-    survives any display cap. Returns ("", []) when not applicable or
+    survives any display cap. When the event has no OPEN markets, a
+    second-chance settled lookup (#782) distinguishes "you are
+    researching an hour that already settled" from a genuinely
+    unknown event. Returns (event_ticker, tickers, state) with state
+    in {"open", "settled", ""}; ("", [], "") when not applicable or
     on ANY failure — the caller degrades to the plain
     http_status_error path; the recovery must never mask the original
-    404. The derived event ticker is returned alongside so the caller
-    prints exactly what was queried.
+    404.
     """
     import logging
     import os.path
 
     if "-T" not in resolved:
         # Range shape (-B7737), bare garbage ("00"), hyphenless typos.
-        return "", []
+        return "", [], ""
     # rsplit, not split: the LAST '-T' is the strike separator, which
     # keeps negative thresholds (KXCPI-26JUN-T-0.2 -> KXCPI-26JUN)
     # and mid-event '-T' shapes correct.
     event_ticker = resolved.rsplit("-T", 1)[0]
     if not event_ticker:
-        return "", []
+        return "", [], ""
     try:
         from gimmes.kalshi.markets import list_markets
 
         markets, _ = await list_markets(
             client, event_ticker=event_ticker, limit=200,
         )
+        state = "open"
+        if not markets:
+            # #782: the c2259 shape — probing a SETTLED ladder. The
+            # "settled" filter is the backtest's proven-valid value.
+            markets, _ = await list_markets(
+                client, event_ticker=event_ticker,
+                status="settled", limit=200,
+            )
+            state = "settled" if markets else ""
     except Exception:
         logging.getLogger("gimmes.cli").debug(
             "ticker recovery failed for %s", resolved, exc_info=True,
         )
-        return "", []
+        return "", [], ""
     tickers = [m.ticker for m in markets]
     tickers.sort(
         key=lambda t: (-len(os.path.commonprefix([t, resolved])), t),
     )
-    return event_ticker, tickers
+    return event_ticker, tickers, state
 
 
 def _run(coro):  # type: ignore[no-untyped-def]
@@ -389,7 +401,7 @@ async def _mark_positions_to_market(
     broker,   # PaperBroker
     client,   # KalshiClient
     *,
-    known_prices: dict[str, float] | None = None,
+    known_markets: dict | None = None,
 ) -> list:
     """Mark all paper positions to market and return refreshed list.
 
@@ -398,20 +410,24 @@ async def _mark_positions_to_market(
     every other consumer (risk-check, the order/validate position
     load) kept counting a resolved position's cost basis and stale
     unrealized P&L until the next `gimmes positions` run.
+
+    #781 triage: callers pass full Market objects (known_markets),
+    not bare prices — a caller-supplied price used to skip the settle
+    check entirely, so ordering a ticker you already hold could size
+    against a just-resolved position.
     """
     from gimmes.kalshi.markets import get_market
     from gimmes.models.market import MarketStatus
 
     positions = await broker.get_positions()
-    prices = dict(known_prices or {})
 
-    markets: dict = {}
+    markets: dict = dict(known_markets or {})
     for pos in positions:
         try:
-            if pos.ticker not in prices:
-                market = await get_market(client, pos.ticker)
-                prices[pos.ticker] = market.midpoint or market.last_price
-                markets[pos.ticker] = market
+            if pos.ticker not in markets:
+                markets[pos.ticker] = await get_market(
+                    client, pos.ticker,
+                )
             resolved_market = markets.get(pos.ticker)
             if (
                 resolved_market is not None
@@ -447,8 +463,8 @@ async def _mark_positions_to_market(
                 continue
             await broker.mark_to_market(
                 pos.ticker,
-                prices[pos.ticker],
-                close_time=getattr(markets.get(pos.ticker), "close_time", None),
+                resolved_market.midpoint or resolved_market.last_price,
+                close_time=getattr(resolved_market, "close_time", None),
             )
         except Exception as exc:
             console.print(
@@ -808,7 +824,7 @@ def validate(
 
             if broker:
                 positions = await _mark_positions_to_market(
-                    broker, client, known_prices={ticker: raw_price},
+                    broker, client, known_markets={ticker: market},
                 )
             else:
                 from gimmes.kalshi.portfolio import get_all_positions
@@ -1295,7 +1311,7 @@ def order(
             # Get positions for validation
             if broker:
                 positions = await _mark_positions_to_market(
-                    broker, client, known_prices={ticker: raw_price},
+                    broker, client, known_markets={ticker: market},
                 )
             else:
                 from gimmes.kalshi.portfolio import get_all_positions
@@ -3546,6 +3562,7 @@ def market_info(
                 # not conflate agent typos with real API failures.
                 suggestions: list[str] = []
                 event_ticker = ""
+                event_state = ""
                 failing_url = str(
                     getattr(exc.request, "url", "") or ""
                 )
@@ -3559,9 +3576,56 @@ def market_info(
                     # it an unknown ticker would both hide it from
                     # ERROR escalation and tell the agent to retry a
                     # DIFFERENT strike.
-                    event_ticker, suggestions = (
+                    event_ticker, suggestions, event_state = (
                         await _recover_unknown_ticker(client, resolved)
                     )
+                if event_state == "settled":
+                    # #782: the event exists but has ALREADY SETTLED —
+                    # the agent is researching the wrong hour (the
+                    # c2259 bisection probe). Deliberately list ZERO
+                    # settled tickers: printing them would hand a
+                    # ladder-probing agent exactly the data it wanted;
+                    # the corrective action is "go back to your
+                    # shortlist", which needs no ticker.
+                    async with Database(config.db_path) as db:
+                        await _log_cli_error(db, ErrorLogEntry(
+                            severity=ErrorSeverity.WARNING,
+                            category=ErrorCategory.CONFIG_ERROR,
+                            error_code="ticker_not_found",
+                            component="cli.market-info",
+                            message=(
+                                f"Unknown ticker '{resolved}' (404) —"
+                                f" event '{event_ticker}' exists but"
+                                f" is ALREADY SETTLED"
+                                f" ({len(suggestions)} settled"
+                                f" markets)"
+                            ),
+                            context=json.dumps({
+                                "ticker": ticker,
+                                "resolved": resolved,
+                                "event_ticker": event_ticker,
+                                "event_state": "settled",
+                                "suggestions": [],
+                                "suggestions_total": len(suggestions),
+                                "status_code": 404,
+                            }),
+                        ))
+                    console.print(
+                        f"[red bold]Market lookup FAILED (404):"
+                        f" unknown ticker"
+                        f" '{rich_escape(resolved)}'[/red bold]"
+                    )
+                    console.print(
+                        f"The event {rich_escape(event_ticker)} exists"
+                        f" but is ALREADY SETTLED — you are"
+                        f" researching an hour that has settled."
+                    )
+                    console.print(
+                        "[yellow]Only research tickers from your"
+                        " current shortlist. NEVER probe settled"
+                        " ladders (#782).[/yellow]"
+                    )
+                    raise typer.Exit(1)
                 if suggestions:
                     shown = suggestions[:_AMBIGUOUS_MATCH_DISPLAY_LIMIT]
                     async with Database(config.db_path) as db:

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3194,7 +3194,7 @@ def test_closer_cap_sizing_note_pinned() -> None:
 def test_caddie_ticker_discipline_rule(caddie_text: str) -> None:
     """#778: eight guessed ticker variants in one minute — the
     discipline rule and its adjacency to the failure rule must hold."""
-    assert "Ticker discipline (#778)" in caddie_text
+    assert "Ticker discipline (#778/#782)" in caddie_text
     assert "strike decimals included" in caddie_text
     assert "retry ONCE" in caddie_text
     assert (
@@ -3203,10 +3203,10 @@ def test_caddie_ticker_discipline_rule(caddie_text: str) -> None:
     )
     # Adjacent to the market-info failure rule so the fallthrough
     # reads as one flow
-    start = caddie_text.index("Ticker discipline (#778)")
+    start = caddie_text.index("Ticker discipline (#778/#782)")
     assert (
         "If `market-info` fails for a candidate"
-        in caddie_text[start:start + 900]
+        in caddie_text[start:start + 1600]
     )
     assert "NEVER guess ticker format variants" in caddie_text
     # The quoted trigger matches the console's actual casing
@@ -3216,3 +3216,28 @@ def test_caddie_ticker_discipline_rule(caddie_text: str) -> None:
 def test_scout_verbatim_ticker_rule(scout_text: str) -> None:
     assert "transcribed verbatim from `gimmes scan` output" in scout_text
     assert "a dropped suffix here becomes their 404 (#778)" in scout_text
+
+
+def test_caddie_no_settled_ladder_probing(caddie_text: str) -> None:
+    """#782: the c2259 bisection — fabricated midpoint strikes against
+    a settled ladder to triangulate BTC's close."""
+    assert "NEVER probe a settled ladder" in caddie_text
+    assert "cycle 2259" in caddie_text
+    assert (
+        "NEVER run `market-info` on tickers outside your"
+        " assignment/shortlist" in caddie_text
+    )
+    assert 'the event "is ALREADY SETTLED"' in caddie_text
+    # The Shadow spot lookup names web sources and bans ladder prices
+    assert "web sources ONLY" in caddie_text
+    assert "NEVER Kalshi ladder prices, open or settled, #782" in caddie_text
+
+
+def test_monitor_log_outcome_is_not_settlement(monitor_text: str) -> None:
+    """#781: log-outcome stamps the resolution; it does not settle."""
+    assert (
+        "does NOT settle or remove the position" in monitor_text
+    )
+    assert (
+        "until the settlement sweep's close row exists" in monitor_text
+    )

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -804,7 +804,8 @@ class TestMarketInfo404Recovery:
         m.ticker = ticker
         return m
 
-    def _run(self, seeded_db, ticker, *, list_markets=None,
+    @staticmethod
+    def _run(seeded_db, ticker, *, list_markets=None,
              list_markets_effect=None, status=404):
         response = MagicMock(status_code=status, text="err")
         get_market = AsyncMock(
@@ -975,3 +976,83 @@ class TestMarketInfo404Recovery:
         assert any(
             e["error_code"] == "http_status_error" for e in errors
         )
+
+
+class TestMarketInfo404SettledEvent:
+    """#782: a 404 on a SETTLED event's ticker gets the wrong-hour
+    signal — with ZERO settled tickers listed (a ladder-probing agent
+    must not be handed the data it was fishing for)."""
+
+    def test_settled_event_warns_without_suggestions(
+        self, seeded_db: Path,
+    ) -> None:
+        settled = MagicMock()
+        settled.ticker = "KXBTCD-26AUG1709-T63399.99"
+        result, lm = TestMarketInfo404Recovery._run(
+            seeded_db,
+            "KXBTCD-26AUG1709-T63424.99",
+            list_markets_effect=[([], None), ([settled], None)],
+        )
+        assert result.exit_code == 1
+        assert "ALREADY SETTLED" in result.output
+        assert "NEVER probe settled" in result.output
+        assert "KXBTCD-26AUG1709-T63399.99" not in result.output
+        assert lm.await_count == 2
+        assert lm.await_args_list[1].kwargs["status"] == "settled"
+        errors = _read_error_log(seeded_db)
+        row = [e for e in errors if e["error_code"] == "ticker_not_found"]
+        assert len(row) == 1
+        assert row[0]["severity"] == "warning"
+        import json
+
+        ctx = json.loads(row[0]["context"])
+        assert ctx["event_state"] == "settled"
+        assert ctx["suggestions"] == []
+        # Same key as the open branch — dashboards must not need two
+        # queries for one concept (review-found)
+        assert ctx["suggestions_total"] == 1
+        assert not any(
+            e["error_code"] == "http_status_error" for e in errors
+        )
+
+    def test_settled_lookup_failure_degrades(
+        self, seeded_db: Path,
+    ) -> None:
+        result, _ = TestMarketInfo404Recovery._run(
+            seeded_db,
+            "KXBTCD-26AUG1709-T63424.99",
+            list_markets_effect=[([], None), RuntimeError("api down")],
+        )
+        assert result.exit_code == 1
+        errors = _read_error_log(seeded_db)
+        assert any(
+            e["error_code"] == "http_status_error" for e in errors
+        )
+
+    def test_both_lookups_empty_falls_back_to_error(
+        self, seeded_db: Path,
+    ) -> None:
+        result, lm = TestMarketInfo404Recovery._run(
+            seeded_db,
+            "KXBTCD-26AUG1709-T63424.99",
+        )
+        assert result.exit_code == 1
+        assert lm.await_count == 2
+        errors = _read_error_log(seeded_db)
+        assert any(
+            e["error_code"] == "http_status_error" for e in errors
+        )
+
+    def test_open_branch_never_makes_second_call(
+        self, seeded_db: Path,
+    ) -> None:
+        mk = MagicMock()
+        mk.ticker = "KXBTCD-26AUG1710-T63499.99"
+        result, lm = TestMarketInfo404Recovery._run(
+            seeded_db,
+            "KXBTCD-26AUG1710-T63499",
+            list_markets=[mk],
+        )
+        assert result.exit_code == 1
+        assert "EXISTS" in result.output
+        assert lm.await_count == 1

--- a/tests/unit/test_mark_to_market.py
+++ b/tests/unit/test_mark_to_market.py
@@ -37,7 +37,10 @@ class TestMarkPositionsToMarket:
         broker.mark_to_market.assert_any_call("A", 0.70, close_time=ANY)
         broker.mark_to_market.assert_any_call("B", 0.70, close_time=ANY)
 
-    async def test_known_prices_skip_api_call(self) -> None:
+    async def test_known_markets_skip_api_call(self) -> None:
+        """#781 triage: callers pass full Market objects so the settle
+        check covers held tickers too — a bare known price used to
+        skip it entirely."""
         broker = AsyncMock()
         broker.get_positions = AsyncMock(return_value=[_pos("A"), _pos("B")])
         broker.mark_to_market = AsyncMock()
@@ -48,10 +51,10 @@ class TestMarkPositionsToMarket:
             from gimmes.cli import _mark_positions_to_market
 
             await _mark_positions_to_market(
-                broker, client, known_prices={"A": 0.65},
+                broker, client, known_markets={"A": _market(0.65)},
             )
 
-        # A uses known price, B fetches from API
+        # A uses the supplied market, B fetches from API
         broker.mark_to_market.assert_any_call("A", 0.65, close_time=ANY)
         broker.mark_to_market.assert_any_call("B", 0.80, close_time=ANY)
         # get_market called only for B

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -487,3 +487,61 @@ class TestOpenPositionMissingTradeLog:
         assert "No open trade row recorded" in result.output
         assert "POSITION CLOSED/SETTLED" not in result.output
         assert _read_errors(db_path) == []
+
+
+class TestKnownMarketsSettle:
+    """#781 triage regression pin: a caller-supplied market for a held
+    ticker gets the settle check — the old known_prices form skipped
+    it, so ordering a ticker you already hold could size against a
+    just-resolved position."""
+
+    def test_known_market_settled_settles_not_marks(self) -> None:
+        market = MagicMock()
+        market.status = MarketStatus.DETERMINED
+        market.result = "yes"
+        market.midpoint = 0.5
+        market.last_price = 0.5
+        market.close_time = None
+        pos = Position(
+            ticker=TICKER, side="no", count=100, avg_price=0.5,
+            market_price=0.5, cost_basis=50.0, unrealized_pnl=0.0,
+        )
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(side_effect=[[pos], []])
+        client = AsyncMock()
+        get_market = AsyncMock(
+            side_effect=AssertionError("must not fetch a known market"),
+        )
+        with patch("gimmes.kalshi.markets.get_market", get_market):
+            asyncio.run(_mark_positions_to_market(
+                broker, client, known_markets={TICKER: market},
+            ))
+        broker.settle.assert_awaited_once_with(TICKER, "yes")
+        broker.mark_to_market.assert_not_awaited()
+        get_market.assert_not_awaited()
+
+    def test_known_market_determined_without_result_marks(self) -> None:
+        """Fail-open pin (review-found): DETERMINED with an empty
+        result must mark, not settle — a future 'settle on empty
+        result' change has to be deliberate."""
+        market = MagicMock()
+        market.status = MarketStatus.DETERMINED
+        market.result = ""
+        market.midpoint = 0.5
+        market.last_price = 0.5
+        market.close_time = None
+        pos = Position(
+            ticker=TICKER, side="no", count=100, avg_price=0.5,
+            market_price=0.5, cost_basis=50.0, unrealized_pnl=0.0,
+        )
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(side_effect=[[pos], []])
+        with patch(
+            "gimmes.kalshi.markets.get_market",
+            AsyncMock(side_effect=AssertionError("no fetch")),
+        ):
+            asyncio.run(_mark_positions_to_market(
+                broker, AsyncMock(), known_markets={TICKER: market},
+            ))
+        broker.settle.assert_not_awaited()
+        broker.mark_to_market.assert_awaited_once()


### PR DESCRIPTION
## Summary

The post-#778 404s were a **new failure class**: cycle 2259's Caddie bisected the *settled* 9 AM BTC ladder to triangulate realized price — fabricating $25-increment midpoint strikes never present in any shortlist. The #778 recovery correctly found no *open* markets for the settled event and degraded silently, so the agent got no corrective signal.

**Recovery second chance:** when the open-markets lookup is empty, `market-info` retries with `status="settled"` (the backtest's production-proven filter). A settled event now yields "the event exists but is ALREADY SETTLED — only research tickers from your current shortlist; NEVER probe settled ladders (#782)" — with deliberately **zero** settled tickers listed, since printing them would hand a ladder-probing agent exactly the data it was fishing for. Same `ticker_not_found` WARNING channel (context gains `event_state: settled`); both-lookups-empty keeps the ERROR path byte-identical. Known window, documented: closed-but-not-yet-settled events (minutes-wide for BTC hourlies) still degrade to the plain ERROR path — the safe direction.

**#781-triage bug fixed here:** `_mark_positions_to_market` now takes `known_markets` (full Market objects) instead of `known_prices` — the old form skipped the settle check entirely for a held ticker being ordered/validated, so sizing could run against a just-resolved position. Held tickers now get the settle check; the mark price and close_time come from the resolved market (held tickers previously always marked with `close_time=None`).

**Prompt law:** caddie.md — `market-info` only on shortlist tickers, never probe settled ladders (cycle 2259 named), Shadow spot lookup uses web sources only (never Kalshi ladder prices); monitor.md — `log-outcome` records the resolution but does **not** settle or remove the position (the false "settled this cycle" claim behind #781's escalation). Drift-guard pinned.

**Filed during review:** #784 — the pre-existing order-path market-status gate hole (a DETERMINED candidate market is refused only incidentally).

Closes #782

## Test plan

- Settled-branch tests: wrong-hour message + WARNING row with `event_state`/`suggestions_total`, zero settled tickers in output, `status="settled"` passthrough pinned on the second call, settled-lookup failure degrades, both-empty double-lookup documented, open branch never makes a second call.
- `known_markets`: settle check on a caller-supplied DETERMINED market (with `get_market` fail-if-called), fail-open pin for a result-less DETERMINED market, the skip-API-call contract preserved.
- Prompt pins for the caddie and monitor additions; the #778 pin updated for the extended heading.
- Frozen full unit suite: **2438 passed**. Lint clean.

Note: pr-review-toolkit not installed; equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r
