### PR TITLE
Market-status gate: non-ACTIVE markets refuse orders explicitly (#784)

### DIFF
--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -128,6 +128,8 @@ A permission-denied `gimmes order` (the command was blocked and never ran) count
 
 An `Hourly shadow gate (#769)` rejection is the same FINAL class: the distance gate refused the entry even though validation passed. Log the `order_failed` skip citing the shadow gate, never retry or resize.
 
+A `Market status gate (#784)` rejection is also FINAL: the market cannot execute orders (resolved, closed, or paused). For a CLOSE on a resolved market, settlement supersedes the close — the settle sweep realizes the position; report it, log the skip, never retry.
+
 If the order command fails (non-zero exit code or error output), MUST:
 1. Log the failure via the `--rationale-file` heredoc pattern — captured CLI output may contain `$` or backticks (#589):
    ```bash

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -1335,8 +1335,71 @@ def order(
                 )
                 await sync_positions(db, positions)
 
+            # #784: markets only match orders while ACTIVE. Sits AFTER
+            # the settle sweep above (a just-resolved held position
+            # settles in this same invocation) and before sizing.
+            # Membership formulation is load-bearing: StrEnum keeps
+            # string stubs working and unknown statuses failing OPEN.
+            from gimmes.models.market import (
+                SETTLED_STATUSES,
+                UNTRADEABLE_STATUSES,
+            )
+
             order_action = OrderAction(action.lower())
             is_buy = order_action == OrderAction.BUY
+            if market.status in UNTRADEABLE_STATUSES:
+                if market.status in SETTLED_STATUSES and is_buy:
+                    detail = (
+                        "the market has RESOLVED — entries are"
+                        " impossible; do not retry"
+                    )
+                elif market.status in SETTLED_STATUSES:
+                    detail = (
+                        "settlement supersedes this close — the settle"
+                        " sweep realizes the position once the result"
+                        " publishes (#782); do not retry"
+                    )
+                else:
+                    detail = (
+                        f"status {market.status}, not active — orders"
+                        f" cannot execute"
+                    )
+                console.print(
+                    f"[red]Market status gate (#784):"
+                    f" {rich_escape(ticker)} — {detail}.[/red]"
+                )
+                await _audit_row(
+                    ErrorLogEntry(
+                        severity=ErrorSeverity.ERROR,
+                        category=ErrorCategory.ORDER_FAILURE,
+                        error_code="market_not_active",
+                        component="cli.order",
+                        agent=agent,
+                        cycle=gate_cycle,
+                        message=(
+                            f"Order refused for {ticker}: market"
+                            f" status {market.status} (#784)"
+                        ),
+                        context=json.dumps({
+                            "ticker": ticker,
+                            "side": side,
+                            "action": action,
+                            "status": str(market.status),
+                            "cycle": gate_cycle,
+                        }),
+                    ),
+                    "Failed to record market_not_active audit row",
+                )
+                # Status cannot revert within a cycle for the settled/
+                # closed cases, and the live path already armed
+                # terminal via http_status_error here — _mark_terminal
+                # self-guards to in-cycle BUYs, so a paused market's
+                # close can retry next dispatch.
+                await _mark_terminal({
+                    "error_code": "market_not_active",
+                    "status": str(market.status),
+                })
+                raise typer.Exit(1)
             is_taker = taker or config.orders.preferred_order_type != "maker"
 
             bankroll = config.bankroll

--- a/src/gimmes/models/market.py
+++ b/src/gimmes/models/market.py
@@ -26,6 +26,19 @@ class MarketStatus(StrEnum):
     FINALIZED = "finalized"
 
 
+# #784: markets where an order can execute vs not. Kalshi matches
+# orders only on ACTIVE markets; everything else dies as a raw 4xx
+# (live) or an empty-book cancel (paper) — the status gate makes the
+# refusal explicit and named. SETTLED_STATUSES is the subset where
+# settlement supersedes any close order (mirrors the #782 sweep
+# trigger).
+SETTLED_STATUSES = frozenset({
+    MarketStatus.DETERMINED,
+    MarketStatus.FINALIZED,
+})
+UNTRADEABLE_STATUSES = frozenset(MarketStatus) - {MarketStatus.ACTIVE}
+
+
 class Market(BaseModel):
     """A Kalshi binary contract market."""
 

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -55,6 +55,7 @@ def validate_trade(
     """Run all pre-trade validation checks.
 
     Checks:
+    0. Market status — never approve an untradeable market (#784)
     1. Daily loss limit
     2. Position count limit
     3. Single position size limit

--- a/src/gimmes/risk/validator.py
+++ b/src/gimmes/risk/validator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from gimmes.config import GimmesConfig
-from gimmes.models.market import Market
+from gimmes.models.market import UNTRADEABLE_STATUSES, Market
 from gimmes.risk.limits import (
     check_bankroll,
     check_daily_loss,
@@ -67,6 +67,17 @@ def validate_trade(
     """
     checks: list[str] = []
     failures: list[str] = []
+
+    # 0. Market status (#784): validation must never APPROVE a market
+    # orders cannot execute on. Membership formulation keeps string
+    # stubs working and unknown statuses failing open.
+    if market.status in UNTRADEABLE_STATUSES:
+        failures.append(
+            f"Market not active (status {market.status}) — orders"
+            f" cannot execute (#784)"
+        )
+    else:
+        checks.append(f"Market status OK ({market.status})")
 
     # 1. Daily loss limit
     loss_check = check_daily_loss(daily_pnl, bankroll, config)

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3241,3 +3241,12 @@ def test_monitor_log_outcome_is_not_settlement(monitor_text: str) -> None:
     assert (
         "until the settlement sweep's close row exists" in monitor_text
     )
+
+
+def test_closer_market_status_gate_final() -> None:
+    """#784: the status-gate rejection is FINAL-class, and a CLOSE on
+    a resolved market defers to settlement."""
+    closer_text = _CLOSER.read_text()
+    assert "Market status gate (#784)" in closer_text
+    assert "settlement supersedes the close" in closer_text
+    assert "report it, log the skip, never retry" in closer_text

--- a/tests/unit/test_market_status_gate.py
+++ b/tests/unit/test_market_status_gate.py
@@ -1,0 +1,145 @@
+"""#784: the market-status gate — orders on non-ACTIVE markets are
+refused explicitly instead of dying as incidental cancels/4xxs."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gimmes.models.market import (
+    SETTLED_STATUSES,
+    UNTRADEABLE_STATUSES,
+    MarketStatus,
+)
+from tests.unit import test_order_error_handling as h
+
+
+def _gate_rows(insert_error):
+    return [
+        c.args[1]
+        for c in insert_error.await_args_list
+        if len(c.args) > 1
+        and c.args[1].error_code == "market_not_active"
+    ]
+
+
+class TestMarketStatusGate:
+    def _run(self, *, status, cli_args=None, extra_args=None,
+             insert_activity_mock=None, monkeypatch=None, cycle=None):
+        if monkeypatch is not None and cycle is not None:
+            monkeypatch.setenv("GIMMES_CYCLE", cycle)
+        market = h._stub_market()
+        market.status = status
+        broker = h._make_mock_broker()
+        self._last_broker = broker
+        result, console, insert_error = h._run_order_cli(
+            broker, market=market, cli_args=cli_args,
+            extra_args=extra_args,
+            insert_activity_mock=insert_activity_mock,
+        )
+        return result, h._printed(console), insert_error
+
+    @pytest.mark.parametrize(
+        "status", sorted(UNTRADEABLE_STATUSES, key=str),
+    )
+    def test_buy_refused_on_every_non_active_status(
+        self, status,
+    ) -> None:
+        result, out, insert_error = self._run(status=status)
+        assert result.exit_code == 1, out
+        assert "Market status gate (#784)" in out
+        assert self._last_broker.create_order.await_count == 0
+        rows = _gate_rows(insert_error)
+        assert len(rows) == 1
+        assert json.loads(rows[0].context)["status"] == str(status)
+
+    def test_string_active_stub_proceeds(self) -> None:
+        """StrEnum/str equivalence pin: the harness's plain 'active'
+        string must keep passing the gate."""
+        result, out, _ = self._run(status="active")
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+
+    def test_magicmock_status_proceeds(self) -> None:
+        """Blast-radius pin: membership (not != ACTIVE) means an
+        unset MagicMock status fails OPEN."""
+        result, out, _ = self._run(status=MagicMock())
+        assert result.exit_code == 0, out
+        assert self._last_broker.create_order.await_count == 1
+
+    def test_sell_on_determined_names_settlement(self) -> None:
+        result, out, _ = self._run(
+            status=MarketStatus.DETERMINED,
+            cli_args=[
+                "order", "TEST-TICKER", "--action", "sell",
+                "--side", "yes", "--count", "10", "--yes",
+            ],
+        )
+        assert result.exit_code == 1, out
+        assert "settlement supersedes" in out
+        assert self._last_broker.create_order.await_count == 0
+        # Settle sweep ran BEFORE the refusal (#782 ordering)
+        assert self._last_broker.get_positions.await_count == 1
+
+    def test_buy_on_determined_names_resolution(self) -> None:
+        result, out, _ = self._run(status=MarketStatus.DETERMINED)
+        assert result.exit_code == 1, out
+        assert "RESOLVED" in out
+
+    def test_sell_on_closed_does_not_claim_settlement(self) -> None:
+        """#781 pin: closed-not-yet-settled is a real transient — the
+        message must not claim the market resolved."""
+        result, out, _ = self._run(
+            status=MarketStatus.CLOSED,
+            cli_args=[
+                "order", "TEST-TICKER", "--action", "sell",
+                "--side", "yes", "--count", "10", "--yes",
+            ],
+        )
+        assert result.exit_code == 1, out
+        assert "settlement supersedes" not in out
+        assert "not active" in out
+
+    def test_in_cycle_refusal_stamps_and_arms(
+        self, monkeypatch,
+    ) -> None:
+        activity = AsyncMock(return_value=1)
+        result, out, insert_error = self._run(
+            status=MarketStatus.DETERMINED,
+            extra_args=["--agent", "closer"],
+            insert_activity_mock=activity,
+            monkeypatch=monkeypatch, cycle="42",
+        )
+        assert result.exit_code == 1, out
+        rows = _gate_rows(insert_error)
+        assert rows[0].cycle == 42
+        markers = [
+            c.kwargs
+            for c in activity.await_args_list
+            if c.kwargs.get("message", "").startswith(
+                "Order attempt terminal:"
+            )
+        ]
+        assert len(markers) == 1
+
+    def test_out_of_cycle_refusal_does_not_arm(self) -> None:
+        activity = AsyncMock(return_value=1)
+        result, out, insert_error = self._run(
+            status=MarketStatus.DETERMINED,
+            insert_activity_mock=activity,
+        )
+        assert result.exit_code == 1, out
+        rows = _gate_rows(insert_error)
+        assert rows[0].cycle == 0
+        assert not any(
+            c.kwargs.get("message", "").startswith(
+                "Order attempt terminal:"
+            )
+            for c in activity.await_args_list
+        )
+
+    def test_settled_statuses_subset(self) -> None:
+        assert SETTLED_STATUSES < UNTRADEABLE_STATUSES
+        assert MarketStatus.ACTIVE not in UNTRADEABLE_STATUSES

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -606,3 +606,34 @@ class TestHourlyPriceBand:
         )
         assert not any("band" in c.lower() for c in result.checks)
         assert not any("band" in f.lower() for f in result.failures)
+
+
+class TestMarketStatusCheck:
+    """#784 check 0: validation never APPROVEs an untradeable market."""
+
+    @staticmethod
+    def _cfg() -> GimmesConfig:
+        return GimmesConfig(
+            mode=Mode.DRIVING_RANGE,
+            strategy=StrategyConfig(side="yes", min_true_probability=0.9),
+        )
+
+    def _validate_status(self, status):
+        m = _make_market()
+        m.status = status
+        return validate_trade(
+            m, 50.0, 0.95, 1000.0, 0.0, 0, [], self._cfg(),
+        )
+
+    def test_determined_fails(self) -> None:
+        result = self._validate_status(MarketStatus.DETERMINED)
+        assert not result.approved
+        assert any("not active" in f for f in result.failures)
+
+    def test_closed_fails(self) -> None:
+        result = self._validate_status(MarketStatus.CLOSED)
+        assert not result.approved
+
+    def test_active_passes_with_check_line(self) -> None:
+        result = self._validate_status(MarketStatus.ACTIVE)
+        assert any("Market status OK" in c for c in result.checks)


### PR DESCRIPTION
## Summary

Fourth gate in the order path (agent → terminal → shadow → **status**): ordering into a non-ACTIVE market was previously stopped only incidentally (paper: #690 empty-book cancel; live: raw Kalshi 4xx as generic `http_status_error`). Now it's a deliberate, classified refusal.

- `SETTLED_STATUSES` / `UNTRADEABLE_STATUSES` constants beside the enum; the gate sits **after** the #782 settle sweep — a just-resolved held position settles in the same invocation the order is refused — and before sizing. `market_not_active` ORDER_FAILURE row, cycle-stamped; branch messages: buy-on-settled says RESOLVED, sell-on-settled says settlement supersedes (softened for the DETERMINED-no-result transient), closed says "not active" without claiming settlement (the #781 lesson, test-pinned). The #768 terminal marker arms for in-cycle BUYs — a resolved market can't un-resolve within a cycle, and the live path already armed terminal via the 4xx handler; sells stay retryable (paused-market closes recover next dispatch).
- `validate_trade` check 0: validation never APPROVEs an untradeable market (`gimmes validate` exits 1 through existing plumbing).
- **Membership formulation is load-bearing**: `status in UNTRADEABLE_STATUSES` (never `!= ACTIVE`) — StrEnum keeps the harness's plain `"active"` strings passing and MagicMock/unknown statuses failing OPEN. Zero edits across ~50 existing order-harness tests; both properties pinned by dedicated tests. Real API enum drift can't reach the gate (pydantic parse raises upstream — filed as #787).
- closer.md: FINAL-class sentence; a CLOSE on a resolved market defers to settlement. Drift-pinned.

Filed during review: **#787** (enum-drift market aborts entire scans — pre-existing), **#788** (wall-clock-flaky loop test — pre-existing).

Closes #784

## Test plan

- 15 gate tests: all 7 non-ACTIVE statuses refuse (parametrized, context carries status), string-"active"/MagicMock equivalence pins, sell-on-DETERMINED names settlement + sweep-before-gate ordering assert, sell-on-CLOSED does not claim settlement, buy-on-DETERMINED names resolution, in-cycle stamps + arms the terminal marker, out-of-cycle doesn't arm, settled⊂untradeable sanity.
- 3 validator tests (determined/closed fail; active passes with the check line). Mutation matrix fully killed (gate removal, membership→!=, message branch, validator check, marker arm — verified empirically in review).
- Frozen full unit suite: **2457 passed** in 16:16 (clean re-run after a concurrent-agent-interference kill of the first attempt). Lint clean.

Note: pr-review-toolkit not installed; equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r