### PR TITLE
Past-close stale-position alert with doubling re-log (#783)

### DIFF
--- a/.claude/agents/groundskeeper.md
+++ b/.claude/agents/groundskeeper.md
@@ -39,6 +39,7 @@ If there are no unresolved errors, report "No issues to escalate" and exit.
 - Any error with `critical` severity
 - Any error with `risk_breach` category — EXCEPT `churn_roundtrip` WARNING rows (#661): those are audit-trail records for the Pro agent's churn analysis, written on every sub-hour close including correct stop-loss closes — do NOT file issues for them. `reopen_gate_overridden` rows DO escalate (a forced bypass always warrants review).
 - `auth_failure` errors that have been unresolved for 2+ cycles
+- `position_past_close` rows whose context carries reason `settle_failed` or `determined_no_result` (#783) — a published result that is not realizing is a broken sweep, not settlement lag; `awaiting_determination` rows follow the pattern rules below (Kalshi lag is normal, but re-logs at growing buckets mean the lag keeps doubling)
 
 **Pattern escalation (file issue if threshold met):**
 - Same `error_code` appears 3+ times in the last 24 hours

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -409,6 +409,8 @@ async def _mark_positions_to_market(
     client,   # KalshiClient
     *,
     known_markets: dict[str, Market] | None = None,
+    db=None,   # Database | None — enables the #783 past-close alert
+    past_close_minutes: int = 30,
 ) -> list:
     """Mark all paper positions to market and return refreshed list.
 
@@ -429,6 +431,7 @@ async def _mark_positions_to_market(
     positions = await broker.get_positions()
 
     markets: dict[str, Market] = dict(known_markets or {})
+    past_close: dict[str, dict] = {}
     for pos in positions:
         try:
             if pos.ticker not in markets:
@@ -459,15 +462,17 @@ async def _mark_positions_to_market(
                         f" {resolved_market.status.value}[/dim]"
                     )
                 except Exception as exc:
-                    # An accurate diagnosis, not the mark warning: a
-                    # lock-contended settle silently retried-and-
-                    # failed every run would hide behind "could not
-                    # mark" (review-found).
-                    console.print(
-                        f"[yellow]Warning: could not settle"
-                        f" {pos.ticker}: {exc}[/yellow]"
+                    # An accurate diagnosis, not the mark warning
+                    # (review-found), and the actionable "sweep
+                    # broken" #783 case.
+                    _record_settle_failed(
+                        past_close, pos.ticker,
+                        resolved_market.status, exc,
                     )
                 continue
+            _collect_past_close(
+                past_close, pos, resolved_market, past_close_minutes,
+            )
             await broker.mark_to_market(
                 pos.ticker,
                 # Market.midpoint already falls back to last_price
@@ -480,7 +485,149 @@ async def _mark_positions_to_market(
                 f" to market: {exc}[/yellow]"
             )
 
+    if past_close and isinstance(past_close_minutes, int) and past_close_minutes > 0:
+        await _note_past_close_positions(db, past_close)
+
     return await broker.get_positions()
+
+
+def _record_settle_failed(
+    past_close: dict, ticker: str, status, exc: Exception,
+) -> None:
+    """#783: identical warning + entry shape from BOTH sweep and
+    positions command — the change-detection dedup compares serialized
+    payloads, so divergence between the two commands would thrash it.
+    """
+    console.print(
+        f"[yellow]Warning: could not settle {ticker}: {exc}[/yellow]"
+    )
+    past_close[ticker] = {
+        "reason": "settle_failed",
+        "status": str(status),
+    }
+
+
+def _collect_past_close(
+    past_close: dict, pos, market, threshold_minutes: int,
+) -> None:
+    """#783: record an open position whose market is past close_time
+    but unsettled. Reason distinguishes 'Kalshi is slow' (closed,
+    awaiting determination — the 2026-08-14 INX shape) from
+    actionable states. Threshold 0 disables; strict greater-than."""
+    from datetime import UTC, datetime, timedelta
+
+    from gimmes.models.market import MarketStatus
+
+    if not isinstance(threshold_minutes, int) or threshold_minutes <= 0:
+        # Includes MagicMock configs in CLI tests — observability must
+        # never break the marking sweep.
+        return
+    ct = market.close_time or getattr(pos, "close_time", None)
+    if isinstance(ct, str):
+        try:
+            ct = datetime.fromisoformat(ct)
+        except ValueError:
+            return
+    if not isinstance(ct, datetime):
+        # None, or a test double — the alert is observability and
+        # must never break the marking sweep.
+        return
+    if ct.tzinfo is None:
+        ct = ct.replace(tzinfo=UTC)
+    past = datetime.now(UTC) - ct
+    if past <= timedelta(minutes=threshold_minutes):
+        return
+    status = market.status
+    if status == MarketStatus.CLOSED:
+        reason = "awaiting_determination"
+    elif status in (MarketStatus.DETERMINED, MarketStatus.FINALIZED):
+        reason = "determined_no_result"
+    else:
+        reason = "active_past_close"
+    minutes_past = int(past.total_seconds() // 60)
+    past_close[pos.ticker] = {
+        "reason": reason,
+        "status": str(status),
+        "minutes_past": minutes_past,
+        # #783 review: the dedup payload excludes raw minutes (grows
+        # every cycle) but includes this doubling bucket, so a STUCK
+        # position re-logs at ~1x/2x/4x/8x threshold — reaching
+        # Groundskeeper's 3+/24h pattern rule within hours instead of
+        # writing one row that ages out silently.
+        "bucket": max(1, minutes_past // threshold_minutes).bit_length(),
+    }
+
+
+async def _note_past_close_positions(db, entries: dict) -> None:
+    """#783: console note every run; durable WARNING row only on state
+    change (#767 pattern — minutes_past is EXCLUDED from the dedup
+    payload since it grows every cycle, but the doubling bucket is
+    included so stuck positions re-log). Self-guarding: observability
+    must never break the sweep it rides on.
+    """
+    import json as _json
+    import logging
+
+    from gimmes.models.error import (
+        ErrorCategory,
+        ErrorLogEntry,
+        ErrorSeverity,
+    )
+
+    try:
+        details = []
+        for ticker, e in sorted(entries.items()):
+            mins = (
+                f", {e['minutes_past']}min past"
+                if "minutes_past" in e else ""
+            )
+            details.append(
+                f"{ticker} ({e['reason']}, status {e['status']}{mins})"
+            )
+            console.print(
+                f"[dim]Past close (#783): {ticker}{mins},"
+                f" status {e['status']} — {e['reason']}[/dim]"
+            )
+        if db is None:
+            return
+        payload = _json.dumps(
+            {
+                t: {
+                    "reason": e["reason"],
+                    "status": e["status"],
+                    "bucket": e.get("bucket", 0),
+                }
+                for t, e in entries.items()
+            },
+            sort_keys=True,
+        )
+        cursor = await db.conn.execute(
+            "SELECT context FROM error_log"
+            " WHERE error_code = 'position_past_close'"
+            " ORDER BY id DESC LIMIT 1"
+        )
+        last = await cursor.fetchone()
+        if last and last["context"] == payload:
+            return
+        await _log_cli_error(db, ErrorLogEntry(
+            severity=ErrorSeverity.WARNING,
+            category=ErrorCategory.DATA_INTEGRITY,
+            error_code="position_past_close",
+            component="cli.mark",
+            message=(
+                "Open positions past market close without settlement: "
+                + "; ".join(details)
+                + " — awaiting_determination means Kalshi settlement"
+                " lag (normal for index markets); investigate"
+                " settle_failed / determined_no_result or steadily"
+                " growing lag"
+            ),
+            context=payload,
+        ))
+    except Exception:
+        logging.getLogger("gimmes.cli").warning(
+            "past-close alert failed", exc_info=True,
+        )
 
 
 @asynccontextmanager
@@ -833,6 +980,10 @@ def validate(
             if broker:
                 positions = await _mark_positions_to_market(
                     broker, client, known_markets={ticker: market},
+                    db=db,
+                    past_close_minutes=(
+                        config.risk.position_past_close_minutes
+                    ),
                 )
             else:
                 from gimmes.kalshi.portfolio import get_all_positions
@@ -1320,6 +1471,10 @@ def order(
             if broker:
                 positions = await _mark_positions_to_market(
                     broker, client, known_markets={ticker: market},
+                    db=db,
+                    past_close_minutes=(
+                        config.risk.position_past_close_minutes
+                    ),
                 )
             else:
                 from gimmes.kalshi.portfolio import get_all_positions
@@ -2746,6 +2901,7 @@ def positions() -> None:
 
         async with trading_context(config) as (client, broker, db):
             stale: set[str] = set()
+            past_close: dict[str, dict] = {}
             suspect: set[str] = set()
             if broker:
                 pos_list = await broker.get_positions()
@@ -2790,7 +2946,21 @@ def positions() -> None:
                             in (MarketStatus.DETERMINED, MarketStatus.FINALIZED)
                             and market.result in ("yes", "no")
                         ):
-                            await broker.settle(pos.ticker, market.result)
+                            try:
+                                await broker.settle(
+                                    pos.ticker, market.result,
+                                )
+                            except Exception as exc:
+                                _record_settle_failed(
+                                    past_close, pos.ticker,
+                                    market.status, exc,
+                                )
+                        else:
+                            # #783: unsettled past-close positions
+                            _collect_past_close(
+                                past_close, pos, market,
+                                config.risk.position_past_close_minutes,
+                            )
                     except Exception as exc:
                         # #674: the position keeps its LAST mark — the
                         # Stop column must say STALE, not render a
@@ -2799,6 +2969,13 @@ def positions() -> None:
                         console.print(
                             f"[yellow]Warning: could not update {pos.ticker}: {exc}[/yellow]"
                         )
+                _pc_threshold = config.risk.position_past_close_minutes
+                if (
+                    past_close
+                    and isinstance(_pc_threshold, int)
+                    and _pc_threshold > 0
+                ):
+                    await _note_past_close_positions(db, past_close)
                 # Re-fetch after mark-to-market
                 pos_list = await broker.get_positions()
             else:
@@ -2856,7 +3033,12 @@ def risk_check() -> None:
                 # count, deployed capital, or unrealized P&L. Balance
                 # is read AFTER so the settlement credit and the
                 # position list come from the same snapshot.
-                pos = await _mark_positions_to_market(broker, client)
+                pos = await _mark_positions_to_market(
+                    broker, client, db=db,
+                    past_close_minutes=(
+                        config.risk.position_past_close_minutes
+                    ),
+                )
                 balance = await broker.get_balance()
             else:
                 from gimmes.kalshi.portfolio import get_all_positions, get_balance

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -558,7 +558,9 @@ def _collect_past_close(
     }
 
 
-async def _note_past_close_positions(db, entries: dict) -> None:
+async def _note_past_close_positions(
+    db, entries: dict, *, component: str = "cli.mark",
+) -> None:
     """#783: console note every run; durable WARNING row only on state
     change (#767 pattern — minutes_past is EXCLUDED from the dedup
     payload since it grows every cycle, but the doubling bucket is
@@ -601,9 +603,13 @@ async def _note_past_close_positions(db, entries: dict) -> None:
             },
             sort_keys=True,
         )
+        # Unresolved rows only (Copilot review): resolving the last
+        # row while the condition persists must RE-ARM the alert, not
+        # suppress it.
         cursor = await db.conn.execute(
             "SELECT context FROM error_log"
             " WHERE error_code = 'position_past_close'"
+            " AND resolved = 0"
             " ORDER BY id DESC LIMIT 1"
         )
         last = await cursor.fetchone()
@@ -613,7 +619,7 @@ async def _note_past_close_positions(db, entries: dict) -> None:
             severity=ErrorSeverity.WARNING,
             category=ErrorCategory.DATA_INTEGRITY,
             error_code="position_past_close",
-            component="cli.mark",
+            component=component,
             message=(
                 "Open positions past market close without settlement: "
                 + "; ".join(details)
@@ -2975,7 +2981,9 @@ def positions() -> None:
                     and isinstance(_pc_threshold, int)
                     and _pc_threshold > 0
                 ):
-                    await _note_past_close_positions(db, past_close)
+                    await _note_past_close_positions(
+                        db, past_close, component="cli.positions",
+                    )
                 # Re-fetch after mark-to-market
                 pos_list = await broker.get_positions()
             else:

--- a/src/gimmes/config.py
+++ b/src/gimmes/config.py
@@ -710,6 +710,25 @@ class RiskConfig(BaseModel):
             "max_val": 0.95,
         },
     )
