### PR TITLE
classifier_block skip reason: auto error row + terminal gate (#636)

### DIFF
--- a/.claude/agents/closer.md
+++ b/.claude/agents/closer.md
@@ -128,7 +128,7 @@ No validate or size step is needed — the order command validates that the posi
 
 ## Order Failure Protocol
 
-A permission-denied `gimmes order` (the command was blocked and never ran) counts as an order failure: log the `order_failed` skip exactly as below. That skip arms a CLI gate (#768) making the failure terminal for every session this cycle — CLI-enforced for BUY retries; SELL/CLOSE retries are not CLI-blocked (the close_failed backstop governs those) but remain forbidden by this protocol.
+A permission-denied `gimmes order` (the command was blocked by the permission/safety classifier and never ran) is logged with `--reason classifier_block`, NOT `order_failed` (#636) — the CLI auto-writes the `safety_classifier_block` error row Groundskeeper tracks, and the skip arms the same #768 terminal gate. `order_failed` means the command RAN and errored. Both classes are terminal for every session this cycle — CLI-enforced for BUY retries; SELL/CLOSE retries are not CLI-blocked (the close_failed backstop governs those) but remain forbidden by this protocol.
 
 An `Hourly shadow gate (#769)` rejection is the same FINAL class: the distance gate refused the entry even though validation passed. Log the `order_failed` skip citing the shadow gate, never retry or resize.
 

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4149,6 +4149,11 @@ _SKIP_REASONS = frozenset({
     "cooldown", "research_failed", "review_reject", "validation_failed",
     "order_failed", "close_failed", "no_position", "price_moved",
     "liquidity", "infra_failed", "already_traded", "order_canceled",
+    # #636: a permission/safety-classifier denial of a gimmes command.
+    # Distinct from order_failed (the CLI ran and errored) — the
+    # blocked command never ran, so this skip is the ONLY trace, and
+    # log-trade auto-writes the error_log row Groundskeeper needs.
+    "classifier_block",
     # #746: shed by the candidate cap / deadline protocol — not a
     # verdict on the candidate; it stays eligible next cycle.
     "deferred_capacity",
@@ -4363,14 +4368,51 @@ def log_trade(
                 )
             row_id = await insert_trade(db, trade)
             console.print(f"[green]Logged trade #{row_id}: {action} {ticker}[/green]")
-            # #768: an order_failed/order_canceled skip arms the CLI's
-            # terminal-attempt gate for this ticker for the rest of the
-            # cycle. This is the ONLY trace a permission-classifier
-            # denial leaves (the order command never ran), so the
-            # marker is machine-written here, post-insert. Best-effort:
+            # #768: an order_failed/order_canceled/classifier_block
+            # skip arms the CLI's terminal-attempt gate for this
+            # ticker for the rest of the cycle. The marker is
+            # machine-written here, post-insert. Best-effort:
             # log-trade is the logger of last resort and must never
             # exit nonzero because of the marker.
-            if action == "skip" and reason in ("order_failed", "order_canceled"):
+            # #636: a classifier block leaves no other error trail —
+            # machine-write the error row so Groundskeeper can track
+            # and escalate recurrences. Best-effort, same doctrine as
+            # the #768 marker below.
+            if action == "skip" and reason == "classifier_block":
+                from gimmes.models.error import (
+                    ErrorCategory,
+                    ErrorLogEntry,
+                    ErrorSeverity,
+                )
+                from gimmes.store.queries import _cycle_from_env
+                try:
+                    import json as _json
+
+                    await _log_cli_error(db, ErrorLogEntry(
+                        severity=ErrorSeverity.WARNING,
+                        category=ErrorCategory.AGENT_FAILURE,
+                        error_code="safety_classifier_block",
+                        component="cli.log-trade",
+                        agent=agent,
+                        cycle=_cycle_from_env(),
+                        message=(
+                            f"Classifier/permission block: {agent}"
+                            f" denied on {ticker} (#636)"
+                        ),
+                        context=_json.dumps({
+                            "ticker": ticker,
+                            "agent": agent,
+                            "side": resolved_side,
+                        }),
+                    ))
+                except sqlite3.Error:
+                    logging.getLogger(__name__).error(
+                        "classifier_block error row failed for %s (#636)",
+                        ticker, exc_info=True,
+                    )
+            if action == "skip" and reason in (
+                "order_failed", "order_canceled", "classifier_block",
+            ):
                 from gimmes.store.queries import (
                     _cycle_from_env,
                     _session_id_from_env,

--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -4405,7 +4405,10 @@ def log_trade(
                             "side": resolved_side,
                         }),
                     ))
-                except sqlite3.Error:
+                except Exception:
+                    # Broad on purpose: entry construction and JSON
+                    # serialization sit inside the try, and the skip
+                    # row must land whatever fails here (#636).
                     logging.getLogger(__name__).error(
                         "classifier_block error row failed for %s (#636)",
                         ticker, exc_info=True,

--- a/src/gimmes/strategy/advisor.py
+++ b/src/gimmes/strategy/advisor.py
@@ -214,6 +214,10 @@ NON_ENTRY_SKIP_REASONS = frozenset({
     # a missed entry double-counts the SAME candidate against the
     # cycle that actually decides it.
     "deferred_capacity",
+    # #636: a permission-classifier denial is a proceed that died to
+    # tooling (the infra_failed class) — not a candidate verdict, so
+    # it must not enter the missed-entry FNR numerator.
+    "classifier_block",
 })
 
 MIN_TRADES_THRESHOLD = 30

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3142,7 +3142,7 @@ def test_caddie_master_dispatch_templates_carry_agent_closer(
     )
 
 
-def test_closer_permission_denial_is_order_failure() -> None:
+def test_closer_permission_denial_is_classifier_block() -> None:
     closer_text = _CLOSER.read_text()
     assert "permission-denied `gimmes order`" in closer_text
     assert "arms the same #768 terminal gate" in closer_text

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -3145,8 +3145,8 @@ def test_caddie_master_dispatch_templates_carry_agent_closer(
 def test_closer_permission_denial_is_order_failure() -> None:
     closer_text = _CLOSER.read_text()
     assert "permission-denied `gimmes order`" in closer_text
-    assert "counts as an order failure" in closer_text
-    assert "arms a CLI gate (#768)" in closer_text
+    assert "arms the same #768 terminal gate" in closer_text
+    assert "Both classes are terminal for every session" in closer_text
     # BUY-only CLI scoping + the protocol prohibition that backstops
     # the unenforced SELL/CLOSE side — dropping either re-broadens or
     # weakens the claim (Copilot review on #770).
@@ -3357,3 +3357,16 @@ def test_caddie_entry_price_derivation(caddie_text: str) -> None:
     ) in caddie_text
     assert "MUST name the side and show the derivation" in caddie_text
     assert "**`--price` stays in YES terms.**" in caddie_text
+
+
+def test_closer_classifier_block_reason() -> None:
+    """#636: a permission-classifier denial logs classifier_block
+    (auto-writes the Groundskeeper error row), never order_failed —
+    order_failed means the command RAN and errored."""
+    closer_text = _CLOSER.read_text()
+    assert "`--reason classifier_block`" in closer_text
+    assert "NOT `order_failed` (#636)" in closer_text
+    assert "auto-writes the `safety_classifier_block` error row" in (
+        closer_text
+    )
+    assert "`order_failed` means the command RAN and errored" in closer_text

--- a/tests/unit/test_order_agent_gate.py
+++ b/tests/unit/test_order_agent_gate.py
@@ -467,6 +467,112 @@ class TestLogTradeTerminalMarker:
         assert len(_db_run(db_path, _rows)) == 1
 
 
+class TestClassifierBlockSkip:
+    """#636: a classifier_block skip is the only trace a permission
+    denial leaves — log-trade machine-writes BOTH the error row
+    (Groundskeeper's feed) and the #768 terminal marker."""
+
+    @staticmethod
+    async def _noop(db):
+        pass
+
+    def _log_skip(self, monkeypatch, tmp_path, *, cycle="42"):
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, self._noop)
+        _patch_config(monkeypatch, db_path)
+        if cycle is None:
+            monkeypatch.delenv("GIMMES_CYCLE", raising=False)
+        else:
+            monkeypatch.setenv("GIMMES_CYCLE", cycle)
+        result = runner.invoke(app, [
+            "log-trade", "KXTEST-26AUG-T1", "--action", "skip",
+            "--reason", "classifier_block", "--agent", "closer",
+        ])
+        return result, db_path
+
+    def _errors(self, db_path: Path) -> list[dict]:
+        async def _q(db):
+            cursor = await db.conn.execute(
+                "SELECT severity, category, error_code, cycle, context"
+                " FROM error_log WHERE error_code ="
+                " 'safety_classifier_block'"
+            )
+            return [dict(r) for r in await cursor.fetchall()]
+
+        return _db_run(db_path, _q)
+
+    def _markers(self, db_path: Path) -> list[dict]:
+        async def _q(db):
+            cursor = await db.conn.execute(
+                "SELECT cycle, message FROM activity_log"
+                " WHERE message LIKE 'Order attempt terminal:%'"
+            )
+            return [dict(r) for r in await cursor.fetchall()]
+
+        return _db_run(db_path, _q)
+
+    def test_writes_error_row_and_marker(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        result, db_path = self._log_skip(monkeypatch, tmp_path)
+        assert result.exit_code == 0, result.output
+        errors = self._errors(db_path)
+        assert len(errors) == 1
+        assert errors[0]["severity"] == "warning"
+        assert errors[0]["category"] == "agent_failure"
+        assert errors[0]["cycle"] == 42
+        assert "KXTEST-26AUG-T1" in errors[0]["context"]
+        markers = self._markers(db_path)
+        assert len(markers) == 1
+        assert markers[0]["cycle"] == 42
+
+    def test_error_row_written_even_without_cycle(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """The error trail must survive manual/off-cycle use; only
+        the marker (a cycle-scoped gate) requires GIMMES_CYCLE."""
+        result, db_path = self._log_skip(
+            monkeypatch, tmp_path, cycle=None,
+        )
+        assert result.exit_code == 0, result.output
+        assert len(self._errors(db_path)) == 1
+        assert self._markers(db_path) == []
+
+    def test_error_write_failure_still_logs_skip(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """Logger of last resort: the skip row lands and the command
+        exits 0 even if the error write fails."""
+        db_path = tmp_path / "gimmes.db"
+        _db_run(db_path, self._noop)
+        _patch_config(monkeypatch, db_path)
+        monkeypatch.setenv("GIMMES_CYCLE", "42")
+        monkeypatch.setattr(
+            cli_module, "_log_cli_error",
+            AsyncMock(side_effect=sqlite3.OperationalError("locked")),
+        )
+        result = runner.invoke(app, [
+            "log-trade", "KXTEST-26AUG-T1", "--action", "skip",
+            "--reason", "classifier_block", "--agent", "closer",
+        ])
+        assert result.exit_code == 0, result.output
+
+        async def _rows(db):
+            cursor = await db.conn.execute(
+                "SELECT ticker FROM trades WHERE action = 'skip'"
+            )
+            return [dict(r) for r in await cursor.fetchall()]
+
+        assert len(_db_run(db_path, _rows)) == 1
+
+    def test_non_entry_semantics(self) -> None:
+        """classifier_block joins the non-entry set — a proceed that
+        died to tooling must not enter the missed-entry FNR (#636)."""
+        from gimmes.strategy.advisor import NON_ENTRY_SKIP_REASONS
+
+        assert "classifier_block" in NON_ENTRY_SKIP_REASONS
+
+
 class TestHasTerminalOrderAttempt:
     """Round-trip on a real DB, including the 24h restart bound."""
 


### PR DESCRIPTION
Closes #636 (as rescoped in the 2026-08-12 triage — the observability half; the CM `--yes` fallback question was resolved by #768's identity gate).

## Gap
When the permission/safety classifier blocks a `gimmes order`, the command never runs — the Closer's skip is the ONLY trace, and nothing reaches `error_log`, so Groundskeeper cannot track or escalate recurrences. Observed cycle 1560 (KXPAYROLLS-26MAY close-out) and cycle 2255 (KXPAYROLLS-26AUG new-entry, skip #32087 in the skip log only).

## Fix
- New `classifier_block` skip reason in `_SKIP_REASONS`, distinct from `order_failed` (which now unambiguously means the command RAN and errored).
- `log-trade --action skip --reason classifier_block` machine-writes a `safety_classifier_block` error row (WARNING / AGENT_FAILURE, agent + cycle stamped, ticker/agent/side in context) — best-effort, logger-of-last-resort doctrine: the skip row always lands and the command exits 0 even if the error write fails. Groundskeeper's `(error_code, component)` recurrence tracking now sees every block.
- The skip arms the existing #768 terminal-attempt marker (reason tuple extended) — a blocked order stays terminal for the cycle.
- `classifier_block` joins `NON_ENTRY_SKIP_REASONS`: a proceed that died to tooling is not a candidate verdict and must not enter the missed-entry FNR (the `infra_failed` class); it keeps honest zeros instead of inheriting candidate analytics (#657 path verified).
- closer.md Order Failure Protocol rewritten to route permission denials to `classifier_block`.

## Tests
`TestClassifierBlockSkip` (4): error row + marker with GIMMES_CYCLE; error row still written WITHOUT cycle (only the cycle-scoped marker is gated on env); best-effort failure path (skip row lands, exit 0); non-entry membership. Prompt pins updated (`test_closer_classifier_block_reason`; the old #768 pin re-anchored to the new wording).

## Review
Correctness review APPROVE (verified `_log_cli_error` self-commits, the #657 elif keeps honest zeros for the new reason, advisor identity-assert covers the set alias, no other `_SKIP_REASONS` consumer shifts; their agent-field nit applied). Frozen full-suite gate: **2538 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r