### PR TITLE
Reject percent-form probabilities at parse time (#645)

### DIFF
--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -306,6 +306,8 @@ For all other skips (PASS on research grounds, NEEDS MORE RESEARCH after re-scor
 
 If a `log-trade` skip command fails, note the failure in your output and continue. Do not retry failed log commands.
 
+**Probability format (#645):** `--prob` on log-candidate is a decimal fraction (`0.85` = 85%) — percent-form values like `--prob 85` are rejected by the CLI. `--price` is likewise a decimal dollar price (`0.41`, not `41`), though only `--prob` is CLI-enforced.
+
 **Ticker discipline (#778/#782):** copy tickers EXACTLY as printed in your assignment/scan/candidates output — strike decimals included (`-T63399.99`, never `-T63399`). If `market-info` prints "The event ... EXISTS" with a market list, take exactly ONE printed suggestion matching your assigned strike and retry ONCE; if that retry fails or no suggestion matches your assignment, fall through to the failure rule below. NEVER manufacture date-format or strike-format variants — eight guessed variants in cycle 2232 produced eight error escalations and filed #778. NEVER run `market-info` on tickers outside your assignment/shortlist, and NEVER probe a settled ladder to triangulate spot or realized price — cycle 2259 invented $25-increment midpoint strikes against the settled 9 AM ladder to bisect BTC's close, producing three fabricated-ticker 404s (#782). If `market-info` says the event "is ALREADY SETTLED", you are researching the wrong hour: return to your current shortlist.
 
 If `market-info` fails for a candidate, log the candidate with `--price 0 --prob 0` and log the skip with the failure in the rationale.

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -15,6 +15,8 @@ You are the Closer — the execution agent in the GIMMES trading pipeline. You t
 
 ## Your Mission
 
+**Probability format (#645):** `--prob` is a decimal fraction in [0, 1] — 85% is `--prob 0.85`, NEVER `--prob 85`. Percent-form values are rejected by the CLI; the #645 incident passed the percent form and Kelly silently sized 0 contracts.
+
 For each approved candidate (GimmeScore >= configured `strategy.gimme_threshold`, Caddie recommends PROCEED), execute this EXACT sequence. NEVER skip or reorder steps:
 
 0. **Staleness gate (#661)**: run `gimmes candidates --ticker TICKER --limit 3` — if the output shows `STALE-CLOSE`, the research predates the ticker's most recent close and MUST NOT be executed; reject (go to step 5, `--reason review_reject`) and note stale-post-close research.

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -194,7 +194,7 @@ def _read_prose_file(path: Path, option_name: str) -> str:
 
 
 _PROB_RANGE_MSG = (
-    "--prob must be a decimal fraction between 0 and 1,"
+    "--prob must be a decimal fraction in [0, 1] (endpoints allowed),"
     " e.g. 0.85, not 85 (#645)"
 )
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -193,6 +193,24 @@ def _read_prose_file(path: Path, option_name: str) -> str:
     return content
 
 
+_PROB_RANGE_MSG = (
+    "--prob must be a decimal fraction between 0 and 1,"
+    " e.g. 0.85, not 85 (#645)"
+)
+
+
+def _prob_option_callback(value: float | None) -> float | None:
+    """#645: reject percent-form probabilities at parse time — the
+    Closer once passed --prob 85 and Kelly silently sized 0 contracts.
+    The chained-comparison form is load-bearing: it rejects NaN/inf,
+    which `value > 1 or value < 0` would let through."""
+    if value is None:
+        return value
+    if not (0.0 <= value <= 1.0):
+        raise typer.BadParameter(_PROB_RANGE_MSG)
+    return value
+
+
 def _resolve_prose_arg(
     inline: str,
     file_path: Path | None,
@@ -882,6 +900,7 @@ def size(
     ticker: str = typer.Argument(..., help="Market ticker"),
     probability: float = typer.Option(
         ..., "--prob", "-p", help="True probability for configured side",
+        callback=_prob_option_callback,
     ),
 ) -> None:
     """Calculate position size for a market."""
@@ -961,7 +980,10 @@ def size(
 @app.command(rich_help_panel="Trading")
 def validate(
     ticker: str = typer.Argument(..., help="Market ticker"),
-    probability: float = typer.Option(..., "--prob", "-p", help="Estimated true probability"),
+    probability: float = typer.Option(
+        ..., "--prob", "-p", help="Estimated true probability",
+        callback=_prob_option_callback,
+    ),
     dollars: float = typer.Option(0, "--dollars", "-d", help="Trade size in dollars (0=auto-size)"),
     size_up: bool = typer.Option(False, "--size-up", help="Allow adding to existing position"),
 ) -> None:
@@ -1101,6 +1123,7 @@ def order(
     probability: float | None = typer.Option(
         None, "--prob", "-p",
         help="True probability for configured side (buy only: sizing/edge)",
+        callback=_prob_option_callback,
     ),
     yes: bool = typer.Option(
         False, "--yes", "-y", help="Skip confirmation (for autonomous mode)",
@@ -4056,7 +4079,9 @@ def log_trade(
     side: str = typer.Option("", "--side", "-s"),
     count: int = typer.Option(0, "--count", "-c"),
     price_val: float = typer.Option(0, "--price"),
-    prob: float | None = typer.Option(None, "--prob", "-p"),
+    prob: float | None = typer.Option(
+        None, "--prob", "-p", callback=_prob_option_callback,
+    ),
     score_val: float = typer.Option(0, "--score"),
     rationale: str = typer.Option("", "--rationale", "-r"),
     rationale_file: Path | None = typer.Option(
@@ -4326,7 +4351,10 @@ def log_candidate(
     ticker: str = typer.Argument(..., help="Market ticker"),
     title: str = typer.Option("", "--title", "-t", help="Event title"),
     price_val: float = typer.Option(0, "--price", help="Market price"),
-    prob: float = typer.Option(0, "--prob", "-p", help="Model probability estimate"),
+    prob: float = typer.Option(
+        0, "--prob", "-p", help="Model probability estimate",
+        callback=_prob_option_callback,
+    ),
     score_val: float = typer.Option(0, "--score", help="GimmeScore (0-100)"),
     memo: str = typer.Option("", "--memo", "-m", help="Research memo summary"),
     memo_file: Path | None = typer.Option(

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3259,3 +3259,14 @@ def test_groundskeeper_past_close_escalation(groundskeeper_text: str) -> None:
     assert "settle_failed" in groundskeeper_text
     assert "determined_no_result" in groundskeeper_text
     assert "awaiting_determination" in groundskeeper_text
+
+
+def test_closer_prob_decimal_format_rule() -> None:
+    closer_text = _CLOSER.read_text()
+    assert "Probability format (#645)" in closer_text
+    assert "NEVER `--prob 85`" in closer_text
+
+
+def test_caddie_log_candidate_prob_decimal_rule(caddie_text: str) -> None:
+    assert "Probability format (#645)" in caddie_text
+    assert "percent-form values like `--prob 85` are rejected" in caddie_text

--- a/tests/unit/test_prob_guard.py
+++ b/tests/unit/test_prob_guard.py
@@ -1,0 +1,68 @@
+"""#645: percent-form probabilities are rejected at parse time — the
+Closer once passed --prob 85 and Kelly silently sized 0 contracts."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from gimmes.cli import _PROB_RANGE_MSG, _prob_option_callback, app
+
+runner = CliRunner()
+
+
+def _flatten(output: str) -> str:
+    """Rich draws the error in a box — strip borders AND rejoin the
+    wrapped lines before asserting the full message."""
+    return " ".join(
+        output.replace("│", " ").replace("╭", " ")
+        .replace("╰", " ").replace("─", " ").replace("╮", " ")
+        .replace("╯", " ").split()
+    )
+
+
+class TestProbCallback:
+    @pytest.mark.parametrize("value", [None, 0.0, 0.85, 1.0])
+    def test_valid_values_pass_through(self, value) -> None:
+        assert _prob_option_callback(value) == value
+
+    @pytest.mark.parametrize(
+        "value", [85.0, 1.01, -0.1, float("nan"), float("inf")],
+    )
+    def test_invalid_values_reject(self, value) -> None:
+        with pytest.raises(typer.BadParameter) as exc:
+            _prob_option_callback(value)
+        assert _PROB_RANGE_MSG in str(exc.value)
+
+
+class TestProbCliRejection:
+    """Parse-time rejection: no config/mocks needed — the command body
+    never runs. Rich wraps output, so assertions whitespace-normalize."""
+
+    def test_order_rejects_percent_form(self) -> None:
+        result = runner.invoke(
+            app, ["order", "KXTEST-26AUG-T1", "--prob", "85", "--yes"],
+        )
+        assert result.exit_code != 0
+        assert _PROB_RANGE_MSG in _flatten(result.output)
+
+    def test_log_candidate_rejects_percent_form(self) -> None:
+        result = runner.invoke(
+            app, ["log-candidate", "KXTEST-26AUG-T1", "--prob", "85"],
+        )
+        assert result.exit_code != 0
+        assert _PROB_RANGE_MSG in _flatten(result.output)
+
+    @pytest.mark.parametrize("argv", [
+        ["size", "KXTEST-26AUG-T1", "--prob", "85"],
+        ["validate", "KXTEST-26AUG-T1", "--prob", "85"],
+        ["log-trade", "KXTEST-26AUG-T1", "--action", "skip",
+         "--prob", "85"],
+    ])
+    def test_other_commands_reject_percent_form(self, argv) -> None:
+        """Wiring pin per command — removing the callback from any
+        single option must fail a test (review-found survivors)."""
+        result = runner.invoke(app, argv)
+        assert result.exit_code != 0
+        assert _PROB_RANGE_MSG in _flatten(result.output)


### PR DESCRIPTION
## Summary

The #645 incident: the Closer passed `--prob 85` (percent form) instead of `0.85`; Kelly's range guard silently returned 0 contracts — no error anywhere, and the trade would have been permanently missed without a manual audit.

**Fix:** a shared typer callback on **all five** `--prob` options (`size`, `validate`, `order`, `log-trade`, `log-candidate`) rejects values outside [0, 1] at parse time with an actionable message (`--prob must be a decimal fraction between 0 and 1, e.g. 0.85, not 85 (#645)`) — before any config or DB access, exiting 2 (non-zero, so the Closer's failure protocol fires). The chained-comparison form is load-bearing: it rejects NaN and inf, which the naive two-comparison form would pass. `None` passthrough (order/log-trade defaults) and the `--prob 0` bookkeeping default (log-candidate, #657) are preserved.

**Prompts:** closer.md and caddie.md state the decimal-fraction rule with the 0.85-never-85 worked example; caddie.md clarifies `--price` on log-candidate is likewise a decimal dollar price though only `--prob` is CLI-enforced (review caught the original wording overclaiming). Both drift-pinned; the #657 `--prob 0` drift-pin regex was verified non-matching against the new text.

Closes #645

## Test plan

- Callback units: 0/0.85/1.0/None pass; 85/1.01/−0.1/NaN/inf reject with the message (the NaN case is the sole killer of the naive-comparison mutant — deliberately parametrized).
- CLI-level parse rejection for **each** of the five commands (review found three wirings had no killing test) — no mocks needed, the command body never runs; assertions strip Rich's error-box borders.
- Prompt pins for both files.
- Frozen full unit suite: **2488 passed**. Lint clean.

Note: pr-review-toolkit not installed; equivalent review roles ran via general-purpose agents, findings addressed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r
