### PR TITLE
Released-figure verification rule for Monitor's playbook (#634)

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -111,7 +111,7 @@ The c1391–c1405 failure (where Monitor missed Barclays' +0.55% across 15 cycle
 
 If a bank returned no result in your search, log that explicitly in the observation: `Goldman Sachs: no April CPI MoM forecast found this cycle.`
 
-**5. Released-figure verification (#634).** A RELEASED official figure (an actual print, not a forecast) is settlement truth — it moves positions, so it gets a stricter bar than any forecast:
+**5. Released-figure verification (#634).** A RELEASED official figure (an actual print, not a forecast) is the settlement METRIC'S value — it moves positions, so it gets a stricter bar than any forecast. A verified release says NOTHING about settlement STATUS: markets settle when the API says so, never because a figure printed (#760).
 
 - Before a released figure enters an observation, confirm it against TWO independent sources, or against the official releasing agency directly (DOL, BLS, BEA — the release itself outranks any secondary report).
 - Always record the reference period next to the value (`initial claims week ending May 24: 215K`). The #634 failure mode is reporting a prior week's or wrong-series value as current — the reference date is what catches it.

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -111,6 +111,12 @@ The c1391–c1405 failure (where Monitor missed Barclays' +0.55% across 15 cycle
 
 If a bank returned no result in your search, log that explicitly in the observation: `Goldman Sachs: no April CPI MoM forecast found this cycle.`
 
+**5. Released-figure verification (#634).** A RELEASED official figure (an actual print, not a forecast) is settlement truth — it moves positions, so it gets a stricter bar than any forecast:
+
+- Before a released figure enters an observation, confirm it against TWO independent sources, or against the official releasing agency directly (DOL, BLS, BEA — the release itself outranks any secondary report).
+- Always record the reference period next to the value (`initial claims week ending May 24: 215K`). The #634 failure mode is reporting a prior week's or wrong-series value as current — the reference date is what catches it.
+- If secondary sources disagree on the exact settlement metric — by ANY amount — and you have NOT confirmed against the official release, report the figure as `UNVERIFIED` with both values and both sources. The official agency release RESOLVES such a conflict: report the agency value and note the divergent secondary (`215K per DOL release; Reuters showed 240K — superseded`). Never assert a single number you could not confirm. In cycle 1560 Monitor asserted DOL initial claims of 240K when every public source showed 215K (a 12% miss); Caddie's cross-referencing caught it downstream, which is the wrong layer — verification belongs at the point of reporting.
+
 ## Writing Observations (REQUIRED every cycle for every position)
 
 **Read-back assertion (MUST follow — closes #577).** Before writing the observation body, you MUST:

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3327,3 +3327,16 @@ def test_monitor_governing_decision_label(monitor_text: str) -> None:
         "citing a superseded (truncated) decision as governing"
         " is the #633 failure"
     ) in monitor_text
+
+
+def test_monitor_released_figure_verification(monitor_text: str) -> None:
+    """#634: released official figures require two-source (or
+    official-agency) confirmation with a reference period; source
+    disagreement reports UNVERIFIED, never a single asserted value."""
+    block = _playbook_block(monitor_text)
+    assert "**5. Released-figure verification (#634).**" in block
+    assert "TWO independent sources" in block
+    assert "the release itself outranks any secondary report" in block
+    assert "record the reference period next to the value" in block
+    assert "report the figure as `UNVERIFIED` with both values" in block
+    assert "The official agency release RESOLVES such a conflict" in block

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3340,3 +3340,4 @@ def test_monitor_released_figure_verification(monitor_text: str) -> None:
     assert "record the reference period next to the value" in block
     assert "report the figure as `UNVERIFIED` with both values" in block
     assert "The official agency release RESOLVES such a conflict" in block
+    assert "A verified release says NOTHING about settlement STATUS" in block


### PR DESCRIPTION
Closes #634.

## Incident
Cycle 1560: Monitor reported DOL initial claims for the week ending May 24 as 240K; every public source showed 215K (a 12% miss). The wrong figure fed downstream analysis for KXJOBLESSCLAIMS-26MAY28-215000 and was caught only by Caddie cross-referencing — the wrong layer. No error row was generated.

## Fix
New rule **§5 Released-figure verification (#634)** in monitor.md's Fundamental-Economic-Trigger Source Playbook, scoped to RELEASED official figures only (actual prints, not forecasts — no added cost on ordinary sweep cycles):

- Two independent sources OR the official releasing agency (DOL/BLS/BEA — the release itself outranks any secondary report) before a released figure enters an observation.
- Reference period recorded next to the value (`initial claims week ending May 24: 215K`) — the #634 failure mode is a prior-week/wrong-series value reported as current, and the reference date is what catches it.
- Secondary-source disagreement without agency confirmation → report `UNVERIFIED` with both values and both sources; an official agency release resolves the conflict outright (report the agency value, note the divergent secondary as superseded).

Prompt pin `test_monitor_released_figure_verification` scoped to `_playbook_block` like its §1–§4 siblings.

## Review
Agent-definition-only change; correctness review APPROVE (verified no contradiction with #641 freshness, #731 sweep cadence, #618 cache-bust, #615 audit footer, or the #760 field-test rule; cadence rule 3(d) guarantees a released figure can only enter on a sweep cycle, where §5 applies). Both reviewer notes applied (agency-resolves-conflict clause; playbook-scoped pin). Frozen full-suite gate: **2529 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r