### PR TITLE
Reconcile backfills empty settlement-rules snapshots (#647)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -3664,6 +3664,57 @@ async def _sweep_resting_paper_orders(broker, client, db, *, config, quiet: bool
     return filled
 
 
+_RULES_BACKFILL_MAX = 10
+
+
+async def _backfill_rules_snapshots(client, db) -> None:  # type: ignore[no-untyped-def]
+    """#647: backfill positions.rules_primary where empty.
+
+    The snapshot is written on the BUY path, which misses resting
+    orders that fill later, pre-v17 positions, and rows recreated by
+    the sync DELETE — the semantics guard silently passes all of
+    them. Reconcile has a live client in both modes; best-effort,
+    capped per run.
+    """
+    import logging
+
+    from gimmes.kalshi.markets import get_market
+    from gimmes.store.queries import (
+        get_tickers_missing_rules,
+        set_position_rules_snapshot,
+    )
+
+    _log = logging.getLogger(__name__)
+    tickers = await get_tickers_missing_rules(db)
+    if not tickers:
+        return
+    if len(tickers) > _RULES_BACKFILL_MAX:
+        _log.warning(
+            "#647 rules backfill: %d positions missing snapshots,"
+            " capping at %d this run",
+            len(tickers), _RULES_BACKFILL_MAX,
+        )
+    filled = 0
+    for ticker in tickers[:_RULES_BACKFILL_MAX]:
+        try:
+            market = await get_market(client, ticker)
+        except Exception:
+            _log.warning(
+                "#647 rules backfill: market fetch failed for %s",
+                ticker, exc_info=True,
+            )
+            continue
+        if market.rules_primary and await set_position_rules_snapshot(
+            db, ticker=ticker, rules_primary=market.rules_primary,
+        ):
+            filled += 1
+    if filled:
+        console.print(
+            f"[dim]Backfilled settlement-rules snapshots for"
+            f" {filled} position(s) (#647)[/dim]"
+        )
+
+
 _REPAIR_MAX_ORDERS = 20
 _REPAIR_MAX_PAGES = 3
 
@@ -3925,6 +3976,17 @@ def reconcile() -> None:
                 )
 
             await sync_positions(db, fresh)
+
+            # #647: best-effort — reconcile is never blocked.
+            try:
+                await _backfill_rules_snapshots(client, db)
+            except Exception:
+                import logging as _logging
+
+                _logging.getLogger(__name__).error(
+                    "#647 rules backfill failed; continuing"
+                    " reconcile", exc_info=True,
+                )
 
             fresh_tickers = {p.ticker: p for p in fresh}
 

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -792,7 +792,8 @@ async def get_tickers_missing_rules(db: Database) -> list[str]:
     pass."""
     cursor = await db.conn.execute(
         """SELECT ticker FROM positions
