### PR TITLE
Championship close-row true-up on reconcile (#698)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3664,7 +3664,208 @@ async def _sweep_resting_paper_orders(broker, client, db, *, config, quiet: bool
     return filled
 
 
+_REPAIR_MAX_ORDERS = 20
+_REPAIR_MAX_PAGES = 3
+
+
+async def _repair_championship_close_rows(client, db) -> None:  # type: ignore[no-untyped-def]
+    """#698: converge each order's close ledger to Kalshi fill truth.
+
+    Championship resting sells drift from the ledger in both
+    directions: a canceled/never-filled order leaves rows for an exit
+    that never traded (annul/shrink, #690 semantics), and fills that
+    land AFTER placement are never logged (#744 logs only the
+    placement-time fill) — append the delta at the fill-weighted
+    price. Runs BEFORE settlement consumption so the #663 residual
+    math sees the trued-up ledger; a ticker/side that already has a
+    settlement close is never touched (double-count guard). Reruns
+    converge to a no-op: the target is ledger sum == fills sum per
+    order_id.
+    """
+    import json as _json
+    import logging
+
+    from gimmes.kalshi.orders import list_fills, list_orders
+    from gimmes.models.error import (
+        ErrorCategory,
+        ErrorLogEntry,
+        ErrorSeverity,
+    )
+    from gimmes.models.order import OrderAction
+    from gimmes.models.trade import TradeDecision
+    from gimmes.store.queries import (
+        annul_close_rows,
+        get_close_order_ledger,
+        get_entry_analytics,
+        has_settlement_close,
+        insert_trade,
+        shrink_newest_close_row,
+    )
+
+    _log = logging.getLogger(__name__)
+
+    async def _audit(code: str, message: str, context: dict) -> None:  # type: ignore[type-arg]
+        await _log_cli_error(db, ErrorLogEntry(
+            severity=ErrorSeverity.WARNING,
+            category=ErrorCategory.DATA_INTEGRITY,
+            error_code=code,
+            component="cli.reconcile",
+            message=message,
+            context=_json.dumps(context),
+        ))
+
+    ledger = {r["order_id"]: r for r in await get_close_order_ledger(db)}
+
+    # Currently-resting sells: append candidates for post-placement
+    # fills, and the never-annul guard — a live order may still fill.
+    resting: set[str] = set()
+    appends: dict = {}
+    cursor = None
+    for _ in range(_REPAIR_MAX_PAGES):
+        orders, cursor = await list_orders(
+            client, status="resting", cursor=cursor,
+        )
+        for o in orders:
+            resting.add(o.order_id)
+            if o.action is OrderAction.SELL and o.order_id not in ledger:
+                appends[o.order_id] = {
+                    "order_id": o.order_id, "ticker": o.ticker,
+                    "side": o.side.value, "agent": "reconcile",
+                    "ledger_count": 0,
+                }
+        if not cursor:
+            break
+    # A truncated resting read means `oid in resting` is not a safe
+    # never-annul guard — shrink/annul is disabled for the run.
+    resting_complete = not cursor  # "" and None both mean last page
+
+    # Append-only candidates first (new work by construction), then
+    # ledger orders newest-first — converged veterans must not
+    # starve them out of the fills-call cap.
+    candidates = {**appends, **ledger}
+    if not candidates:
+        return
+    if len(candidates) > _REPAIR_MAX_ORDERS:
+        _log.warning(
+            "#698 repair: %d candidate orders, capping at %d",
+            len(candidates), _REPAIR_MAX_ORDERS,
+        )
+        candidates = dict(list(candidates.items())[:_REPAIR_MAX_ORDERS])
+
+    for oid, row in candidates.items():
+        fills = []
+        f_cursor = None
+        for _ in range(2):
+            page, f_cursor = await list_fills(
+                client, order_id=oid, cursor=f_cursor,
+            )
+            fills.extend(page)
+            if not f_cursor:
+                break
+        filled = sum(f.count for f in fills)
+        ledger_count = int(row["ledger_count"])
+        if filled == ledger_count:
+            continue
+        ticker, side = row["ticker"], row["side"]
+        if f_cursor:
+            # Truncated fills read: `filled` is a floor, not a total.
+            # Repairing on it would shrink genuine close history.
+            await _audit(
+                "close_repair_manual",
+                f"#698: fills for {oid} on {ticker} exceed the page"
+                f" cap — read {filled} of an unknown total; left"
+                f" untouched",
+                {"order_id": oid, "ticker": ticker,
+                 "ledger": ledger_count, "filled_floor": filled},
+            )
+            continue
+        if await has_settlement_close(db, ticker, side):
+            await _audit(
+                "close_repair_settlement_owns",
+                f"#698: {ticker} ledger/fill mismatch on {oid}"
+                f" (ledger {ledger_count}, filled {filled}) but"
+                f" settlement already closed the position — left"
+                f" untouched",
+                {"order_id": oid, "ticker": ticker,
+                 "ledger": ledger_count, "filled": filled},
+            )
+            continue
+
+        if ledger_count > filled:
+            if not resting_complete:
+                continue  # cannot prove the order is not still live
+            if oid in resting:
+                continue  # still live — may yet fill
+            marker = (
+                f" [#698 repair: order {oid} terminal with"
+                f" {filled} filled of {ledger_count} logged]"
+            )
+            if filled == 0:
+                repaired = bool(await annul_close_rows(db, oid, marker))
+            else:
+                repaired = await shrink_newest_close_row(
+                    db, oid, ledger_count - filled, marker,
+                )
+            if not repaired:
+                await _audit(
+                    "close_repair_manual",
+                    f"#698: could not auto-repair {oid} on"
+                    f" {ticker} (multi-row overstatement:"
+                    f" ledger {ledger_count}, filled {filled})",
+                    {"order_id": oid, "ticker": ticker,
+                     "ledger": ledger_count, "filled": filled},
+                )
+                continue
+        else:
+            delta = filled - ledger_count
+            # Attribute the delta to the newest fills (the unlogged
+            # ones), weighting the exit price accordingly.
+            remaining, cost = delta, 0.0
+            for f in sorted(
+                fills, key=lambda f: str(f.created_time or ""),
+                reverse=True,
+            ):
+                take = min(remaining, f.count)
+                price_f = f.no_price if side == "no" else f.yes_price
+                cost += take * price_f
+                remaining -= take
+                if remaining <= 0:
+                    break
+            price = round(cost / delta, 4) if delta else 0.0
+            trade = TradeDecision(
+                ticker=ticker,
+                action=TradeDecision.Action.CLOSE,
+                side=side,
+                count=delta,
+                price=price,
+                model_probability=0.0,
+                rationale=(
+                    f"resting-sell fill true-up on reconcile (#698):"
+                    f" {delta} filled after placement"
+                ),
+                agent=row["agent"] or "reconcile",
+                order_id=oid,
+            )
+            entry = await get_entry_analytics(db, ticker, side)
+            if entry:
+                trade.model_probability = entry["model_probability"]
+                trade.edge = entry["edge"]
+                trade.kelly_fraction = entry["kelly_fraction"]
+                trade.gimme_score = entry["gimme_score"]
+            await insert_trade(db, trade)
+
+        await _audit(
+            "close_row_repaired",
+            f"#698: trued up {ticker} order {oid} — ledger"
+            f" {ledger_count} -> filled {filled}",
+            {"order_id": oid, "ticker": ticker,
+             "ledger": ledger_count, "filled": filled},
+        )
+
+
+
 @app.command(rich_help_panel="Portfolio")
+
 def reconcile() -> None:
     """Sync local position data with the authoritative source.
 
@@ -3707,6 +3908,18 @@ def reconcile() -> None:
             # <= 0 and skips). Any settlements-API failure degrades
             # to today's drift behavior — reconcile is never blocked.
             if not broker:
+                # #698: true up per-order close rows from fill truth
+                # BEFORE settlements consume residuals. Best-effort —
+                # reconcile is never blocked (same contract as #663).
+                try:
+                    await _repair_championship_close_rows(client, db)
+                except Exception:
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).error(
+                        "#698 close-row repair failed; continuing"
+                        " reconcile", exc_info=True,
+                    )
                 await _consume_settlements_before_sync(
                     client, db, fresh, old_tickers=old_tickers,
                 )

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -455,6 +455,86 @@ def settlement_outcome(side: str, won: bool) -> str:
     return "no" if side == "yes" else "yes"
 
 
+async def get_close_order_ledger(db: Database) -> list[dict]:  # type: ignore[type-arg]
+    """Per-order close ledger for the championship true-up (#698).
+
+    Groups non-settlement ``action='close'`` rows that carry an
+    order_id, restricted to the repair window: tickers that still
+    have a positions row, or rows younger than 7 days. Settled
+    history beyond that is owned by the settlement path.
+    """
+    cursor = await db.conn.execute(
+        """SELECT order_id,
+                  MAX(ticker) AS ticker,
+                  MAX(side) AS side,
+                  MAX(agent) AS agent,
+                  SUM(count) AS ledger_count
+           FROM trades
+           WHERE action = 'close' AND order_id != ''
+             AND agent != 'settlement'
+             AND (
+               ticker IN (SELECT ticker FROM positions)
+               OR timestamp >= datetime('now', '-7 days')
+             )
+           GROUP BY order_id
+           ORDER BY MAX(id) DESC"""
+    )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def annul_close_rows(db: Database, order_id: str, marker: str) -> int:
+    """#698 (reusing the #690 shape): annul every close row of a
+    terminal never-filled order — append-only ledger, no DELETE.
+    ``reason='order_canceled'`` keeps the rows out of residual math
+    (count_opened_closed sums open/size_up/close only) and out of
+    the missed-entry FNR (NON_ENTRY_SKIP_REASONS)."""
+    cursor = await db.conn.execute(
+        """UPDATE trades SET action = 'skip',
+           reason = 'order_canceled',
+           rationale = rationale || ?
+           WHERE order_id = ? AND action = 'close'""",
+        (marker, order_id),
+    )
+    await db.conn.commit()
+    return cursor.rowcount
+
+
+async def shrink_newest_close_row(
+    db: Database, order_id: str, excess: int, marker: str,
+) -> bool:
+    """#698: shrink the newest close row of a partially-filled
+    terminal order by the unfilled excess. Returns False when the
+    newest row is smaller than the excess (multi-row overstatement —
+    warned by the caller, left for manual repair)."""
+    cursor = await db.conn.execute(
+        """SELECT id, count FROM trades
+           WHERE order_id = ? AND action = 'close'
+           ORDER BY id DESC LIMIT 1""",
+        (order_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None or int(row["count"]) < excess:
+        return False
+    if int(row["count"]) == excess:
+        await db.conn.execute(
+            """UPDATE trades SET action = 'skip',
+               reason = 'order_canceled',
+               rationale = rationale || ?
+               WHERE id = ?""",
+            (marker, row["id"]),
+        )
+    else:
+        await db.conn.execute(
+            """UPDATE trades SET count = count - ?,
+               rationale = rationale || ?
+               WHERE id = ?""",
+            (excess, marker, row["id"]),
+        )
+    await db.conn.commit()
+    return True
+
+
 async def has_settlement_close(
     db: Database, ticker: str, side: str
 ) -> bool:

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -474,7 +474,7 @@ async def get_close_order_ledger(db: Database) -> list[dict]:  # type: ignore[ty
              AND agent != 'settlement'
              AND (
                ticker IN (SELECT ticker FROM positions)
-               OR timestamp >= datetime('now', '-7 days')
+               OR datetime(timestamp) >= datetime('now', '-7 days')
              )
            GROUP BY order_id
            ORDER BY MAX(id) DESC"""

--- a/tests/unit/test_cli_reconcile_order_repair.py
+++ b/tests/unit/test_cli_reconcile_order_repair.py
@@ -1,0 +1,365 @@
+"""Championship reconcile trues up per-order close rows (#698).
+
+Two drift directions, one convergence target (ledger sum == Kalshi
+fill sum per order_id): a canceled/never-filled resting sell leaves
+close rows for an exit that never traded (annul/shrink, #690
+semantics); fills landing AFTER placement are never logged (#744
+logs only the placement-time fill) — append the delta at the
+fill-weighted price. A ticker/side with an agent='settlement' close
+is never touched, and a still-resting order is never annulled.
+
+Synchronous CLI tests (asyncio.run for setup) — CliRunner drives the
+command's own asyncio.run, which cannot nest (#663 pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.kalshi import orders as orders_module
+from gimmes.kalshi import portfolio as portfolio_module
+from gimmes.models.order import Fill, Order, OrderAction, OrderSide
+from gimmes.models.portfolio import Position
+from gimmes.models.trade import TradeDecision
+from gimmes.store.database import Database
+from gimmes.store.queries import insert_trade, upsert_position
+
+runner = CliRunner()
+
+TICKER = "KXCPI-26APR-T0.5"
+OID = "ord-698-1"
+
+
+def _fill(count: int, no_price: float, created: str) -> Fill:
+    return Fill(
+        trade_id=f"t-{created}", order_id=OID, ticker=TICKER,
+        action=OrderAction.SELL, side=OrderSide.NO, count=count,
+        yes_price=round(1 - no_price, 4), no_price=no_price,
+        created_time=created, is_taker=False,
+    )
+
+
+def _resting_order(remaining: int = 40) -> Order:
+    return Order(
+        order_id=OID, ticker=TICKER, action=OrderAction.SELL,
+        side=OrderSide.NO, status="resting", yes_price=0.1,
+        no_price=0.9, count=100, remaining_count=remaining,
+        created_time="2026-08-17T10:00:00Z", client_order_id="c1",
+    )
+
+
+def _seed(
+    db_path: Path, *, close_count: int | None = 100,
+    close_agent: str = "closer", keep_position: bool = True,
+    settlement_close: bool = False,
+) -> None:
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            await insert_trade(db, TradeDecision(
+                ticker=TICKER, action=TradeDecision.Action.OPEN,
+                side="no", count=100, price=0.63,
+                model_probability=0.8, agent="closer",
+            ))
+            if close_count is not None:
+                await insert_trade(db, TradeDecision(
+                    ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                    side="no", count=close_count, price=0.9,
+                    agent=close_agent, order_id=OID,
+                ))
+            if settlement_close:
+                await insert_trade(db, TradeDecision(
+                    ticker=TICKER, action=TradeDecision.Action.CLOSE,
+                    side="no", count=100, price=1.0,
+                    agent="settlement",
+                ))
+            if keep_position:
+                await upsert_position(db, Position(
+                    ticker=TICKER, title="CPI", side="no", count=100,
+                    avg_price=0.63, market_price=0.7,
+                    cost_basis=63.0, market_value=70.0,
+                    unrealized_pnl=7.0, realized_pnl=0.0,
+                ))
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch, db_path: Path, *,
+    resting: list[Order] = [], fills: list[Fill] = [],
+    fills_error: bool = False, fills_cursor: str | None = None,
+) -> None:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.is_championship = True
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    @asynccontextmanager
+    async def _ctx(_config):  # type: ignore[no-untyped-def]
+        db = Database(db_path)
+        await db.connect()
+        try:
+            yield MagicMock(), None, db
+        finally:
+            await db.close()
+
+    monkeypatch.setattr(cli_module, "trading_context", _ctx)
+
+    async def _no_positions(_client):  # type: ignore[no-untyped-def]
+        return []
+
+    monkeypatch.setattr(
+        portfolio_module, "get_all_positions", _no_positions,
+    )
+
+    async def _no_settlements(_client, _tickers, **_kw):  # type: ignore[no-untyped-def]
+        return {}
+
+    monkeypatch.setattr(
+        portfolio_module, "get_settlements_for_tickers",
+        _no_settlements,
+    )
+
+    async def _list_orders(_client, **_kw):  # type: ignore[no-untyped-def]
+        # Kalshi returns "" (not a missing field) on the last page —
+        # the completeness check must treat both as complete (#698
+        # review: `cursor is None` would have disabled shrink/annul
+        # on every production run).
+        return resting, ""
+
+    monkeypatch.setattr(orders_module, "list_orders", _list_orders)
+
+    async def _list_fills(_client, **_kw):  # type: ignore[no-untyped-def]
+        if fills_error:
+            raise RuntimeError("fills endpoint down")
+        return fills, fills_cursor
+
+    monkeypatch.setattr(orders_module, "list_fills", _list_fills)
+
+
+def _rows(db_path: Path) -> list[dict]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT action, reason, count, price, agent, order_id,"
+        " rationale FROM trades WHERE ticker = ? ORDER BY id",
+        (TICKER,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _errors(db_path: Path, code: str) -> list[dict]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT error_code, context FROM error_log"
+        " WHERE error_code = ?", (code,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def test_canceled_never_filled_annulled(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=100)
+    _wire(monkeypatch, db_path, resting=[], fills=[])
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [r for r in _rows(db_path) if r["order_id"] == OID]
+    assert len(closes) == 1
+    assert closes[0]["action"] == "skip"
+    assert closes[0]["reason"] == "order_canceled"
+    assert "#698 repair" in closes[0]["rationale"]
+    assert len(_errors(db_path, "close_row_repaired")) == 1
+
+
+def test_partial_fill_shrinks_newest_row(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=100)
+    _wire(
+        monkeypatch, db_path, resting=[],
+        fills=[_fill(60, 0.9, "2026-08-17T10:01:00Z")],
+    )
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [
+        r for r in _rows(db_path)
+        if r["order_id"] == OID and r["action"] == "close"
+    ]
+    assert len(closes) == 1
+    assert closes[0]["count"] == 60
+    assert closes[0]["price"] == 0.9
+
+
+def test_post_placement_fills_appended(monkeypatch, tmp_path) -> None:
+    """Ledger logged 40 at placement but 100 filled: the 60
+    post-placement contracts get a delta row at the fill-weighted
+    price, inheriting entry analytics (#656 pattern)."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=40)
+    _wire(
+        monkeypatch, db_path, resting=[],
+        fills=[
+            _fill(40, 0.9, "2026-08-17T10:00:01Z"),
+            _fill(40, 0.91, "2026-08-17T10:05:00Z"),
+            _fill(20, 0.92, "2026-08-17T10:06:00Z"),
+        ],
+    )
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [
+        r for r in _rows(db_path)
+        if r["order_id"] == OID and r["action"] == "close"
+    ]
+    assert len(closes) == 2
+    delta = closes[1]
+    assert delta["count"] == 60
+    # newest-first attribution: 20 @ 0.92 + 40 @ 0.91
+    assert delta["price"] == round((20 * 0.92 + 40 * 0.91) / 60, 4)
+    assert delta["agent"] == "closer"
+    assert "#698" in delta["rationale"]
+
+
+def test_still_resting_never_annulled(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=100)
+    _wire(monkeypatch, db_path, resting=[_resting_order()], fills=[])
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [r for r in _rows(db_path) if r["order_id"] == OID]
+    assert closes[0]["action"] == "close"
+    assert closes[0]["count"] == 100
+
+
+def test_settlement_close_never_touched(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=100, settlement_close=True)
+    _wire(monkeypatch, db_path, resting=[], fills=[])
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [r for r in _rows(db_path) if r["order_id"] == OID]
+    assert closes[0]["action"] == "close"
+    assert len(_errors(db_path, "close_repair_settlement_owns")) == 1
+
+
+def test_idempotent_second_run(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=40)
+    fills = [
+        _fill(40, 0.9, "2026-08-17T10:00:01Z"),
+        _fill(60, 0.91, "2026-08-17T10:05:00Z"),
+    ]
+    _wire(monkeypatch, db_path, resting=[], fills=fills)
+    assert runner.invoke(app, ["reconcile"]).exit_code == 0
+    first = _rows(db_path)
+    assert runner.invoke(app, ["reconcile"]).exit_code == 0
+    assert _rows(db_path) == first
+    assert len(_errors(db_path, "close_row_repaired")) == 1
+
+
+def test_fills_failure_degrades(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=100)
+    _wire(monkeypatch, db_path, resting=[], fills=[], fills_error=True)
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [r for r in _rows(db_path) if r["order_id"] == OID]
+    assert closes[0]["action"] == "close"  # untouched, not blocked
+
+
+def test_paper_mode_repair_not_called(monkeypatch, tmp_path) -> None:
+    """broker set -> the repair pass must never run (#255/#690 own
+    the paper side)."""
+    called = False
+
+    async def _spy(client, db):  # type: ignore[no-untyped-def]
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        cli_module, "_repair_championship_close_rows", _spy,
+    )
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=None)
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    cfg.is_championship = False
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    @asynccontextmanager
+    async def _ctx(_config):  # type: ignore[no-untyped-def]
+        db = Database(db_path)
+        await db.connect()
+        try:
+            broker = MagicMock()
+
+            async def _pos():
+                return []
+
+            broker.get_positions = _pos
+            yield MagicMock(), broker, db
+        finally:
+            await db.close()
+
+    monkeypatch.setattr(cli_module, "trading_context", _ctx)
+
+    async def _sweep(*a, **kw):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(
+        cli_module, "_sweep_resting_paper_orders", _sweep,
+    )
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert called is False
+
+
+def test_truncated_fills_never_repair(monkeypatch, tmp_path) -> None:
+    """A fills read that still has a cursor is a floor, not a total —
+    shrinking on it would delete genuine close history."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=100)
+    _wire(
+        monkeypatch, db_path, resting=[],
+        fills=[_fill(60, 0.9, "2026-08-17T10:01:00Z")],
+        fills_cursor="more",
+    )
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [r for r in _rows(db_path) if r["order_id"] == OID]
+    assert closes[0]["action"] == "close"
+    assert closes[0]["count"] == 100
+    assert len(_errors(db_path, "close_repair_manual")) >= 1
+
+
+def test_append_while_still_resting(monkeypatch, tmp_path) -> None:
+    """Partial fills on a LIVE resting order append immediately —
+    only shrink/annul waits for the order to go terminal."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, close_count=None)
+    _wire(
+        monkeypatch, db_path, resting=[_resting_order(remaining=60)],
+        fills=[_fill(40, 0.9, "2026-08-17T10:01:00Z")],
+    )
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    closes = [
+        r for r in _rows(db_path)
+        if r["order_id"] == OID and r["action"] == "close"
+    ]
+    assert len(closes) == 1
+    assert closes[0]["count"] == 40
+    assert closes[0]["price"] == 0.9

--- a/tests/unit/test_cli_reconcile_order_repair.py
+++ b/tests/unit/test_cli_reconcile_order_repair.py
@@ -98,9 +98,12 @@ def _seed(
 
 def _wire(
     monkeypatch: pytest.MonkeyPatch, db_path: Path, *,
-    resting: list[Order] = [], fills: list[Fill] = [],
+    resting: list[Order] | None = None,
+    fills: list[Fill] | None = None,
     fills_error: bool = False, fills_cursor: str | None = None,
 ) -> None:
+    resting = resting or []
+    fills = fills or []
     cfg = MagicMock()
     cfg.db_path = db_path
     cfg.is_championship = True


### PR DESCRIPTION
Closes #698.

## Premise update (Plan-agent finding)
The issue predates #744's log-on-fill: `gimmes order` no longer logs a full close row for a resting sell — only the placement-time fill. So the live championship gap is bidirectional:
- **Overstatement** (the issue's original case, now legacy/crash-window): rows for canceled/never-filled orders describe an exit that never traded; the #663 clamp warns but the fabricated price stands in P&L.
- **Understatement** (the new, live case): fills landing after placement are never logged — the between-cycle sweep is paper-only, and championship has no local expiry reconciliation.

## Fix
`_repair_championship_close_rows` runs in reconcile's championship branch BEFORE settlement consumption, converging per `order_id` to: ledger close-row sum == Kalshi fills sum (`list_fills(order_id=…)` is quantity truth; order status only gates annul-eligibility).

- Zero filled, terminal → annul all rows (#690 semantics: `action='skip'`, `reason='order_canceled'`, append-only ledger); partial → shrink the newest row (equal-count rows annul instead of zeroing).
- Ledger short → append a delta close row at the fill-weighted price (newest-first attribution), entry analytics inherited (#656 pattern), same `order_id` so reruns converge to a no-op.
- Guards: settlement-closed ticker/side never touched; still-resting orders never annulled/shrunk (appends allowed — pinned); truncated fills/orders reads audit `close_repair_manual` and skip rather than repairing on a floor; append candidates outrank converged veterans under the 20-order fills-call cap; whole pass best-effort (reconcile never blocked, #663 contract).
- Audit: WARNING/DATA_INTEGRITY rows (`close_row_repaired`, `close_repair_settlement_owns`, `close_repair_manual`) for Groundskeeper.

## Tests
10 in `test_cli_reconcile_order_repair.py` (real DB, API mocked at module seams): annul, shrink, append with weighted price, still-resting never annulled, live-order append, settlement guard, idempotent rerun, fills failure degrades, truncated-fills never repairs, paper mode never calls the pass.

## Review
Two full adversarial passes. First pass found three completeness defects (silent fills truncation → wrongful shrink of genuine history; truncated resting read defeating the never-annul guard; cap starvation of append candidates) — all fixed. Re-verification found one more: `cursor is None` vs Kalshi's `""` last-page cursor would have silently disabled shrink/annul on every production run — fixed to truthiness (matching every other pagination consumer) with the mock returning `""` to pin it. Final verdict APPROVE. Frozen full-suite gate: **2554 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r