### PR TITLE
Escape remaining Rich markup sites: errors, wizard, Pro, report (#650)

### DIFF
--- a/src/gimmes/backtest/report.py
+++ b/src/gimmes/backtest/report.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, time
 
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -212,7 +213,7 @@ def format_backtest_report(result: BacktestResult, console: Console) -> None:
         console.print(
             f"[yellow]Warning: pagination limit reached for "
             f"{len(result.truncated_chunks)} chunk(s): "
-            f"{', '.join(result.truncated_chunks)}. "
+            f"{rich_escape(', '.join(result.truncated_chunks))}. "
             f"Results may be incomplete.[/yellow]"
         )
     console.print()

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -158,18 +158,23 @@ def _read_prose_file(path: Path, option_name: str) -> str:
     content to write."
     """
     if not path.exists():
-        console.print(f"[red]{option_name}: file not found: {path}[/red]")
+        console.print(
+            f"[red]{option_name}: file not found: {rich_escape(str(path))}[/red]"
+        )
         raise typer.Exit(1)
     if not path.is_file():
         console.print(
-            f"[red]{option_name}: not a regular file: {path}"
+            f"[red]{option_name}: not a regular file: {rich_escape(str(path))}"
             " (FIFOs, sockets, and device files are rejected)[/red]"
         )
         raise typer.Exit(1)
     try:
         size = path.stat().st_size
     except OSError as e:
-        console.print(f"[red]{option_name}: cannot stat {path}: {rich_escape(str(e))}[/red]")
+        console.print(
+            f"[red]{option_name}: cannot stat {rich_escape(str(path))}:"
+            f" {rich_escape(str(e))}[/red]"
+        )
         raise typer.Exit(1) from e
     if size > _MAX_PROSE_BYTES:
         console.print(
@@ -180,10 +185,16 @@ def _read_prose_file(path: Path, option_name: str) -> str:
     try:
         content = path.read_text(encoding="utf-8")
     except UnicodeDecodeError as e:
-        console.print(f"[red]{option_name}: file is not valid UTF-8: {path}[/red]")
+        console.print(
+            f"[red]{option_name}: file is not valid UTF-8:"
+            f" {rich_escape(str(path))}[/red]"
+        )
         raise typer.Exit(1) from e
     except OSError as e:
-        console.print(f"[red]{option_name}: cannot read {path}: {rich_escape(str(e))}[/red]")
+        console.print(
+            f"[red]{option_name}: cannot read {rich_escape(str(path))}:"
+            f" {rich_escape(str(e))}[/red]"
+        )
         raise typer.Exit(1) from e
     if content.endswith("\n"):
         content = content[:-1]

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -169,7 +169,7 @@ def _read_prose_file(path: Path, option_name: str) -> str:
     try:
         size = path.stat().st_size
     except OSError as e:
-        console.print(f"[red]{option_name}: cannot stat {path}: {e}[/red]")
+        console.print(f"[red]{option_name}: cannot stat {path}: {rich_escape(str(e))}[/red]")
         raise typer.Exit(1) from e
     if size > _MAX_PROSE_BYTES:
         console.print(
@@ -183,7 +183,7 @@ def _read_prose_file(path: Path, option_name: str) -> str:
         console.print(f"[red]{option_name}: file is not valid UTF-8: {path}[/red]")
         raise typer.Exit(1) from e
     except OSError as e:
-        console.print(f"[red]{option_name}: cannot read {path}: {e}[/red]")
+        console.print(f"[red]{option_name}: cannot read {path}: {rich_escape(str(e))}[/red]")
         raise typer.Exit(1) from e
     if content.endswith("\n"):
         content = content[:-1]
@@ -365,7 +365,7 @@ def _run(coro):  # type: ignore[no-untyped-def]
                 )
                 raise typer.Exit(1)
         detail = _api_error_detail(e)
-        console.print(f"[red]API error ({e.response.status_code}): {detail}[/red]")
+        console.print(f"[red]API error ({e.response.status_code}): {rich_escape(detail)}[/red]")
         raise typer.Exit(1)
     except httpx.TimeoutException:
         logger.debug("Timeout error", exc_info=True)
@@ -404,7 +404,7 @@ def _run(coro):  # type: ignore[no-untyped-def]
         raise
     except (ConnectionError, ValueError, RuntimeError) as e:
         logger.debug("CLI error", exc_info=True)
-        console.print(f"[red]Error: {e}[/red]")
+        console.print(f"[red]Error: {rich_escape(str(e))}[/red]")
         raise typer.Exit(1)
 
 
@@ -1073,7 +1073,8 @@ def validate(
                 daily_pnl = await get_daily_pnl(db)
             except Exception as exc:
                 console.print(
-                    f"[red bold]VALIDATION FAILED: Could not query daily P&L — {exc}[/red bold]"
+                    f"[red bold]VALIDATION FAILED: Could not query"
+                    f" daily P&L — {rich_escape(str(exc))}[/red bold]"
                 )
                 console.print(
                     "[red]Refusing to validate with unknown P&L "
@@ -1087,7 +1088,8 @@ def validate(
             except Exception as exc:
                 console.print(
                     f"[red bold]VALIDATION FAILED: Could not query"
-                    f" deployed cost basis — {exc}[/red bold]"
+                    f" deployed cost basis —"
+                    f" {rich_escape(str(exc))}[/red bold]"
                 )
                 console.print(
                     "[red]Refusing to validate with unknown deployed"
@@ -2094,7 +2096,8 @@ def order(
                     logger.error("Failed to log error to DB", exc_info=True)
                 console.print(
                     f"[red bold]Order FAILED"
-                    f" ({exc.response.status_code}): {detail}[/red bold]"
+                    f" ({exc.response.status_code}):"
+                    f" {rich_escape(detail)}[/red bold]"
                 )
                 await _mark_terminal({
                     "error_code": "http_status_error",
@@ -2150,7 +2153,7 @@ def order(
                     ))
                 except Exception:
                     logger.error("Failed to log error to DB", exc_info=True)
-                console.print(f"[red bold]Order FAILED: {exc}[/red bold]")
+                console.print(f"[red bold]Order FAILED: {rich_escape(str(exc))}[/red bold]")
                 await _mark_terminal({"error_code": error_code})
                 raise typer.Exit(1)
 
@@ -2722,7 +2725,7 @@ def candidates(
                         flags.append("[dim]STALE[/dim]")
             newest_seen.add(row_ticker)
             status = " ".join(flags)
-            rec = str(c.get("recommendation", ""))
+            rec = rich_escape(str(c.get("recommendation", "")))  # #650
             table.add_row(
                 str(c.get("ticker", "")),
                 f"{c.get('gimme_score', 0):.0f}",
@@ -4051,7 +4054,8 @@ def market_info(
                     ))
                 console.print(
                     f"[red bold]Market lookup FAILED"
-                    f" ({exc.response.status_code}): {detail}[/red bold]"
+                    f" ({exc.response.status_code}):"
+                    f" {rich_escape(detail)}[/red bold]"
                 )
                 raise typer.Exit(1)
             except httpx.RequestError as exc:
@@ -4074,7 +4078,8 @@ def market_info(
                     ))
                 console.print(
                     f"[red bold]Market lookup FAILED:"
-                    f" {type(exc).__name__}: {exc}[/red bold]"
+                    f" {type(exc).__name__}:"
+                    f" {rich_escape(str(exc))}[/red bold]"
                 )
                 raise typer.Exit(1)
             settlement = scan_settlement_rules(market.rules_primary)
@@ -5464,7 +5469,7 @@ def audit_cycles(
     try:
         parsed_date = _date.fromisoformat(target_date)
     except ValueError as exc:
-        console.print(f"[red]Invalid --date value: {exc}[/red]")
+        console.print(f"[red]Invalid --date value: {rich_escape(str(exc))}[/red]")
         raise typer.Exit(1)
 
     log_dir = GIMMES_HOME / "logs"
@@ -5574,7 +5579,7 @@ def pause_backtest(
         try:
             date_from_d = _date.fromisoformat(date_from)
         except ValueError as exc:
-            console.print(f"[red]Invalid --from value: {exc}[/red]")
+            console.print(f"[red]Invalid --from value: {rich_escape(str(exc))}[/red]")
             raise typer.Exit(1)
 
     if date_to is None:
@@ -5583,7 +5588,7 @@ def pause_backtest(
         try:
             date_to_d = _date.fromisoformat(date_to)
         except ValueError as exc:
-            console.print(f"[red]Invalid --to value: {exc}[/red]")
+            console.print(f"[red]Invalid --to value: {rich_escape(str(exc))}[/red]")
             raise typer.Exit(1)
 
     if date_to_d < date_from_d:
@@ -5973,9 +5978,11 @@ def lesson(
                 )
                 console.print(
                     f"[{color}][{rec.confidence.value.upper()}][/{color}] "
-                    f"{rec.parameter_path}: {rec.current_value} → {rec.recommended_value}"
+                    f"{rich_escape(rec.parameter_path)}:"
+                    f" {rich_escape(str(rec.current_value))} →"
+                    f" {rich_escape(str(rec.recommended_value))}"
                 )
-                console.print(f"  {rec.rationale}\n")
+                console.print(f"  {rich_escape(rec.rationale)}\n")
 
             # Persist recommendations (skip if pending rec already exists for same parameter)
             if not dry_run:
@@ -6010,8 +6017,10 @@ def lesson(
                 for row in past:
                     table.add_row(
                         str(row["id"]),
-                        row["parameter_path"],
-                        f"{row['current_value']} → {row['recommended_value']}",
+                        rich_escape(row["parameter_path"]),  # #650
+                        rich_escape(
+                            f"{row['current_value']} → {row['recommended_value']}"
+                        ),
                         row["confidence"],
                         format_local_timestamp(row["timestamp"], date_only=True),
                     )
@@ -6066,11 +6075,11 @@ def recommendations(
                 table.add_row(
                     str(row["id"]),
                     format_local_timestamp(row["timestamp"], date_only=True),
-                    row["parameter_path"],
-                    row["current_value"],
-                    row["recommended_value"],
+                    rich_escape(row["parameter_path"]),  # #650
+                    rich_escape(str(row["current_value"])),
+                    rich_escape(str(row["recommended_value"])),
                     f"[{conf_color}]{conf}[/{conf_color}]",
-                    row["analysis_type"],
+                    rich_escape(row["analysis_type"]),  # #650
                     f"[{status_color}]{row['status']}[/{status_color}]",
                 )
             console.print(table)
@@ -6112,11 +6121,14 @@ def tune() -> None:
                 conf_color = {"high": "red", "medium": "yellow", "low": "dim"}.get(conf, "white")
                 console.print(
                     f"\n[{conf_color}][{conf.upper()}][/{conf_color}] "
-                    f"[cyan]{row['parameter_path']}[/cyan]: "
-                    f"{row['current_value']} → [bold]{row['recommended_value']}[/bold]"
+                    f"[cyan]{rich_escape(row['parameter_path'])}[/cyan]: "
+                    f"{rich_escape(str(row['current_value']))} →"
+                    f" [bold]{rich_escape(str(row['recommended_value']))}[/bold]"
                 )
-                console.print(f"  {row['rationale']}")
-                console.print(f"  [dim]Analysis: {row['analysis_type']}[/dim]")
+                console.print(f"  {rich_escape(row['rationale'])}")
+                console.print(
+                    f"  [dim]Analysis: {rich_escape(row['analysis_type'])}[/dim]"
+                )
 
                 answer = typer.prompt("  Apply? [y/n/q]", default="n").strip().lower()
                 if answer == "q":
@@ -6410,7 +6422,7 @@ def config_set(
     try:
         setting, parsed = validate_config_value(key, value)
     except ValueError as e:
-        console.print(f"[red]Error: {e}[/red]")
+        console.print(f"[red]Error: {rich_escape(str(e))}[/red]")
         raise typer.Exit(1) from None
 
     overrides = _load_config_from_db(db_path)
@@ -6493,7 +6505,7 @@ def config_get(
         try:
             setting = resolve_setting(key)
         except ValueError as e:
-            console.print(f"[red]Error: {e}[/red]")
+            console.print(f"[red]Error: {rich_escape(str(e))}[/red]")
             raise typer.Exit(1) from None
 
         current = _get_current_value(overrides, key, setting.default)
@@ -6535,7 +6547,7 @@ def _resolve_list_field(key: str) -> tuple[Path, list]:
     try:
         setting = resolve_setting(key)
     except ValueError as e:
-        console.print(f"[red]Error: {e}[/red]")
+        console.print(f"[red]Error: {rich_escape(str(e))}[/red]")
         raise typer.Exit(1) from None
 
     if setting.type != "list":
@@ -6762,7 +6774,7 @@ def _set_mode(target: str) -> None:
     try:
         _update_env_var("GIMMES_MODE", target)
     except OSError as e:
-        console.print(f"[red]Error: Could not write to {ENV_FILE}: {e}[/red]")
+        console.print(f"[red]Error: Could not write to {ENV_FILE}: {rich_escape(str(e))}[/red]")
         raise typer.Exit(1)
 
     # Reload .env so load_config() in this process sees the change

--- a/src/gimmes/config_wizard.py
+++ b/src/gimmes/config_wizard.py
@@ -12,6 +12,7 @@ import typer
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.panel import Panel
 from rich.text import Text
 
@@ -261,7 +262,7 @@ def _prompt_setting(
     else:
         label = f"[bold]{setting.name}[/bold]"
     console.print(f"\n  {label}")
-    console.print(f"  Current value: [cyan]{display}[/cyan]")
+    console.print(f"  Current value: [cyan]{rich_escape(display)}[/cyan]")
 
     # Show description indented
     for line in setting.description.split("\n"):
@@ -282,7 +283,7 @@ def _prompt_setting(
         try:
             return _parse_input(raw, setting)
         except ValueError as e:
-            console.print(f"  [red]Invalid: {e}. Try again.[/red]")
+            console.print(f"  [red]Invalid: {rich_escape(str(e))}. Try again.[/red]")
 
 
 def _get_current_value(overrides: dict, dotted_key: str, default: object) -> object:
@@ -431,7 +432,7 @@ def run_config_wizard(
             if value_changed:
                 changed = True
                 display = _format_current(new_value, setting)
-                console.print(f"  [green]Updated to: {display}[/green]")
+                console.print(f"  [green]Updated to: {rich_escape(display)}[/green]")
 
     # Validate scoring weights if any were touched
     scoring_touched = section_filter is None or section_filter == "scoring"

--- a/src/gimmes/init.py
+++ b/src/gimmes/init.py
@@ -14,6 +14,7 @@ from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from rich.console import Console
+from rich.markup import escape as rich_escape
 
 from gimmes.config import DEFAULT_SERIES, GIMMES_HOME, config_keys_in_db, save_config_value
 
@@ -157,7 +158,7 @@ def _install_private_key(source: Path, password: bytes) -> Path | None:
     try:
         encrypted = _encrypt_private_key(content, password)
     except Exception as e:
-        console.print(f"[red]Failed to encrypt private key:[/red] {e}")
+        console.print(f"[red]Failed to encrypt private key:[/red] {rich_escape(str(e))}")
         return None
 
     KEYS_DIR.mkdir(exist_ok=True)
@@ -358,7 +359,7 @@ async def _verify_connection() -> bool:
         console.print("[green bold]Connection verified — credentials are working.[/green bold]")
         return True
     except Exception as e:
-        console.print(f"[red]Connection failed:[/red] {e}")
+        console.print(f"[red]Connection failed:[/red] {rich_escape(str(e))}")
         console.print("Check your API key and private key, then try [bold]gimmes mode[/bold].")
         return False
 

--- a/tests/unit/test_cli_markup_escape.py
+++ b/tests/unit/test_cli_markup_escape.py
@@ -180,3 +180,57 @@ def test_validate_failure_messages_brackets(tmp_path: Path) -> None:
     assert "determine]" in result.output
     # F6 (#644): the checks line and header ticker are escaped too.
     assert "[margin" in result.output
+
+
+def test_recommendations_table_brackets(tmp_path: Path) -> None:
+    """#650: Pro recommendation cells (parameter_path, values) are
+    DB text — bracket fragments must survive the table render."""
+    row = {
+        "id": 1, "timestamp": "2026-08-17 12:00:00",
+        "parameter_path": "p[exp]",
+        "current_value": "[auto]", "recommended_value": "[manual]",
+        "confidence": "high", "analysis_type": "win_rate",
+        "status": "pending",
+    }
+    with patch("gimmes.store.database.Database", MagicMock()), \
+         patch(
+             "gimmes.store.queries.get_recommendations",
+             AsyncMock(return_value=[row]),
+         ), patch("gimmes.cli.load_config", return_value=_config(tmp_path)):
+        result = runner.invoke(app, ["recommendations"])
+    assert "[exp]" in result.output, result.output
+    assert "[auto]" in result.output, result.output
+    assert "[manual]" in result.output, result.output
+    assert "\\[exp]" not in result.output
+
+
+def test_candidates_recommendation_cell_brackets(tmp_path: Path) -> None:
+    """#650: the candidates `recommendation` DB cell renders escaped."""
+    row = {
+        "ticker": "KXCPI-26APR-T0.5", "gimme_score": 70.0,
+        "market_price": 0.5, "model_probability": 0.6, "edge": 0.1,
+        "cap_blocked": 0, "recommendation": "proceed [shadow]",
+        "scanned_at": "2026-07-01 12:00:00",
+    }
+    with patch("gimmes.store.database.Database", MagicMock()), \
+         patch(
+             "gimmes.store.queries.get_candidate_for_ticker",
+             AsyncMock(return_value=[row]),
+         ), patch("gimmes.cli.load_config", return_value=_config(tmp_path)):
+        result = runner.invoke(
+            app, ["candidates", "--ticker", "KXCPI-26APR-T0.5"],
+        )
+    assert "[shadow]" in result.output, result.output
+    assert "\\[shadow]" not in result.output
+
+
+def test_config_set_error_brackets(tmp_path: Path) -> None:
+    """#650: ValueError text from config validation prints escaped."""
+    with patch(
+        "gimmes.config_wizard.validate_config_value",
+        side_effect=ValueError("unknown key [scanner.bogus]"),
+    ), patch("gimmes.cli.load_config", return_value=_config(tmp_path)):
+        result = runner.invoke(app, ["config", "set", "x", "1"])
+    assert result.exit_code == 1
+    assert "[scanner.bogus]" in result.output, result.output
+    assert "\\[scanner.bogus]" not in result.output


### PR DESCRIPTION
Closes #650.

The #644 follow-up batch — `rich_escape` applied at every remaining site that interpolates external/DB/exception text into Rich-markup prints or Table cells:

- **cli.py**: shared API error handler detail (`_api_error_detail` print sites — escape at display only, the raw text still goes to error-log rows); order-failure prints (both the HTTP-status and non-HTTP branches); market-info lookup failures (both the HTTPStatusError and RequestError branches — the latter embeds the user-supplied ticker via the request URL); validate's P&L / cost-basis guard prints; `Invalid --date/--from/--to` and the generic `Error: {e}` sites; env-file write failure; candidates `recommendation` cell; Pro recommendation prints and tables (parameter_path, values, rationale, analysis_type in both `recommendations` and `tune`).
- **config_wizard.py**: current/updated value displays and validation-error text (rich_escape newly imported).
- **backtest/report.py**: truncated chunk names.
- **init.py**: encrypt/connection failure exception prints.

## Tests
Three regressions in the #644 house pattern (bracket fragment survives + no-double-escape): Pro recommendations table cells, candidates recommendation cell, config-set ValueError text.

## Review
Correctness review (general-purpose agent substituting for the missing pr-review-toolkit) verified every escape is display-only (no DB writes or comparisons downstream) and caught **four sites the first sweep missed** — recommendations `analysis_type` cell, the market-info RequestError branch, the order non-HTTP failure branch, and the validate P&L/cost-basis guards — all fixed, plus the missing no-double-escape assertion. Frozen full-suite gate: **2533 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r