+    position_past_close_minutes: int = Field(
+        default=30, ge=0, le=1440,
+        json_schema_extra={
+            "display_name": "Past-Close Alert",
+            "description": (
+                "Flag an open position whose market closed more than this\n"
+                "many minutes ago without settling (#783). Distinguishes\n"
+                "'Kalshi settlement confirmation is slow' from 'the sweep\n"
+                "is broken' — a WARNING row is written once per state\n"
+                "change, not per cycle.\n"
+                "\n"
+                "  • 30 (default): hourly BTC (~1 min lag) stays quiet;\n"
+                "    the 2026-08-14 INX 2-hour lag would have flagged\n"
+                "  • 0: disable the check entirely"
+            ),
+            "min_val": 0,
+            "max_val": 1440,
+        },
+    )
     max_event_exposure_pct: float = Field(
         default=0.15, gt=0.0, le=1.0,
         json_schema_extra={

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3250,3 +3250,12 @@ def test_closer_market_status_gate_final() -> None:
     assert "Market status gate (#784)" in closer_text
     assert "settlement supersedes the close" in closer_text
     assert "report it, log the skip, never retry" in closer_text
+
+
+def test_groundskeeper_past_close_escalation(groundskeeper_text: str) -> None:
+    """#783: actionable past-close reasons escalate immediately; lag
+    rows ride the pattern rules."""
+    assert "position_past_close" in groundskeeper_text
+    assert "settle_failed" in groundskeeper_text
+    assert "determined_no_result" in groundskeeper_text
+    assert "awaiting_determination" in groundskeeper_text

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -58,7 +58,8 @@ def _config(db_path: Path) -> MagicMock:
 def _read_errors(db_path: Path) -> list[dict]:
     async def _q(db):
         cursor = await db.conn.execute(
-            "SELECT error_code, category, component, message, context"
+            "SELECT severity, error_code, category, component,"
+            " message, context"
             " FROM error_log"
         )
         return [dict(r) for r in await cursor.fetchall()]
@@ -545,3 +546,237 @@ class TestKnownMarketsSettle:
             ))
         broker.settle.assert_not_awaited()
         broker.mark_to_market.assert_awaited_once()
