### PR TITLE
No-op the failure backoff sleep in loop tests (#788)

### DIFF
--- a/tests/unit/test_autonomous_loop.py
+++ b/tests/unit/test_autonomous_loop.py
@@ -135,6 +135,13 @@ class TestAutonomousLoop:
                 "gimmes.cli._check_remote_staleness",
                 return_value=None,
             ),
+            # #788: _apply_failure_backoff sleeps 30*2^(n-1)s (cap
+            # 240) for REAL between failures — this file alone was
+            # 961s of every ~976s frozen gate, and the default-five
+            # breaker test slept 450s, indistinguishable from a
+            # hang. No-op at the fixture level; tests that need
+            # sleep behavior override with their own inner patch.
+            patch("gimmes.cli._resilient_sleep"),
         ):
             yield
 
@@ -988,7 +995,12 @@ class TestAutonomousLoop:
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch("subprocess.Popen", return_value=mock_proc),
             patch("os.killpg") as mock_killpg,
-            patch("time.sleep", side_effect=KeyboardInterrupt),
+            # #788: the autouse fixture no-ops _resilient_sleep, so
+            # the interrupt must come from the sleep seam itself.
+            patch(
+                "gimmes.cli._resilient_sleep",
+                side_effect=KeyboardInterrupt,
+            ),
             patch("gimmes.clubhouse.server.start_background", return_value=None),
         ):
             _autonomous_loop("driving_range", pause_seconds=60)


### PR DESCRIPTION
Closes #788.

## Root cause (differs from the issue's hypothesis)
The reported "wall-clock-dependent hang" was not the hourly-window clock path (that lane is inert under default config — `hourly_series` defaults empty). It was `_apply_failure_backoff` doing REAL `_resilient_sleep(min(30·2^(n−1), 240))` between failure cycles: `test_circuit_breaker_default_is_five` slept 30+60+120+240 = **450 seconds** — indistinguishable from a hang when a run is killed mid-backoff — and the breaker/failure-path tests together made `test_autonomous_loop.py` account for **961.72s of every ~976s frozen gate**.

## Fix
- `TestAutonomousLoop`'s autouse fixture now includes `patch("gimmes.cli._resilient_sleep")`. Tests needing sleep behavior (KeyboardInterrupt spurs, backoff call assertions) still govern via their own inner patches — mock.patch nesting verified.
- The Ctrl+C-during-sleep test raised its interrupt from `time.sleep` inside real `_resilient_sleep`; under the no-op that never runs, so it now raises from the `_resilient_sleep` seam directly — same production path pinned (interrupt during between-cycle sleep → no killpg on an exited process), one frame higher and more precise.

## Result
File runtime **961.72s → 1.50s** (192 passed). Full frozen gate **16:16 → 15.58s** (2544 passed) — verified on this branch's gate run.

## Review
Correctness review APPROVE: no test asserts sleep timing or call values that the no-op hides; inner-patch override semantics confirmed empirically; all other classes in the file use success-path cycles or patch the sleep per-test; backoff routing is still pinned by TestApiErrorLoopIntegration's `assert_any_call(30)` (noted gap: the 60/120/240 ladder values are unasserted — pre-existing, out of scope).

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r