### PR TITLE
log-trade requires a concrete side under dual-side mode (#708)

### DIFF
--- a/.claude/agents/caddie-master.md
+++ b/.claude/agents/caddie-master.md
@@ -326,12 +326,14 @@ Evaluate the output using these rules (where `gimme_threshold` is from Step 0.5,
 
 1. **No prior research** (no records found, or expired per above) → send to Caddie
 2. **Prior score < cooldown_cutoff** (clear PASS) → skip re-research, log the skip via the `--rationale-file` heredoc pattern (#589):
+**`--side SIDE` (#708):** SIDE is the side the decision is about — your `trading_side` when config is `yes`/`no`; under `both`, the side the candidate was scanned/evaluated on (the Side column in scan output, the side your `--prob` is expressed against). The CLI rejects log-trade without a concrete side under both-mode.
+
    ```bash
    RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Cooldown: prior score SCORE (below cutoff), skipping re-research
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason cooldown \
+   gimmes log-trade TICKER --action skip --reason cooldown --side SIDE \
      --rationale-file "$RATIONALE_FILE" --agent caddie-master
    rm -f "$RATIONALE_FILE"
    ```
@@ -342,7 +344,7 @@ Evaluate the output using these rules (where `gimme_threshold` is from Step 0.5,
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Already traded: open position held, prior score SCORE
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason already_traded \
+   gimmes log-trade TICKER --action skip --reason already_traded --side SIDE \
      --rationale-file "$RATIONALE_FILE" --agent caddie-master
    rm -f "$RATIONALE_FILE"
    ```
@@ -363,7 +365,7 @@ Dispatch the **Caddie** agent to research the candidates that passed the cooldow
 gimmes config get strategy.max_candidates_per_cycle
 ```
 
-If more candidates passed cooldown than the cap, keep the top `max_candidates_per_cycle` by Scout quick score and log each candidate over the cap as a skip with `--reason deferred_capacity` (rationale: "over per-cycle candidate cap (#746) — eligible next cycle"). Research and review time are ~2.5 + ~4 minutes PER candidate; an unbounded intake is how cycles die at the timeout with zero Closer dispatches. If the config read fails, use 5.
+If more candidates passed cooldown than the cap, keep the top `max_candidates_per_cycle` by Scout quick score and log each candidate over the cap as a skip with `--reason deferred_capacity --side SIDE` (rationale: "over per-cycle candidate cap (#746) — eligible next cycle"). Research and review time are ~2.5 + ~4 minutes PER candidate; an unbounded intake is how cycles die at the timeout with zero Closer dispatches. If the config read fails, use 5.
 
 **Priority rule:** Process cap-blocked candidates before new candidates when dispatching to Caddie (cap-blocked candidates count toward the per-cycle cap).
 
@@ -382,7 +384,7 @@ RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
 cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
 Caddie failed to research after retry
 GIMMES_EOF
-gimmes log-trade TICKER --action skip --reason research_failed \
+gimmes log-trade TICKER --action skip --reason research_failed --side SIDE \
   --rationale-file "$RATIONALE_FILE" --agent caddie-master
 rm -f "$RATIONALE_FILE"
 ```
@@ -493,7 +495,7 @@ For each PROCEED candidate:
      --body-file "$BODY_FILE"
    rm -f "$BODY_FILE"
    ```
-   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with `--reason infra_failed` and rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate — this is a tooling casualty, not a review verdict, and `infra_failed` keeps it out of the review-reject audits.
+   If the position-note command fails, do not proceed with this candidate. Log a skip using `log-trade` with `--reason infra_failed --side SIDE` and rationale "Decision note failed to write" (via `--rationale-file`) and move to the next candidate — this is a tooling casualty, not a review verdict, and `infra_failed` keeps it out of the review-reject audits.
 
 6. **Log rejected candidates as skips** so the decision is auditable (use the `--rationale-file` heredoc pattern, #589):
    ```bash
@@ -501,7 +503,7 @@ For each PROCEED candidate:
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Caddie Master review: REJECT — [brief reason]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason review_reject \
+   gimmes log-trade TICKER --action skip --reason review_reject --side SIDE \
      --rationale-file "$RATIONALE_FILE" --agent caddie-master
    rm -f "$RATIONALE_FILE"
    ```

--- a/.claude/agents/caddie.md
+++ b/.claude/agents/caddie.md
@@ -283,12 +283,14 @@ If a `log-candidate` command fails, note the failure in your output and continue
 
 Additionally, for each candidate that receives PASS or that remains at NEEDS MORE RESEARCH after re-scoring, MUST log the skip. Use `--rationale-file` for the same reason:
 
+**`--side SIDE` (#708):** SIDE is the side the decision is about — your `trading_side` when config is `yes`/`no`; under `both`, the side the candidate was scanned/evaluated on (the Side column in scan output, the side your `--prob` is expressed against). The CLI rejects log-trade without a concrete side under both-mode.
+
 ```bash
 RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
 cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
 Caddie: [reason]
 GIMMES_EOF
-gimmes log-trade TICKER --action skip \
+gimmes log-trade TICKER --action skip --side SIDE \
   --price 0.XX --prob 0.XX --score NN \
   --rationale-file "$RATIONALE_FILE" --agent caddie
 rm -f "$RATIONALE_FILE"
@@ -297,7 +299,7 @@ rm -f "$RATIONALE_FILE"
 **Liquidity skips MUST carry `--reason liquidity`** (#710). When the skip is because the order book is empty or one-sided — `market-info` shows YES Bid $0.00 / YES Ask $0.00, or the tradeable side has no resting orders — add `--reason liquidity` to the command:
 
 ```bash
-gimmes log-trade TICKER --action skip --reason liquidity \
+gimmes log-trade TICKER --action skip --reason liquidity --side SIDE \
   --price 0.XX --prob 0.XX --score NN \
   --rationale-file "$RATIONALE_FILE" --agent caddie
 ```

--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -15,6 +15,8 @@ You are the Closer — the execution agent in the GIMMES trading pipeline. You t
 
 ## Your Mission
 
+**`--side SIDE` (#708):** SIDE is the side the decision is about — your `trading_side` when config is `yes`/`no`; under `both`, the side the candidate was scanned/evaluated on (the Side column in scan output, the side your `--prob` is expressed against). The CLI rejects log-trade without a concrete side under both-mode.
+
 **Probability format (#645):** `--prob` is a decimal fraction in [0, 1] — 85% is `--prob 0.85`, NEVER `--prob 85`. Percent-form values are rejected by the CLI; the #645 incident passed the percent form and Kelly silently sized 0 contracts.
 
 For each approved candidate (GimmeScore >= configured `strategy.gimme_threshold`, Caddie recommends PROCEED), execute this EXACT sequence. NEVER skip or reorder steps:
@@ -30,7 +32,7 @@ For each approved candidate (GimmeScore >= configured `strategy.gimme_threshold`
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    [which check failed and why]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason validation_failed --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason validation_failed --side SIDE --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
    If the command fails, note the failure in your output and continue. Do not retry.
@@ -78,7 +80,7 @@ When Caddie Master dispatches you for a SIZE UP (adding to an existing position)
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    SIZE UP rejected: [which check failed]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason validation_failed --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason validation_failed --side SIDE --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
 
@@ -94,7 +96,7 @@ When Caddie Master dispatches you to CLOSE a position (sell all held contracts),
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Close skipped: no open position found
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason no_position --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason no_position --side SIDE --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
 2. **Cancel resting orders**: If any resting orders exist for TICKER, cancel them first with `gimmes cancel ORDER_ID --yes`.
@@ -106,7 +108,7 @@ When Caddie Master dispatches you to CLOSE a position (sell all held contracts),
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Close order failed: [error from CLI output]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason close_failed --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason close_failed --side SIDE --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
    If the command fails, note the failure in your output and continue. Do not retry.
@@ -139,7 +141,7 @@ If the order command fails (non-zero exit code or error output), MUST:
    cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
    Order failed: [error from CLI output]
    GIMMES_EOF
-   gimmes log-trade TICKER --action skip --reason order_failed --rationale-file "$RATIONALE_FILE" --agent closer
+   gimmes log-trade TICKER --action skip --reason order_failed --side SIDE --rationale-file "$RATIONALE_FILE" --agent closer
    rm -f "$RATIONALE_FILE"
    ```
 2. If the log-trade command itself fails, note the failure in your output and continue. Do not retry failed log commands.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -52,12 +52,14 @@ The CLI already applies the hourly gates (no action needed from you): hourly tic
 
 **MUST log every skipped candidate** — every candidate evaluated but not shortlisted MUST get a skip log entry. Zero exceptions. Candidates with a quick score below the configured `gimme_threshold` (from step 0) MUST be logged as skips. Use the `--rationale-file` heredoc pattern so prose containing dollar amounts or `$VAR` references stays intact (#589):
 
+**`--side SIDE` (#708):** SIDE is the side the decision is about — your `trading_side` when config is `yes`/`no`; under `both`, the side the candidate was scanned/evaluated on (the Side column in scan output, the side your `--prob` is expressed against). The CLI rejects log-trade without a concrete side under both-mode.
+
 ```bash
 RATIONALE_FILE=$(mktemp -t gimmes-rationale.XXXXXX)
 cat > "$RATIONALE_FILE" <<'GIMMES_EOF'
 reason for skipping
 GIMMES_EOF
-gimmes log-trade TICKER --action skip \
+gimmes log-trade TICKER --action skip --side SIDE \
   --price 0.XX --prob 0.XX --score NN \
   --rationale-file "$RATIONALE_FILE" --agent scout
 rm -f "$RATIONALE_FILE"
@@ -66,7 +68,7 @@ rm -f "$RATIONALE_FILE"
 **Liquidity skips MUST carry `--reason liquidity`** (#710). When the skip is because the order book is empty or one-sided — Best YES Bid = None, no resting offers, zero depth on the tradeable side — add `--reason liquidity` to the command:
 
 ```bash
-gimmes log-trade TICKER --action skip --reason liquidity \
+gimmes log-trade TICKER --action skip --reason liquidity --side SIDE \
   --price 0.XX --prob 0.XX --score NN \
   --rationale-file "$RATIONALE_FILE" --agent scout
 ```

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4115,6 +4115,19 @@ def log_trade(
     rationale_val = _resolve_prose_arg(
         rationale, rationale_file, "--rationale", "--rationale-file",
     )
+    # #708: under strategy.side='both', an omitted --side used to feed
+    # "both" into TradeDecision's yes/no Literal — an unhandled
+    # pydantic traceback that silently starved the skip table in
+    # dual-side mode. Gate BEFORE the DB opens (same precedent as the
+    # order path's #678 gate); also rejects garbage explicit values.
+    resolved_side = side if side else config.strategy.side
+    if resolved_side not in ("yes", "no"):
+        raise typer.BadParameter(
+            f"log-trade needs a concrete side: got {resolved_side!r}"
+            f" (config strategy.side is {config.strategy.side!r}) —"
+            f" pass --side yes or --side no (#708)",
+            param_hint="--side",
+        )
 
     async def _log() -> None:
         import logging
@@ -4129,7 +4142,6 @@ def log_trade(
         )
         from gimmes.strategy.scanner import tradeable_edge
 
-        resolved_side = side if side else config.strategy.side
         trade = TradeDecision(
             ticker=ticker,
             action=TradeDecision.Action(action),

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3270,3 +3270,22 @@ def test_closer_prob_decimal_format_rule() -> None:
 def test_caddie_log_candidate_prob_decimal_rule(caddie_text: str) -> None:
     assert "Probability format (#645)" in caddie_text
     assert "percent-form values like `--prob 85` are rejected" in caddie_text
+
+
+@pytest.mark.parametrize("agent_file", [
+    "caddie.md", "scout.md", "caddie-master.md", "closer.md",
+])
+def test_log_trade_templates_carry_side(agent_file: str) -> None:
+    """#708: every log-trade command template passes --side — an
+    omitted side under strategy.side='both' fed 'both' into the
+    yes/no Literal and silently starved the skip table."""
+    text = (AGENTS_DIR / agent_file).read_text()
+    joined = text.replace("\\\n", " ")
+    for line in joined.splitlines():
+        if "gimmes log-trade" not in line or "`gimmes log-trade`" in line:
+            continue
+        if "Batched skip-logging" in line:
+            continue  # prose describing the batching rule, not a template
+        assert "--side" in line, (agent_file, line.strip())
+    # The shared SIDE-definition sentence is pinned per file
+    assert "`--side SIDE` (#708):" in text

--- a/tests/unit/test_cli_skip_analytics.py
+++ b/tests/unit/test_cli_skip_analytics.py
@@ -620,3 +620,71 @@ def test_lookup_error_degrades_with_own_cause_logged(
     s = _skip_row(db_path)
     assert s["model_probability"] == 0.0
     assert s["price"] == 0.0
+
+
+class TestDualSideGate:
+    """#708: log-trade under strategy.side='both' needs a concrete
+    --side — 'both' used to feed the yes/no Literal and crash with a
+    pydantic traceback, silently starving the skip table."""
+
+    def test_both_mode_no_side_rejects_cleanly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _bare_db(db_path)
+        _patch_config(monkeypatch, db_path, side="both")
+        result = runner.invoke(app, [
+            "log-trade", TICKER, "--action", "skip",
+            "--reason", "cooldown",
+        ])
+        assert result.exit_code != 0
+        out = " ".join(result.output.split())
+        assert "#708" in out
+        assert "ValidationError" not in result.output
+        assert "Traceback" not in result.output
+        assert _trade_rows(db_path) == []
+
+    @pytest.mark.parametrize("chosen", ["yes", "no"])
+    def test_both_mode_explicit_side_lands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        chosen: str,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _bare_db(db_path)
+        _patch_config(monkeypatch, db_path, side="both")
+        result = runner.invoke(app, [
+            "log-trade", TICKER, "--action", "skip",
+            "--reason", "cooldown", "--side", chosen,
+        ])
+        assert result.exit_code == 0, result.output
+        rows = _trade_rows(db_path)
+        assert len(rows) == 1
+        assert rows[0]["side"] == chosen
+
+    def test_explicit_side_both_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _bare_db(db_path)
+        _patch_config(monkeypatch, db_path, side="no")
+        result = runner.invoke(app, [
+            "log-trade", TICKER, "--action", "skip",
+            "--reason", "cooldown", "--side", "both",
+        ])
+        assert result.exit_code != 0
+        assert "#708" in " ".join(result.output.split())
+
+    @pytest.mark.parametrize("action", ["open", "close"])
+    def test_both_mode_other_actions_gated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        action: str,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _bare_db(db_path)
+        _patch_config(monkeypatch, db_path, side="both")
+        result = runner.invoke(app, [
+            "log-trade", TICKER, "--action", action,
+            "--count", "10", "--price", "0.5",
+        ])
+        assert result.exit_code != 0
+        assert "#708" in " ".join(result.output.split())


### PR DESCRIPTION
## Summary

Under `strategy.side='both'` with no `--side` — the shape every agent skip template produced — `"both"` fed `TradeDecision`'s yes/no Literal and every skip write died on a pydantic error. In dual-side mode the skip table silently starved: skip analytics, `gimmes lesson`, the missed-opportunity audit, and the funnel counters all lost their input.

- **CLI gate:** `log-trade` rejects a non-concrete side with an actionable `BadParameter` (`pass --side yes or --side no (#708)`) before any DB access — the #678 order-path precedent — also catching garbage explicit values (`--side both`). Derive-from-candidate was investigated and is dead: the candidates table carries no side column.
- **Templates:** all 12 `log-trade` command templates across caddie/scout/caddie-master/closer gain `--side SIDE`, the prose-only skip instructions (`deferred_capacity`, `infra_failed`) too, plus a shared SIDE-definition sentence per file (under `both`, the side the candidate was scanned/evaluated on — the Side column in scan output). A parametrized drift pin joins backslash-continued lines and asserts `--side` on every template in all four files.
- **Review-verified:** the closure capture of the hoisted `resolved_side` is sound (all four inner reads); the #657 contiguous skip-reason pins survive; the #768 terminal-marker interplay is *not* a new gap — the pre-fix path also wrote neither row nor marker, this just makes the failure actionable.

Closes #708

## Test plan

- 6 CLI tests: both-mode no-side rejects cleanly (no traceback, no row), both-mode explicit yes/no lands with the right side, `--side both` rejected, open/close actions gated identically.
- Mutation-verified in review: gate removal fails 4 tests; stripping `--side` from either a single-line or backslash-continued template fails the parametrized pin.
- Frozen full unit suite: **2498 passed**. Lint clean.

Note: pr-review-toolkit not installed; equivalent review roles ran via general-purpose agents, findings addressed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r