+
+
+class TestPastClosePositions:
+    """#783: open positions past market close without settlement get a
+    console note + change-detected WARNING row. Reason separates
+    'Kalshi is slow' (awaiting_determination) from actionable states."""
+
+    @staticmethod
+    def _market(status, *, close_minutes_ago=None, result=""):
+        from datetime import UTC, datetime, timedelta
+
+        m = MagicMock()
+        m.status = status
+        m.result = result
+        m.midpoint = 0.5
+        m.last_price = 0.5
+        m.close_time = (
+            datetime.now(UTC) - timedelta(minutes=close_minutes_ago)
+            if close_minutes_ago is not None else None
+        )
+        return m
+
+    def _pos(self):
+        return Position(
+            ticker=TICKER, side="no", count=100, avg_price=0.5,
+            market_price=0.5, cost_basis=50.0, unrealized_pnl=0.0,
+        )
+
+    def _run_mark(self, db_path, market, *, threshold=30,
+                  settle_effect=None):
+        broker = AsyncMock()
+        broker.get_positions = AsyncMock(
+            side_effect=[[self._pos()], []],
+        )
+        if settle_effect is not None:
+            broker.settle = AsyncMock(side_effect=settle_effect)
+
+        async def _go():
+            db = Database(db_path)
+            await db.connect()
+            try:
+                with patch(
+                    "gimmes.kalshi.markets.get_market",
+                    AsyncMock(return_value=market),
+                ):
+                    await _mark_positions_to_market(
+                        broker, AsyncMock(), db=db,
+                        past_close_minutes=threshold,
+                    )
+            finally:
+                await db.close()
+
+        asyncio.run(_go())
+        return broker
+
+    def _rows(self, db_path):
+        return [
+            e for e in _read_errors(db_path)
+            if e["error_code"] == "position_past_close"
+        ]
+
+    def test_past_close_flags_console_and_row(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=120),
+        )
+        rows = self._rows(db_path)
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "warning"
+        ctx = json.loads(rows[0]["context"])
+        assert ctx[TICKER]["reason"] == "awaiting_determination"
+        # Canonical serialization pin (dedup depends on it)
+        assert rows[0]["context"] == json.dumps(ctx, sort_keys=True)
+
+    def test_threshold_boundary(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=29),
+        )
+        assert self._rows(db_path) == []
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=31),
+        )
+        assert len(self._rows(db_path)) == 1
+
+    def test_change_detected_across_two_runs(self, tmp_path) -> None:
+        from datetime import timedelta
+
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        market = self._market(
+            MarketStatus.CLOSED, close_minutes_ago=50,
+        )
+        self._run_mark(db_path, market)
+        # Mutant pin: minutes_past must be EXCLUDED from the dedup
+        # payload — advance the clock within the same bucket and
+        # assert no re-log.
+        market.close_time -= timedelta(minutes=5)
+        self._run_mark(db_path, market)
+        assert len(self._rows(db_path)) == 1
+
+    def test_state_change_relogs(self, tmp_path) -> None:
+        """Mutant pin: change-detection must RE-log on a changed
+        state, not suppress whenever any prior row exists."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=50),
+        )
+        self._run_mark(
+            db_path,
+            self._market(
+                MarketStatus.DETERMINED, close_minutes_ago=50,
+                result="",
+            ),
+        )
+        assert len(self._rows(db_path)) == 2
+
+    def test_stuck_position_relogs_at_bucket_doubling(
+        self, tmp_path,
+    ) -> None:
+        """#783 review: a position stuck for hours re-logs when the
+        minutes-past bucket doubles (1x -> 2x threshold), so the
+        Groundskeeper 3+/24h pattern rule is reachable."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=40),
+        )
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=70),
+        )
+        assert len(self._rows(db_path)) == 2
+
+    def test_zero_threshold_suppresses_settle_failed_too(
+        self, tmp_path,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(
+                MarketStatus.DETERMINED, close_minutes_ago=5,
+                result="yes",
+            ),
+            threshold=0,
+            settle_effect=RuntimeError("locked"),
+        )
+        assert self._rows(db_path) == []
+
+    def test_settled_market_never_flags(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        broker = self._run_mark(
+            db_path,
+            self._market(
+                MarketStatus.DETERMINED, close_minutes_ago=120,
+                result="yes",
+            ),
+        )
+        broker.settle.assert_awaited_once()
+        assert self._rows(db_path) == []
+
+    def test_settle_failure_flags_actionable(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(
+                MarketStatus.DETERMINED, close_minutes_ago=5,
+                result="yes",
+            ),
+            settle_effect=RuntimeError("locked"),
+        )
+        rows = self._rows(db_path)
+        assert len(rows) == 1
+        ctx = json.loads(rows[0]["context"])
+        assert ctx[TICKER]["reason"] == "settle_failed"
+
+    def test_close_time_none_skipped(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path, self._market(MarketStatus.ACTIVE),
+        )
+        assert self._rows(db_path) == []
+
+    def test_naive_close_time_coerced(self, tmp_path) -> None:
+        from datetime import datetime, timedelta
+
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        market = self._market(MarketStatus.CLOSED)
+        # UTC-derived naive (review-found: local-naive is tz-dependent)
+        from datetime import UTC
+
+        market.close_time = (
+            datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2)
+        )
+        self._run_mark(db_path, market)
+        assert len(self._rows(db_path)) == 1
+
+    def test_zero_threshold_disables(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=999),
+            threshold=0,
+        )
+        assert self._rows(db_path) == []
+
+    def test_determined_without_result_reason(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(
+                MarketStatus.DETERMINED, close_minutes_ago=120,
+                result="",
+            ),
+        )
+        rows = self._rows(db_path)
+        assert len(rows) == 1
+        ctx = json.loads(rows[0]["context"])
+        assert ctx[TICKER]["reason"] == "determined_no_result"

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -780,3 +780,48 @@ class TestPastClosePositions:
         assert len(rows) == 1
         ctx = json.loads(rows[0]["context"])
         assert ctx[TICKER]["reason"] == "determined_no_result"