-           WHERE rules_primary IS NULL OR rules_primary = ''
+           WHERE (rules_primary IS NULL OR rules_primary = '')
+             AND count > 0
            ORDER BY ticker"""
     )
     rows = await cursor.fetchall()

--- a/src/gimmes/store/queries.py
+++ b/src/gimmes/store/queries.py
@@ -785,6 +785,20 @@ async def _check_position_staleness(db: Database, table: str) -> None:
             )
 
 
+async def get_tickers_missing_rules(db: Database) -> list[str]:
+    """Open positions with no settlement-language snapshot (#647):
+    resting fills, pre-v17 rows, and sync DELETE/re-add all leave
+    rules_primary empty, degrading the semantics guard to silent
+    pass."""
+    cursor = await db.conn.execute(
+        """SELECT ticker FROM positions
+           WHERE rules_primary IS NULL OR rules_primary = ''
+           ORDER BY ticker"""
+    )
+    rows = await cursor.fetchall()
+    return [r["ticker"] for r in rows]
+
+
 async def get_positions(db: Database) -> list[Position]:
     """Get all stored positions.
 

--- a/tests/unit/test_cli_reconcile_rules_backfill.py
+++ b/tests/unit/test_cli_reconcile_rules_backfill.py
@@ -162,6 +162,9 @@ def test_zero_count_rows_skipped(monkeypatch, tmp_path) -> None:
     review): the snapshot only matters for open positions."""
     db_path = tmp_path / "g.db"
     positions = _seed(db_path, ["KX-A"])
+    # The broker must ALSO report count=0 — sync_positions runs
+    # before the backfill and would otherwise restore the count.
+    positions = [p.model_copy(update={"count": 0}) for p in positions]
     conn = sqlite3.connect(db_path)
     conn.execute("UPDATE positions SET count = 0 WHERE ticker = 'KX-A'")
     conn.commit()

--- a/tests/unit/test_cli_reconcile_rules_backfill.py
+++ b/tests/unit/test_cli_reconcile_rules_backfill.py
@@ -1,0 +1,157 @@
+"""#647: reconcile backfills empty positions.rules_primary snapshots.
+
+The snapshot is written on the BUY path — resting fills, pre-v17
+positions, and sync-recreated rows all leave it empty, and the
+semantics guard silently passes them. Reconcile has a live client
+in both modes; the backfill is best-effort and capped per run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from gimmes import cli as cli_module
+from gimmes.cli import app
+from gimmes.kalshi import markets as markets_module
+from gimmes.models.portfolio import Position
+from gimmes.store.database import Database
+from gimmes.store.queries import upsert_position
+
+runner = CliRunner()
+
+RULES = "Resolves YES if the value exceeds 0.5 [preliminary]."
+
+
+def _seed(db_path: Path, tickers: list[str]) -> list[Position]:
+    positions = [
+        Position(
+            ticker=t, title=t, side="no", count=10, avg_price=0.5,
+            market_price=0.5, cost_basis=5.0, market_value=5.0,
+            unrealized_pnl=0.0, realized_pnl=0.0,
+        )
+        for t in tickers
+    ]
+
+    async def _s() -> None:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            for p in positions:
+                await upsert_position(db, p)
+        finally:
+            await db.close()
+
+    asyncio.run(_s())
+    return positions
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch, db_path: Path,
+    positions: list[Position], *, fetch_error: bool = False,
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.db_path = db_path
+    monkeypatch.setattr(cli_module, "load_config", lambda: cfg)
+
+    @asynccontextmanager
+    async def _ctx(_config):  # type: ignore[no-untyped-def]
+        db = Database(db_path)
+        await db.connect()
+        try:
+            broker = MagicMock()
+
+            async def _pos():
+                return positions
+
+            broker.get_positions = _pos
+            yield MagicMock(), broker, db
+        finally:
+            await db.close()
+
+    monkeypatch.setattr(cli_module, "trading_context", _ctx)
+
+    async def _sweep(*a, **kw):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(
+        cli_module, "_sweep_resting_paper_orders", _sweep,
+    )
+
+    fetches = MagicMock()
+
+    async def _get_market(_client, ticker):  # type: ignore[no-untyped-def]
+        fetches(ticker)
+        if fetch_error:
+            raise RuntimeError("api down")
+        m = MagicMock()
+        m.rules_primary = RULES
+        return m
+
+    monkeypatch.setattr(markets_module, "get_market", _get_market)
+    return fetches
+
+
+def _rules(db_path: Path) -> dict[str, str | None]:
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT ticker, rules_primary FROM positions"
+    ).fetchall()
+    conn.close()
+    return dict(rows)
+
+
+def test_empty_snapshot_backfilled(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    positions = _seed(db_path, ["KX-A", "KX-B"])
+    _wire(monkeypatch, db_path, positions)
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert _rules(db_path) == {"KX-A": RULES, "KX-B": RULES}
+    assert "Backfilled settlement-rules snapshots for 2" in (
+        result.output
+    )
+
+
+def test_existing_snapshot_not_refetched(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    positions = _seed(db_path, ["KX-A"])
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "UPDATE positions SET rules_primary = 'original'"
+        " WHERE ticker = 'KX-A'"
+    )
+    conn.commit()
+    conn.close()
+    fetches = _wire(monkeypatch, db_path, positions)
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert _rules(db_path)["KX-A"] == "original"
+    fetches.assert_not_called()
+
+
+def test_fetch_failure_degrades(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    positions = _seed(db_path, ["KX-A"])
+    _wire(monkeypatch, db_path, positions, fetch_error=True)
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert _rules(db_path)["KX-A"] in (None, "")
+
+
+def test_backfill_capped_per_run(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "g.db"
+    tickers = [f"KX-{i:02d}" for i in range(12)]
+    positions = _seed(db_path, tickers)
+    fetches = _wire(monkeypatch, db_path, positions)
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    assert fetches.call_count == 10
+    filled = [t for t, r in _rules(db_path).items() if r == RULES]
+    assert len(filled) == 10

--- a/tests/unit/test_cli_reconcile_rules_backfill.py
+++ b/tests/unit/test_cli_reconcile_rules_backfill.py
@@ -155,3 +155,18 @@ def test_backfill_capped_per_run(monkeypatch, tmp_path) -> None:
     assert fetches.call_count == 10
     filled = [t for t, r in _rules(db_path).items() if r == RULES]
     assert len(filled) == 10
+
+
+def test_zero_count_rows_skipped(monkeypatch, tmp_path) -> None:
+    """A count=0 stub row must not spend the fetch cap (#647
+    review): the snapshot only matters for open positions."""
+    db_path = tmp_path / "g.db"
+    positions = _seed(db_path, ["KX-A"])
+    conn = sqlite3.connect(db_path)
+    conn.execute("UPDATE positions SET count = 0 WHERE ticker = 'KX-A'")
+    conn.commit()
+    conn.close()
+    fetches = _wire(monkeypatch, db_path, positions)
+    result = runner.invoke(app, ["reconcile"])
+    assert result.exit_code == 0, result.output
+    fetches.assert_not_called()


### PR DESCRIPTION
Closes #647.

## Gap
`positions.rules_primary` (the settlement-language snapshot the #643 semantics guard reads) is written only on the BUY order path. Resting orders that fill later, positions opened before migration v17, and rows recreated by the sync DELETE all leave it empty — the guard degrades to silent pass for exactly those positions.

## Fix
`_backfill_rules_snapshots` runs in reconcile after `sync_positions`, in BOTH modes (the client is live in both): fetch the market for each open position with an empty snapshot and set it via the existing UPDATE-only `set_position_rules_snapshot`. Capped at 10 fetches/run (warned when more are pending — the queue self-drains next runs), per-ticker failures degrade with a warning, whole pass best-effort (reconcile never blocked).

Ordering verified: the sync upsert's column list never touches `rules_primary`, so a backfilled snapshot sticks permanently — no per-run treadmill; and after-sync is required because the sync DELETE/re-add path recreates rows the UPDATE needs to exist.

## Tests
4 in `test_cli_reconcile_rules_backfill.py`: backfill lands for empty snapshots, existing snapshots are never refetched (zero API calls), fetch failure degrades, cap enforced (10 of 12).

## Review
Correctness review APPROVE (upsert column-list check, cap-starvation severity assessed as self-draining, helper semantics, call-site placement outside both mode branches). Frozen full-suite gate: **2558 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r