### PR TITLE
MarketStatus.UNKNOWN sentinel: enum drift degrades, never aborts (#787)

### DIFF
--- a/src/gimmes/kalshi/markets.py
+++ b/src/gimmes/kalshi/markets.py
@@ -2,8 +2,31 @@
 
 from __future__ import annotations
 
+import logging
+
 from gimmes.kalshi.client import KalshiClient
 from gimmes.models.market import Market, MarketStatus, Orderbook, OrderbookLevel
+
+logger = logging.getLogger(__name__)
+
+# #787: warn once per unseen status string per process — a drifted
+# status appears on every market of its class in every scan page.
+_warned_statuses: set[str] = set()
+
+
+def _parse_status(raw: str) -> MarketStatus:
+    """Map an API status string to the enum; drift degrades to
+    UNKNOWN (untradeable, unsettled) instead of aborting the scan."""
+    try:
+        return MarketStatus(raw)
+    except ValueError:
+        if raw not in _warned_statuses:
+            _warned_statuses.add(raw)
+            logger.warning(
+                "Unknown Kalshi market status %r — treating as"
+                " UNKNOWN (untradeable); enum drift, see #787", raw,
+            )
+        return MarketStatus.UNKNOWN
 
 
 def _dollars_field(data: dict, key: str) -> float:  # type: ignore[type-arg]
@@ -32,7 +55,7 @@ def parse_market(data: dict) -> Market:  # type: ignore[type-arg]
         series_ticker=data.get("series_ticker", ""),
         title=data.get("title", ""),
         subtitle=data.get("subtitle") or "",  # explicit null → "" (#641, same class as #574)
-        status=MarketStatus(data.get("status", "active")),
+        status=_parse_status(data.get("status", "active")),
         yes_bid=_dollars_field(data, "yes_bid"),
         yes_ask=_dollars_field(data, "yes_ask"),
         no_bid=_dollars_field(data, "no_bid"),

--- a/src/gimmes/kalshi/markets.py
+++ b/src/gimmes/kalshi/markets.py
@@ -14,14 +14,20 @@ logger = logging.getLogger(__name__)
 _warned_statuses: set[str] = set()
 
 
-def _parse_status(raw: str) -> MarketStatus:
-    """Map an API status string to the enum; drift degrades to
-    UNKNOWN (untradeable, unsettled) instead of aborting the scan."""
+def _parse_status(raw: object) -> MarketStatus:
+    """Map an API status value to the enum; drift degrades to
+    UNKNOWN (untradeable, unsettled) instead of aborting the scan.
+
+    Accepts object, not str: an explicit JSON null arrives as None,
+    and enum lookup raises ValueError for ANY non-member value
+    (None, int, list included — verified empirically, #787 review).
+    """
     try:
         return MarketStatus(raw)
     except ValueError:
-        if raw not in _warned_statuses:
-            _warned_statuses.add(raw)
+        key = repr(raw)
+        if key not in _warned_statuses:
+            _warned_statuses.add(key)
             logger.warning(
                 "Unknown Kalshi market status %r — treating as"
                 " UNKNOWN (untradeable); enum drift, see #787", raw,

--- a/src/gimmes/models/market.py
+++ b/src/gimmes/models/market.py
@@ -24,6 +24,13 @@ class MarketStatus(StrEnum):
     DISPUTED = "disputed"
     AMENDED = "amended"
     FINALIZED = "finalized"
+    # #787: parse-time sentinel for API status strings this enum
+    # doesn't know yet. Never sent by Kalshi — assigned by
+    # parse_market so one drifted market degrades instead of
+    # aborting the whole scan. UNTRADEABLE_STATUSES (set difference
+    # below) absorbs it automatically, so it fails closed at the
+    # #784 order gate and stays outside SETTLED_STATUSES.
+    UNKNOWN = "unknown"
 
 
 # #784: markets where an order can execute vs not. Kalshi matches

--- a/tests/unit/test_market_status_drift.py
+++ b/tests/unit/test_market_status_drift.py
@@ -23,6 +23,17 @@ def test_unknown_status_parses_to_sentinel() -> None:
     assert m.status is MarketStatus.UNKNOWN
 
 
+def test_null_and_nonstring_status_degrade() -> None:
+    """#787 review: an explicit JSON null (data.get returns None) and
+    any non-string garbage take the same ValueError path — enum
+    lookup raises ValueError for every non-member value."""
+    assert parse_market({"ticker": "T", "status": None}).status is (
+        MarketStatus.UNKNOWN
+    )
+    assert _parse_status(42) is MarketStatus.UNKNOWN
+    assert _parse_status(["active"]) is MarketStatus.UNKNOWN
+
+
 def test_known_statuses_still_parse() -> None:
     for member in MarketStatus:
         if member is MarketStatus.UNKNOWN:
@@ -36,7 +47,7 @@ def test_unknown_fails_closed_everywhere() -> None:
 
 
 def test_warns_once_per_status_string(caplog) -> None:
-    _warned_statuses.discard("halted")
+    _warned_statuses.discard(repr("halted"))
     with caplog.at_level(logging.WARNING, logger="gimmes.kalshi.markets"):
         _parse_status("halted")
         _parse_status("halted")

--- a/tests/unit/test_market_status_drift.py
+++ b/tests/unit/test_market_status_drift.py
@@ -1,0 +1,45 @@
+"""#787: one enum-drift market must degrade, not abort the scan.
+
+parse_market maps unknown API status strings to the UNKNOWN
+sentinel, which the set-difference construction of
+UNTRADEABLE_STATUSES absorbs automatically — everything downstream
+fails closed (#784 order gate refuses; log-outcome guard refuses).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from gimmes.kalshi.markets import _parse_status, _warned_statuses, parse_market
+from gimmes.models.market import (
+    SETTLED_STATUSES,
+    UNTRADEABLE_STATUSES,
+    MarketStatus,
+)
+
+
+def test_unknown_status_parses_to_sentinel() -> None:
+    m = parse_market({"ticker": "KXTEST-26AUG-T1", "status": "paused"})
+    assert m.status is MarketStatus.UNKNOWN
+
+
+def test_known_statuses_still_parse() -> None:
+    for member in MarketStatus:
+        if member is MarketStatus.UNKNOWN:
+            continue
+        assert _parse_status(member.value) is member
+
+
+def test_unknown_fails_closed_everywhere() -> None:
+    assert MarketStatus.UNKNOWN in UNTRADEABLE_STATUSES
+    assert MarketStatus.UNKNOWN not in SETTLED_STATUSES
+
+
+def test_warns_once_per_status_string(caplog) -> None:
+    _warned_statuses.discard("halted")
+    with caplog.at_level(logging.WARNING, logger="gimmes.kalshi.markets"):
+        _parse_status("halted")
+        _parse_status("halted")
+    hits = [r for r in caplog.records if "halted" in r.getMessage()]
+    assert len(hits) == 1
+    assert "#787" in hits[0].getMessage()


### PR DESCRIPTION
Closes #787.

## Bug
`parse_market` did `MarketStatus(data.get("status", "active"))` — a ValueError on any status string the enum lacks. One drifted market aborts the entire `gimmes scan` (no error row), and `get_market` in the order path exits without an error row or terminal marker. Found during the #784 review.

## Fix
- New `MarketStatus.UNKNOWN = "unknown"` sentinel — never sent by Kalshi; assigned only by the parser.
- `_parse_status` maps unknown strings to UNKNOWN with a once-per-string process-level warning (a drifted status appears on every market of its class in every scan page).
- Fails closed everywhere by construction: `UNTRADEABLE_STATUSES = frozenset(MarketStatus) - {ACTIVE}` absorbs the new member automatically (the #784 order gate's parametrized test picks it up with zero changes), the scanner's `!= ACTIVE` filter excludes drifted markets from candidates, the validator rejects, and `SETTLED_STATUSES` is unchanged so the #760 log-outcome guard refuses.
- Bonus: an explicit JSON-null status (previously an uncaught `MarketStatus(None)` crash) now degrades through the same path.

## Tests
`test_market_status_drift.py`: parse→sentinel via full parse_market; round-trip of every non-sentinel member; fail-closed set membership; once-per-string warning with the #787 marker.

## Review
Correctness review APPROVE — swept every `MarketStatus`/`market.status` consumer in src/ (order gate, validator, scanner filter, settle sweeps, prune, rendering, backtest, DB storage): none breaks, no exhaustive matches or member-count assertions anywhere. Frozen full-suite gate: **2543 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r