### PR TITLE
log-outcome settlement guard + split-brain repair (#760)

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -304,6 +304,8 @@ gimmes log-outcome TICKER --outcome yes   # or --outcome no
 
 `gimmes log-outcome` records the resolution but does NOT settle or remove the position — do not report a position as settled until the settlement sweep's close row exists (#781: a "settled this cycle" claim based on log-outcome alone triggered a false stale-position escalation).
 
+**"Settled" is a FIELD TEST, never an inference (#760):** a market is settled ONLY when `market-info` shows Status `determined`/`finalized` OR a non-empty Result row. NEVER conclude settlement from a data release, month arithmetic, or the thesis being confirmed — #760 stamped a JUNE PCE print onto the JULY market while it was still active, corrupting 138 rows. If `log-outcome` refuses with `outcome_market_not_settled`, the refusal is correct and final — report it, do not retry, and do not use `--override` (that flag is only for delisted/unfetchable markets and requires a reason).
+
 NEVER skip this step — missing outcome data degrades all Pro analyses. If the log-outcome command fails, note the failure prominently in your output so the outcome can be recorded on the next cycle. Do not retry.
 
 ## Activity Logging (REQUIRED — you are not done until this runs)

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4096,6 +4096,11 @@ def market_info(
                 ("Event", market.event_ticker),
                 ("Subtitle", verbatim(market.subtitle)),
                 ("Status", market.status.value),
+                # #760: the settlement FIELD TEST — agents verify
+                # Status/Result, never infer settlement from
+                # news/releases. (Settlement value is not mapped by
+                # parse_market, so no row for it.)
+                ("Result", verbatim(market.result)),
                 ("YES Bid", f"${market.yes_bid:.2f}"),
                 ("YES Ask", f"${market.yes_ask:.2f}"),
                 ("Last Price", f"${market.last_price:.2f}"),
@@ -4780,6 +4785,14 @@ def backfill_settlements(
 def log_outcome(
     ticker: str = typer.Argument(..., help="Market ticker"),
     outcome: str = typer.Option(..., "--outcome", "-o", help="Resolution outcome (yes/no)"),
+    override: str = typer.Option(
+        "", "--override",
+        help=(
+            "Record despite a market-fetch FAILURE (delisted or"
+            " unfetchable). Requires a reason; logged as WARNING."
+            " Never bypasses a live not-settled answer (#760)."
+        ),
+    ),
 ) -> None:
     """Record a market's resolution outcome for trades on that ticker."""
     if outcome not in ("yes", "no"):
@@ -4789,9 +4802,102 @@ def log_outcome(
     config = load_config()
 
     async def _log() -> None:
-        from gimmes.store.database import Database
-        from gimmes.store.queries import update_trade_outcome
+        import json as _json
 
+        import httpx
+
+        from gimmes.kalshi.client import KalshiClient
+        from gimmes.models.error import (
+            ErrorCategory,
+            ErrorLogEntry,
+            ErrorSeverity,
+        )
+        from gimmes.models.market import SETTLED_STATUSES
+        from gimmes.store.database import Database
+        from gimmes.store.queries import (
+            _cycle_from_env,
+            update_trade_outcome,
+        )
+
+        # #760: log-outcome was the last unguarded write path — the
+        # Monitor stamped a JUNE data release onto a JULY market that
+        # was still ACTIVE (close a month out), corrupting 138 rows.
+        # Settlement is a FIELD TEST, never an inference: permit only
+        # when the live market is determined/finalized or carries a
+        # published result.
+        market = None
+        fetch_error: str | None = None
+        try:
+            from gimmes.kalshi.markets import get_market
+
+            async with KalshiClient(config) as client:
+                market = await get_market(client, ticker)
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            fetch_error = str(exc)
+
+        if market is not None:
+            settled = (
+                market.status in SETTLED_STATUSES
+                or bool(market.result)
+            )
+            if not settled:
+                async with Database(config.db_path) as db:
+                    await _log_cli_error(db, ErrorLogEntry(
+                        severity=ErrorSeverity.ERROR,
+                        category=ErrorCategory.DATA_INTEGRITY,
+                        error_code="outcome_market_not_settled",
+                        component="cli.log-outcome",
+                        cycle=_cycle_from_env(),
+                        message=(
+                            f"Refused log-outcome for {ticker}:"
+                            f" market status {market.status}, no"
+                            f" published result (#760)"
+                        ),
+                        context=_json.dumps({
+                            "ticker": ticker,
+                            "outcome": outcome,
+                            "status": str(market.status),
+                            "result": market.result,
+                            "close_time": str(market.close_time),
+                        }),
+                    ))
+                console.print(
+                    f"[red]Refused (#760): {rich_escape(ticker)} is"
+                    f" NOT settled per the live API — status"
+                    f" {market.status}, closes"
+                    f" {market.close_time}. Do not infer settlement"
+                    f" from data-release dates. This refusal is"
+                    f" final — do not retry or override.[/red]"
+                )
+                raise typer.Exit(1)
+        else:
+            if not override:
+                console.print(
+                    f"[red]Market fetch failed for"
+                    f" {rich_escape(ticker)}:"
+                    f" {rich_escape(fetch_error or 'unknown')}."
+                    f" For a delisted/unfetchable market, re-run"
+                    f" with --override \"<reason>\" (#760).[/red]"
+                )
+                raise typer.Exit(1)
+            async with Database(config.db_path) as db:
+                await _log_cli_error(db, ErrorLogEntry(
+                    severity=ErrorSeverity.WARNING,
+                    category=ErrorCategory.DATA_INTEGRITY,
+                    error_code="outcome_override_used",
+                    component="cli.log-outcome",
+                    cycle=_cycle_from_env(),
+                    message=(
+                        f"log-outcome override for {ticker}:"
+                        f" {override} (#760)"
+                    ),
+                    context=_json.dumps({
+                        "ticker": ticker,
+                        "outcome": outcome,
+                        "reason": override,
+                        "fetch_error": fetch_error,
+                    }),
+                ))
         async with Database(config.db_path) as db:
             updated = await update_trade_outcome(db, ticker, outcome)
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4870,6 +4870,41 @@ def log_outcome(
                     f" final — do not retry or override.[/red]"
                 )
                 raise typer.Exit(1)
+
+            # A published yes/no result outranks the caller: with
+            # overwrite semantics a wrong --outcome would clobber a
+            # correct row, so a disagreement is refused outright.
+            published = (market.result or "").strip().lower()
+            if published in ("yes", "no") and published != outcome:
+                async with Database(config.db_path) as db:
+                    await _log_cli_error(db, ErrorLogEntry(
+                        severity=ErrorSeverity.ERROR,
+                        category=ErrorCategory.DATA_INTEGRITY,
+                        error_code="outcome_conflicts_with_result",
+                        component="cli.log-outcome",
+                        cycle=_cycle_from_env(),
+                        message=(
+                            f"Refused log-outcome for {ticker}:"
+                            f" requested '{outcome}' but the live"
+                            f" API published result"
+                            f" '{published}' (#760)"
+                        ),
+                        context=_json.dumps({
+                            "ticker": ticker,
+                            "outcome": outcome,
+                            "result": market.result,
+                            "status": str(market.status),
+                        }),
+                    ))
+                console.print(
+                    f"[red]Refused (#760): the live API publishes"
+                    f" result '{rich_escape(published)}' for"
+                    f" {rich_escape(ticker)}, which contradicts"
+                    f" --outcome {rich_escape(outcome)}. The"
+                    f" published result wins; this refusal is"
+                    f" final.[/red]"
+                )
+                raise typer.Exit(1)
         else:
             if not override:
                 console.print(

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4871,11 +4871,12 @@ def log_outcome(
                 )
                 raise typer.Exit(1)
 
-            # A published yes/no result outranks the caller: with
-            # overwrite semantics a wrong --outcome would clobber a
-            # correct row, so a disagreement is refused outright.
+            # A published result outranks the caller: with overwrite
+            # semantics a wrong --outcome would clobber a correct
+            # row. Any disagreement is refused — including non-yes/no
+            # results like "void", which no --outcome can represent.
             published = (market.result or "").strip().lower()
-            if published in ("yes", "no") and published != outcome:
+            if published and published != outcome:
                 async with Database(config.db_path) as db:
                     await _log_cli_error(db, ErrorLogEntry(
                         severity=ErrorSeverity.ERROR,

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -394,14 +394,20 @@ async def run_migrations(db: Database) -> int:
     # genuinely settles keeps the authoritative outcome; fresh/other
     # DBs no-op.
     if current < 20:
-        await db.conn.execute(
-            "UPDATE trades SET resolved_outcome = NULL"
+        # The v16 presence-check precedent: fixture/legacy DBs whose
+        # trades table predates the resolved_outcome column must
+        # no-op (they cannot contain the corruption).
+        cursor = await db.conn.execute("PRAGMA table_info(trades)")
+        trade_cols = {row[1] for row in await cursor.fetchall()}
+        if "resolved_outcome" in trade_cols:
+            await db.conn.execute(
+                "UPDATE trades SET resolved_outcome = NULL"
             " WHERE ticker = 'KXPCECORE-26JUL-T0.3'"
             " AND resolved_outcome = 'no'"
-            " AND NOT EXISTS (SELECT 1 FROM trades s"
-            "   WHERE s.ticker = trades.ticker"
-            "   AND s.agent = 'settlement' AND s.action = 'close')"
-        )
+                " AND NOT EXISTS (SELECT 1 FROM trades s"
+                "   WHERE s.ticker = trades.ticker"
+                "   AND s.agent = 'settlement' AND s.action = 'close')"
+            )
         await db.conn.execute(
             "INSERT INTO schema_version (version) VALUES (?)", (20,)
         )

--- a/src/gimmes/store/migrations.py
+++ b/src/gimmes/store/migrations.py
@@ -7,7 +7,7 @@ from gimmes.store.database import Database
 # The version a fully-migrated DB reports (#680): read-only consumers
 # (the clubhouse) compare against this at startup. Drift-guarded by
 # test_latest_schema_version_constant_matches_migrations.
-LATEST_SCHEMA_VERSION = 19
+LATEST_SCHEMA_VERSION = 20
 
 # Migrations are applied sequentially. Each is a tuple of (version, sql).
 MIGRATIONS: list[tuple[int, str]] = [
@@ -385,5 +385,27 @@ async def run_migrations(db: Database) -> int:
         )
         await db.conn.commit()
         current = 19
+
+    # Version 20 (#760): NULL the premature Monitor-stamped outcomes on
+    # KXPCECORE-26JUL-T0.3 — a JUNE data release was logged against the
+    # JULY market while it was still ACTIVE (closes 2026-08-26). The
+    # honest state until settlement is NULL. The NOT EXISTS settlement-
+    # close guard is load-bearing: a DB migrating AFTER the market
+    # genuinely settles keeps the authoritative outcome; fresh/other
+    # DBs no-op.
+    if current < 20:
+        await db.conn.execute(
+            "UPDATE trades SET resolved_outcome = NULL"
+            " WHERE ticker = 'KXPCECORE-26JUL-T0.3'"
+            " AND resolved_outcome = 'no'"
+            " AND NOT EXISTS (SELECT 1 FROM trades s"
+            "   WHERE s.ticker = trades.ticker"
+            "   AND s.agent = 'settlement' AND s.action = 'close')"
+        )
+        await db.conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (20,)
+        )
+        await db.conn.commit()
+        current = 20
 
     return current

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -131,19 +131,18 @@ async def get_trades(
 async def update_trade_outcome(db: Database, ticker: str, outcome: str) -> int:
     """Set resolved_outcome for all trades matching a ticker.
 
-    Args:
-        ticker: Market ticker.
-        outcome: Resolution result ('yes' or 'no').
+    #760: delegates to the conflict-correcting fill_resolved_outcome —
+    a later AUTHORITATIVE outcome now corrects a wrong earlier one
+    instead of silently updating 0 rows (the old IS NULL clause left
+    KXPCECORE-26JUL-T0.3 split-brained: 138 premature rows that a
+    correct post-settlement log-outcome could never fix).
 
     Returns:
-        Number of rows updated.
+        Number of rows updated (NULL-fills plus corrections).
     """
-    cursor = await db.conn.execute(
-        "UPDATE trades SET resolved_outcome = ? WHERE ticker = ? AND resolved_outcome IS NULL",
-        (outcome, ticker),
-    )
+    updated = await fill_resolved_outcome(db, ticker, outcome)
     await db.conn.commit()
-    return cursor.rowcount
+    return updated
 
 
 # ---------------------------------------------------------------------------
@@ -501,7 +500,7 @@ async def count_opened_closed(
 
 async def fill_resolved_outcome(
     db: Database, ticker: str, outcome: str
-) -> None:
+) -> int:
     """Set `resolved_outcome` on a ticker's trade rows — filling NULLs
     AND overwriting conflicting values.
 
@@ -513,12 +512,13 @@ async def fill_resolved_outcome(
 
     Commit-less — the caller manages the transaction.
     """
-    await db.conn.execute(
+    cursor = await db.conn.execute(
         "UPDATE trades SET resolved_outcome = ?"
         " WHERE ticker = ?"
         " AND (resolved_outcome IS NULL OR resolved_outcome != ?)",
         (outcome, ticker, outcome),
     )
+    return cursor.rowcount
 
 
 async def log_settlement_close(

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3304,3 +3304,14 @@ def test_closer_cap_blocked_covers_event_series(caddie_master_text: str) -> None
         "gimmes risk-check --event EVENT_TICKER" in caddie_master_text
     )
     assert "NEVER shrunk to fit" in caddie_master_text
+
+
+def test_monitor_log_outcome_field_test(monitor_text: str) -> None:
+    """#760: settlement is a field test, never an inference."""
+    assert '"Settled" is a FIELD TEST, never an inference (#760)' in (
+        monitor_text
+    )
+    assert "`determined`/`finalized` OR a non-empty Result" in monitor_text
+    assert "NEVER conclude settlement from a data release" in monitor_text
+    assert "outcome_market_not_settled" in monitor_text
+    assert "do not use `--override`" in monitor_text

--- a/tests/unit/test_cli_log_outcome_guard.py
+++ b/tests/unit/test_cli_log_outcome_guard.py
@@ -145,6 +145,29 @@ class TestLogOutcomeGuard:
         assert len(rows) == 1
         assert rows[0]["severity"] == "error"
 
+    def test_void_result_refused(self, tmp_path) -> None:
+        """A voided market resolves neither yes nor no — no
+        --outcome value is stampable onto it."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            market=_market(MarketStatus.FINALIZED, result="void"),
+        )
+        assert result.exit_code == 1, result.output
+        assert _outcomes(db_path) == [None]
+        assert len(_rows(db_path, "outcome_conflicts_with_result")) == 1
+
+    def test_uppercase_matching_result_writes(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            market=_market(MarketStatus.FINALIZED, result="NO"),
+        )
+        assert result.exit_code == 0, result.output
+        assert _outcomes(db_path) == ["no"]
+
     def test_matching_result_writes(self, tmp_path) -> None:
         db_path = tmp_path / "gimmes.db"
         _db_run(db_path, _seed)

--- a/tests/unit/test_cli_log_outcome_guard.py
+++ b/tests/unit/test_cli_log_outcome_guard.py
@@ -256,9 +256,11 @@ class TestMigrationV20:
 def test_market_info_renders_result_row(tmp_path) -> None:
     """#760: the Result row is the checkable half of the field test."""
     m = MagicMock()
+    m.ticker = "KX-26AUG-T1"
     m.status.value = "finalized"
     m.status = MarketStatus.FINALIZED
     m.result = "yes"
+    m.spread = 0.2
     m.midpoint = 0.5
     m.last_price = 0.5
     m.yes_bid = 0.4
@@ -272,16 +274,27 @@ def test_market_info_renders_result_row(tmp_path) -> None:
     m.rules_primary = "Resolves YES if X."
     m.series_ticker = "KX"
     m.event_ticker = "KX-26AUG"
+    from io import StringIO
+
+    from rich.console import Console
+
     from gimmes.models.market import Orderbook
 
+    buf = StringIO()
     with patch("gimmes.cli.load_config",
                return_value=_config(tmp_path / "gimmes.db")), \
          patch("gimmes.kalshi.markets.get_market",
                AsyncMock(return_value=m)), \
          patch("gimmes.kalshi.markets.get_orderbook",
                AsyncMock(return_value=Orderbook(ticker="KX-26AUG-T1"))), \
-         patch("gimmes.kalshi.client.KalshiClient"):
+         patch("gimmes.kalshi.client.KalshiClient"), \
+         patch("gimmes.cli.console", Console(file=buf, width=200)), \
+         patch(
+             "gimmes.reporting.formatter.console",
+             Console(file=buf, width=200),
+         ):
         result = runner.invoke(app, ["market-info", "KX-26AUG-T1"])
-    out = " ".join(result.output.split())
+    out = " ".join(buf.getvalue().split())
+    assert result.exit_code == 0, buf.getvalue()
     assert "Result" in out
     assert "yes" in out

--- a/tests/unit/test_cli_log_outcome_guard.py
+++ b/tests/unit/test_cli_log_outcome_guard.py
@@ -1,0 +1,287 @@
+"""#760: log-outcome verifies settlement against the live API — a
+Monitor once stamped a JUNE data release onto the still-ACTIVE JULY
+market, corrupting 138 rows with no error trail."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from typer.testing import CliRunner
+
+from gimmes.cli import app
+from gimmes.models.market import MarketStatus
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import insert_trade
+
+runner = CliRunner()
+TICKER = "KXPCECORE-26JUL-T0.3"
+
+
+def _db_run(db_path: Path, fn):
+    async def _go():
+        db = Database(db_path)
+        await db.connect()
+        try:
+            return await fn(db)
+        finally:
+            await db.close()
+
+    return asyncio.run(_go())
+
+
+async def _seed(db):
+    await insert_trade(db, TradeDecision(
+        ticker=TICKER, action=TradeDecision.Action.OPEN,
+        side="no", count=100, price=0.5,
+        model_probability=0.7, agent="closer",
+    ))
+
+
+def _config(db_path):
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    return cfg
+
+
+def _market(status, result=""):
+    m = MagicMock()
+    m.status = status
+    m.result = result
+    m.close_time = "2026-08-26T12:25:00+00:00"
+    return m
+
+
+def _rows(db_path, code):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT severity, error_code, context FROM error_log"
+        " WHERE error_code = ?", (code,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _outcomes(db_path):
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT resolved_outcome FROM trades WHERE ticker = ?",
+        (TICKER,),
+    ).fetchall()
+    conn.close()
+    return [r[0] for r in rows]
+
+
+class TestLogOutcomeGuard:
+    def _run(self, db_path, *, market=None, fetch_effect=None,
+             extra=()):
+        get_market = AsyncMock(
+            return_value=market, side_effect=fetch_effect,
+        )
+        with patch("gimmes.cli.load_config",
+                   return_value=_config(db_path)), \
+             patch("gimmes.kalshi.markets.get_market", get_market), \
+             patch("gimmes.kalshi.client.KalshiClient"):
+            return runner.invoke(app, [
+                "log-outcome", TICKER, "--outcome", "no", *extra,
+            ])
+
+    def test_active_market_refused_with_error_row(
+        self, tmp_path,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path, market=_market(MarketStatus.ACTIVE),
+        )
+        assert result.exit_code == 1, result.output
+        assert "Refused (#760)" in result.output
+        assert _outcomes(db_path) == [None]
+        rows = _rows(db_path, "outcome_market_not_settled")
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "error"
+
+    def test_finalized_market_writes(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path, market=_market(MarketStatus.FINALIZED),
+        )
+        assert result.exit_code == 0, result.output
+        assert _outcomes(db_path) == ["no"]
+
+    def test_closed_with_result_permitted(self, tmp_path) -> None:
+        """The hourly case: status closed but result published."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            market=_market(MarketStatus.CLOSED, result="no"),
+        )
+        assert result.exit_code == 0, result.output
+        assert _outcomes(db_path) == ["no"]
+
+    def test_closed_without_result_refused(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path, market=_market(MarketStatus.CLOSED),
+        )
+        assert result.exit_code == 1, result.output
+        assert _outcomes(db_path) == [None]
+
+    def test_fetch_failure_names_override(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            fetch_effect=httpx.RequestError("gone"),
+        )
+        assert result.exit_code == 1, result.output
+        assert "--override" in result.output
+        assert _outcomes(db_path) == [None]
+
+    def test_fetch_failure_with_override_writes_warning(
+        self, tmp_path,
+    ) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            fetch_effect=httpx.RequestError("gone"),
+            extra=("--override", "delisted market"),
+        )
+        assert result.exit_code == 0, result.output
+        assert _outcomes(db_path) == ["no"]
+        rows = _rows(db_path, "outcome_override_used")
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "warning"
+
+    def test_active_with_override_still_refused(self, tmp_path) -> None:
+        """Override never bypasses a live not-settled answer."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            market=_market(MarketStatus.ACTIVE),
+            extra=("--override", "trust me"),
+        )
+        assert result.exit_code == 1, result.output
+        assert _outcomes(db_path) == [None]
+
+    def test_overwrite_corrects_wrong_outcome(self, tmp_path) -> None:
+        """#760 split-brain defense: an authoritative log-outcome
+        CORRECTS a wrong earlier stamp."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+
+        async def _stamp_wrong(db):
+            await db.conn.execute(
+                "UPDATE trades SET resolved_outcome = 'yes'"
+                " WHERE ticker = ?", (TICKER,),
+            )
+            await db.conn.commit()
+
+        _db_run(db_path, _stamp_wrong)
+        result = self._run(
+            db_path, market=_market(MarketStatus.FINALIZED),
+        )
+        assert result.exit_code == 0, result.output
+        assert _outcomes(db_path) == ["no"]
+        assert "1 trade(s)" in result.output
+
+
+class TestMigrationV20:
+    def test_premature_rows_nulled(self, tmp_path) -> None:
+        from gimmes.store.migrations import run_migrations
+
+        db_path = tmp_path / "gimmes.db"
+
+        async def _go(db):
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.OPEN,
+                side="no", count=100, price=0.5,
+                model_probability=0.7, agent="closer",
+            ))
+            await db.conn.execute(
+                "UPDATE trades SET resolved_outcome = 'no'"
+                " WHERE ticker = ?", (TICKER,),
+            )
+            await db.conn.execute(
+                "DELETE FROM schema_version WHERE version = 20"
+            )
+            await db.conn.commit()
+            await run_migrations(db)
+
+        _db_run(db_path, _go)
+        assert _outcomes(db_path) == [None]
+
+    def test_settled_ticker_untouched(self, tmp_path) -> None:
+        """The NOT EXISTS guard: a genuinely settled DB keeps the
+        authoritative outcome."""
+        from gimmes.store.migrations import run_migrations
+
+        db_path = tmp_path / "gimmes.db"
+
+        async def _go(db):
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.OPEN,
+                side="no", count=100, price=0.5,
+                model_probability=0.7, agent="closer",
+            ))
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                side="no", count=100, price=1.0,
+                model_probability=0.7, agent="settlement",
+            ))
+            await db.conn.execute(
+                "UPDATE trades SET resolved_outcome = 'no'"
+                " WHERE ticker = ?", (TICKER,),
+            )
+            await db.conn.execute(
+                "DELETE FROM schema_version WHERE version = 20"
+            )
+            await db.conn.commit()
+            await run_migrations(db)
+
+        _db_run(db_path, _go)
+        assert set(_outcomes(db_path)) == {"no"}
+
+
+def test_market_info_renders_result_row(tmp_path) -> None:
+    """#760: the Result row is the checkable half of the field test."""
+    m = MagicMock()
+    m.status.value = "finalized"
+    m.status = MarketStatus.FINALIZED
+    m.result = "yes"
+    m.midpoint = 0.5
+    m.last_price = 0.5
+    m.yes_bid = 0.4
+    m.yes_ask = 0.6
+    m.title = "t"
+    m.subtitle = ""
+    m.volume = 1
+    m.volume_24h = 1
+    m.open_interest = 1
+    m.close_time = None
+    m.rules_primary = "Resolves YES if X."
+    m.series_ticker = "KX"
+    m.event_ticker = "KX-26AUG"
+    from gimmes.models.market import Orderbook
+
+    with patch("gimmes.cli.load_config",
+               return_value=_config(tmp_path / "gimmes.db")), \
+         patch("gimmes.kalshi.markets.get_market",
+               AsyncMock(return_value=m)), \
+         patch("gimmes.kalshi.markets.get_orderbook",
+               AsyncMock(return_value=Orderbook(ticker="KX-26AUG-T1"))), \
+         patch("gimmes.kalshi.client.KalshiClient"):
+        result = runner.invoke(app, ["market-info", "KX-26AUG-T1"])
+    out = " ".join(result.output.split())
+    assert "Result" in out
+    assert "yes" in out

--- a/tests/unit/test_cli_log_outcome_guard.py
+++ b/tests/unit/test_cli_log_outcome_guard.py
@@ -126,6 +126,35 @@ class TestLogOutcomeGuard:
         assert result.exit_code == 0, result.output
         assert _outcomes(db_path) == ["no"]
 
+    def test_result_conflict_refused_with_error_row(
+        self, tmp_path,
+    ) -> None:
+        """A published result that contradicts --outcome wins: with
+        overwrite semantics a wrong --outcome would clobber a
+        correct row."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            market=_market(MarketStatus.FINALIZED, result="yes"),
+        )
+        assert result.exit_code == 1, result.output
+        assert "contradicts" in result.output
+        assert _outcomes(db_path) == [None]
+        rows = _rows(db_path, "outcome_conflicts_with_result")
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "error"
+
+    def test_matching_result_writes(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, _seed)
+        result = self._run(
+            db_path,
+            market=_market(MarketStatus.FINALIZED, result="no"),
+        )
+        assert result.exit_code == 0, result.output
+        assert _outcomes(db_path) == ["no"]
+
     def test_closed_without_result_refused(self, tmp_path) -> None:
         db_path = tmp_path / "gimmes.db"
         _db_run(db_path, _seed)

--- a/tests/unit/test_cli_ticker_prefix.py
+++ b/tests/unit/test_cli_ticker_prefix.py
@@ -408,6 +408,7 @@ def _stub_market(ticker: str) -> MagicMock:
     m.title = f"Market {ticker}"
     m.status = MagicMock()
     m.status.value = "active"
+    m.result = ""  # #760: the Result row renders this via verbatim()
     m.yes_bid = 0.50
     m.yes_ask = 0.55
     m.last_price = 0.52

--- a/tests/unit/test_data_collection.py
+++ b/tests/unit/test_data_collection.py
@@ -111,7 +111,7 @@ class TestResolvedOutcome:
         rows = await get_trades(db, ticker="OUTCOME-TEST")
         assert rows[0]["resolved_outcome"] == "yes"
 
-    async def test_update_outcome_idempotent(self, db: Database) -> None:
+    async def test_update_outcome_corrects_conflicts(self, db: Database) -> None:
         from gimmes.models.trade import TradeDecision
 
         trade = TradeDecision(
@@ -129,12 +129,17 @@ class TestResolvedOutcome:
         await insert_trade(db, trade)
 
         await update_trade_outcome(db, "IDEM-TEST", "yes")
-        # Second call should not update (already set)
+        # #760: a later AUTHORITATIVE outcome CORRECTS a wrong earlier
+        # one (the old IS NULL clause left premature stamps
+        # permanently un-fixable — the KXPCECORE split-brain).
         updated = await update_trade_outcome(db, "IDEM-TEST", "no")
-        assert updated == 0
+        assert updated == 1
 
         rows = await get_trades(db, ticker="IDEM-TEST")
-        assert rows[0]["resolved_outcome"] == "yes"  # unchanged
+        assert rows[0]["resolved_outcome"] == "no"  # corrected
+
+        # Idempotent when already correct
+        assert await update_trade_outcome(db, "IDEM-TEST", "no") == 0
 
     async def test_update_outcome_no_match(self, db: Database) -> None:
         updated = await update_trade_outcome(db, "NONEXISTENT", "yes")

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -249,7 +249,7 @@ class TestMigrationV19:
             # Rewind the version stamp so the v19 block re-runs against
             # the newly-seeded row.
             await db.conn.execute(
-                "DELETE FROM schema_version WHERE version = 19"
+                "DELETE FROM schema_version WHERE version >= 19"
             )
             await db.conn.commit()
             await run_migrations(db)


### PR DESCRIPTION
## Summary

The CRITICAL #760 incident: Monitor stamped a **June** PCE release onto the **July** market while it was still ACTIVE (closes 2026-08-26) — corrupting `resolved_outcome` on 138 rows with zero error trail. Triage found a live time bomb: the position was closed early on profit-taking, so the settle path's conflict-corrector can never run for this ticker, and the old `IS NULL` write clause meant a correct post-settlement `log-outcome` would fill only the one NULL row — a permanent 138-`no`/1-`yes` split-brain if July PCE prints above 0.3%.

- **Settlement guard:** `log-outcome` (the last unguarded write path in a CLI that now gates orders four ways) fetches the live market and permits only `determined`/`finalized` **or** a published result — the closed-with-result hourly case (verified legitimate from the Aug 14 INX log) keeps working. An ACTIVE market refuses with an ERROR `outcome_market_not_settled` row (closing the issue's observability gap) and is **never** overridable against a live not-settled answer; `--override REASON` covers only fetch failures (delisted markets), logged as WARNING.
- **Conflict-correcting writes:** `update_trade_outcome` delegates to `fill_resolved_outcome` (now returning rowcount) — a later authoritative outcome corrects a wrong earlier stamp. This is the second known premature-log-outcome incident (the corrector's docstring already cited KXUE-UK26FEB); now the correction path works from the CLI too.
- **Repair:** migration v20 NULLs the 138 premature rows (honest state until Aug 26 — the Pro was reading an asserted, unearned win) behind a `NOT EXISTS` settlement-close guard so a DB migrating after genuine settlement keeps its authoritative outcome.
- **Field test:** `market-info` gains a `Result` row (the dead Settlement Value row was dropped — `parse_market` never maps it, review-found); monitor.md states "Settled" is a **field test, never an inference** — data releases, month arithmetic, and confirmed theses are not settlement — with the #760 counter-example named and drift-pinned.

Closes #760

## Test plan

- 8 guard tests (active refused + ERROR row, finalized writes, closed-with-result permitted, closed-without-result refused, fetch-failure names `--override`, override writes with WARNING row, override never bypasses a live answer, overwrite corrects a wrong stamp) + 2 migration tests (premature rows NULLed; settlement-close guard preserves truth) + the flipped conflict-correction semantics pin + the monitor.md field-test pin + a Result-row render pin.
- Mutation-verified in review: guard removal, overwrite-revert, and migration-guard removal each killed by named tests.
- Frozen full unit suite: **2519 passed**. Lint clean.

Note: pr-review-toolkit not installed; equivalent review roles ran via general-purpose agents, findings addressed pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r