### PR TITLE
Decisions panel renders oldest-first; governing decision full-body (#633)

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -115,7 +115,7 @@ If a bank returned no result in your search, log that explicitly in the observat
 
 **Read-back assertion (MUST follow — closes #577).** Before writing the observation body, you MUST:
 
-1. Re-read the most recent CM `decision`-type note in the `position-context` output for this position.
+1. Re-read the most recent CM `decision`-type note in the `position-context` output for this position — the entry labeled `>>> GOVERNING DECISION` at the BOTTOM of the CADDIE MASTER DECISIONS section (decisions render oldest-first; only the governing entry's body prints in full — #633).
 
 2. Identify every named bank or aggregator source in that decision body that overlaps with the playbook's named-bank or aggregator lists (see `## Fundamental-Economic-Trigger Source Playbook`).
 
@@ -255,7 +255,7 @@ rm -f "$BODY_FILE"
 Do NOT write: "I recommend closing this position." Do NOT write: "This position should be held." Write what you observed and why you are flagging it. Caddie Master decides what to do.
 
 **Flag deduplication rules (MUST follow all):**
-- Look at the **most recent** decision note (type=decision) for this position from Caddie Master. Older decisions are superseded.
+- Look at the **most recent** decision note (type=decision) for this position from Caddie Master — the entry labeled `GOVERNING DECISION` at the bottom of the CADDIE MASTER DECISIONS section. Older decisions are superseded; citing a superseded (truncated) decision as governing is the #633 failure.
 - Do NOT re-flag a trigger condition that the most recent decision already addressed, UNLESS your delta observation identifies something genuinely new that was not present when that decision was made.
 - If the most recent HOLD decision includes a "Re-evaluate if" condition, only re-flag if that specific condition has been met.
 - **Exception (#659):** a position with ANY `StopGate:` banner below the `gimmes positions` table (`MANDATORY-CLOSE`, `DATA-ERROR`, `STALE`, or `BASIS-SUSPECT`) MUST be re-flagged regardless of any prior HOLD's re-evaluation condition — the hard loss backstop outranks flag deduplication.

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -5123,10 +5123,29 @@ def position_context(
             console.print("[dim]No notes yet.[/dim]")
 
         if decisions:
-            console.print("\n[bold yellow]--- CADDIE MASTER DECISIONS ---[/bold yellow]")
-            for n in decisions:
-                console.print(f"[#{n['id']}] cycle={n['cycle']} —")
-                console.print(n["body"][:120] + "...", markup=False)
+            # #633: decisions must render oldest-first like the notes
+            # section — the old newest-first order inverted the
+            # "bottom = most recent" convention agents learn from the
+            # notes panel, and Monitor repeatedly cited a stale HOLD
+            # as governing. The governing (newest) decision prints in
+            # FULL: truncation was amputating the trailing Expiry /
+            # Re-evaluate fields Monitor is required to read.
+            console.print(
+                "\n[bold yellow]--- CADDIE MASTER DECISIONS"
+                " (oldest first — final entry GOVERNS) ---[/bold yellow]"
+            )
+            for n in reversed(decisions[1:]):
+                console.print()
+                body = n["body"]
+                if len(body) > 120:
+                    body = body[:120] + " ... [truncated — superseded]"
+                _print_note({**n, "body": body})
+            console.print()
+            console.print(
+                "[bold yellow]>>> GOVERNING DECISION (most"
+                " recent — full body) <<<[/bold yellow]"
+            )
+            _print_note(decisions[0])
 
     _run(_ctx())
 

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3315,3 +3315,15 @@ def test_monitor_log_outcome_field_test(monitor_text: str) -> None:
     assert "NEVER conclude settlement from a data release" in monitor_text
     assert "outcome_market_not_settled" in monitor_text
     assert "do not use `--override`" in monitor_text
+
+
+def test_monitor_governing_decision_label(monitor_text: str) -> None:
+    """#633: both governing-note rules point at the GOVERNING
+    DECISION label so Monitor anchors on the rendered marker, not on
+    list position."""
+    assert monitor_text.count("GOVERNING DECISION") >= 2
+    assert "decisions render oldest-first" in monitor_text
+    assert (
+        "citing a superseded (truncated) decision as governing"
+        " is the #633 failure"
+    ) in monitor_text

--- a/tests/unit/test_position_lifecycle.py
+++ b/tests/unit/test_position_lifecycle.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -488,6 +489,99 @@ class TestOpenPositionMissingTradeLog:
         assert "No open trade row recorded" in result.output
         assert "POSITION CLOSED/SETTLED" not in result.output
         assert _read_errors(db_path) == []
+
+
+class TestDecisionsPanel:
+    """#633: decisions render oldest-first like the notes panel, the
+    newest is labeled GOVERNING and prints in full — truncation was
+    amputating the Expiry / Re-evaluate fields, and newest-first
+    ordering had Monitor citing a stale HOLD as governing."""
+
+    def _seed_decisions(self, db_path, bodies_by_cycle):
+        async def _seed(db):
+            await db.conn.execute(
+                "INSERT INTO positions"
+                " (ticker, side, count, avg_price, cost_basis)"
+                " VALUES (?, 'no', 100, 0.5, 50.0)",
+                (TICKER,),
+            )
+            for cycle, body in bodies_by_cycle:
+                await db.conn.execute(
+                    "INSERT INTO position_notes"
+                    " (ticker, cycle, agent, note_type, body)"
+                    " VALUES (?, ?, 'caddie-master', 'decision', ?)",
+                    (TICKER, cycle, body),
+                )
+            await db.conn.commit()
+
+        _db_run(db_path, _seed)
+
+    def _run(self, db_path):
+        with patch("gimmes.cli.load_config",
+                   return_value=_config(db_path)):
+            return runner.invoke(app, ["position-context", TICKER])
+
+    def test_oldest_first_with_governing_last(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        self._seed_decisions(db_path, [
+            (1527, "HOLD stale-one"),
+            (1530, "HOLD middle-one"),
+            (1538, "HOLD governing-one"),
+        ])
+        result = self._run(db_path)
+        assert result.exit_code == 0, result.output
+        # Decision notes also appear in the mixed POSITION NOTES
+        # panel — scope every assertion to the decisions section.
+        out = result.output[result.output.index("final entry GOVERNS"):]
+        i27 = out.index("cycle=1527")
+        i30 = out.index("cycle=1530")
+        i38 = out.index("cycle=1538")
+        assert i27 < i30 < i38
+        assert out.count("GOVERNING DECISION") == 1
+        assert i30 < out.index("GOVERNING DECISION") < i38
+
+    def test_governing_full_older_truncated(self, tmp_path) -> None:
+        stale_tail = "stale-tail-marker"
+        old_body = "\n".join(
+            ["HOLD old rationale line"] * 8 + [stale_tail],
+        )
+        gov_body = "\n".join(
+            ["HOLD current rationale line"] * 8
+            + ["Expiry: cycle 1548", "Re-evaluate if: gap closes"],
+        )
+        db_path = tmp_path / "gimmes.db"
+        self._seed_decisions(db_path, [
+            (1527, old_body), (1538, gov_body),
+        ])
+        result = self._run(db_path)
+        assert result.exit_code == 0, result.output
+        out = result.output[result.output.index("final entry GOVERNS"):]
+        assert "Expiry: cycle 1548" in out
+        assert "Re-evaluate if: gap closes" in out
+        assert stale_tail not in out
+        assert "[truncated" in out
+
+    def test_single_short_decision_untruncated(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        self._seed_decisions(db_path, [(1538, "HOLD brief")])
+        result = self._run(db_path)
+        assert result.exit_code == 0, result.output
+        assert "GOVERNING DECISION" in result.output
+        assert "HOLD brief" in result.output
+        assert "[truncated" not in result.output
+        assert "HOLD brief..." not in result.output
+
+    def test_decision_headers_carry_timestamps(self, tmp_path) -> None:
+        db_path = tmp_path / "gimmes.db"
+        self._seed_decisions(db_path, [(1538, "HOLD brief")])
+        result = self._run(db_path)
+        assert result.exit_code == 0, result.output
+        out = result.output[result.output.index("final entry GOVERNS"):]
+        assert re.search(
+            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            r" \| cycle=1538 \| caddie-master \| decision",
+            out,
+        ), out
 
 
 class TestKnownMarketsSettle:


### PR DESCRIPTION
Closes #633.

## Root cause
Monitor repeatedly cited a stale CM HOLD as governing (c1527 over c1538). #580 fixed the eviction half (decisions fetched separately, newest-first, limit 25). The surviving half was presentational:

- The POSITION NOTES panel renders **oldest-first** — agents learn "bottom = most recent" from it. The CADDIE MASTER DECISIONS panel rendered **newest-first**, so applying that convention selects the OLDEST decision as governing — exactly the reported incident.
- Every decision body was truncated at 120 chars with an unconditional `"..."`, amputating the trailing `Expiry:` / `Re-evaluate if:` fields monitor.md rules require Monitor to read from the governing decision.

## Fix
- Decisions render oldest-first (matching notes); the section header states "final entry GOVERNS".
- The newest decision is labeled `>>> GOVERNING DECISION (most recent — full body) <<<` and prints in full via `_print_note` — which also gives decisions the same timestamped `[#id] ts | cycle | agent | type` header as notes.
- Older (superseded) decisions keep 120-char truncation, now with an explicit ` ... [truncated — superseded]` marker only when actually over 120 chars (the old code appended `...` even to short bodies).
- monitor.md's two governing-note rules (read-back assertion + flag-dedup) now point at the rendered `GOVERNING DECISION` label.

## Tests
- `TestDecisionsPanel` (4 tests): ordering with governing-label position, full-body-governing vs truncated-stale (Expiry/Re-evaluate survive; stale tail absent), no spurious ellipsis on short bodies, timestamped header shape. Assertions scoped to the decisions section since decision notes also appear in the mixed notes panel.
- Prompt pin: `test_monitor_governing_decision_label`.

## Review
3-role review run with general-purpose agents substituting for the missing pr-review-toolkit: correctness APPROVE, simplifier's two suggestions applied (structural last-entry handling instead of identity check; module-level `re` import). Frozen full-suite gate: **2528 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r