+
+    def test_resolved_row_rearms(self, tmp_path) -> None:
+        """Copilot review: resolving the last row while the condition
+        persists must re-arm the alert, not suppress it."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        market = self._market(MarketStatus.CLOSED, close_minutes_ago=50)
+        self._run_mark(db_path, market)
+        assert len(self._rows(db_path)) == 1
+
+        async def _resolve(db):
+            await db.conn.execute(
+                "UPDATE error_log SET resolved = 1"
+                " WHERE error_code = 'position_past_close'"
+            )
+            await db.conn.commit()
+
+        _db_run(db_path, _resolve)
+        self._run_mark(db_path, market)
+        assert len(self._rows(db_path)) == 2
+
+    def test_component_passthrough(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, lambda db: asyncio.sleep(0))
+        self._run_mark(
+            db_path,
+            self._market(MarketStatus.CLOSED, close_minutes_ago=50),
+        )
+        assert self._rows(db_path)[0]["component"] == "cli.mark"
+
+        from gimmes.cli import _note_past_close_positions
+
+        async def _direct(db):
+            await _note_past_close_positions(
+                db,
+                {"KXOTHER-26AUG-T1": {
+                    "reason": "awaiting_determination",
+                    "status": "closed", "bucket": 1,
+                }},
+                component="cli.positions",
+            )
+
+        _db_run(db_path, _direct)
+        rows = self._rows(db_path)
+        assert rows[-1]["component"] == "cli.positions"


### PR DESCRIPTION
## Summary

The #781 class — an open position whose market is past `close_time` but not yet settled — had no detector: the existing staleness check compares trade/position timestamps and structurally cannot see "past close, not yet settled" (the settlement trade row doesn't exist yet, which is exactly the condition worth surfacing).

- **New `risk.position_past_close_minutes` knob** (default 30, `0` disables): hourly BTC's ~1-minute confirmation stays permanently quiet; the 2026-08-14 INX 2-hour lag would have flagged at +30.
- **Both sweeps collect** (the marking sweep that risk-check/order/validate ride, and the `positions` command's own loop) with a `reason` separating "Kalshi is slow" (`awaiting_determination`) from actionable states (`settle_failed`, `determined_no_result`, `active_past_close`). Settle failures record through one shared helper — review found the two commands' divergent shapes would have thrashed the change-detection dedup against each other every alternating run.
- **Console note every run; durable WARNING row only on state change** (#767 pattern) — with a **doubling bucket** in the dedup payload. Review found the single-shot design was invisible in practice: one row per state change never reaches Groundskeeper's 3+/24h pattern rule and rots silently in the unresolved list. A stuck position now re-logs at ~1x/2x/4x/8x threshold (30/60/120/240 min at default), reaching pattern escalation within hours; the growing bucket also re-arms the alert if someone resolves the row while the condition persists. groundskeeper.md names `settle_failed`/`determined_no_result` immediate-escalation class (a published result that isn't realizing is a broken sweep, not lag), drift-pinned.
- **Type-strict and self-guarding**: MagicMock configs/test-double close_times skip cleanly, naive datetimes coerce to UTC, threshold 0 suppresses everything including settle_failed rows (both commands, symmetric), and a failed alert can never break the marking sweep.

Closes #783

## Test plan

- 13 tests in `TestPastClosePositions`: flag + canonical-payload pin, strict threshold boundary, change-detection with an in-bucket clock advance (pins minutes-past exclusion), state-change re-log (pins the detection isn't suppress-forever), bucket-doubling re-log, settle-failure reason (below threshold — isolates the path), determined-no-result reason, settled-never-flags, close_time-None skip, UTC-derived naive coercion (review-found: the original was timezone-dependent), zero-threshold disables (including settle_failed).
- Groundskeeper prompt pin. Config wizard suite green with the new knob.
- Frozen full unit suite: **2470 passed**. Lint clean.

Note: pr-review-toolkit not installed; equivalent three-role review + simplifier ran via general-purpose agents, findings ≥80 fixed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r