### PR TITLE
Semantics-guard coverage telemetry on inconclusive parses (#646)

### DIFF
--- a/src/gimmes/cli.py
+++ b/src/gimmes/cli.py
@@ -5602,6 +5602,41 @@ def position_note(
                 rules_primary = await get_position_rules_snapshot(
                     db, resolved_ticker,
                 )
+                # #646: the guard deliberately goes silent on an
+                # inconclusive parse — never reject on parser
+                # uncertainty — but a threshold-style ticker with an
+                # unparseable snapshot is zero enforcement AND zero
+                # visibility. Log the rules text so the comparator
+                # library grows from observed misses.
+                import json as _json
+
+                from gimmes.models.error import (
+                    ErrorCategory,
+                    ErrorLogEntry,
+                    ErrorSeverity,
+                )
+                from gimmes.store.observation_validator import (
+                    threshold_parse_inconclusive,
+                )
+                if threshold_parse_inconclusive(
+                    resolved_ticker, rules_primary,
+                ):
+                    await _log_cli_error(db, ErrorLogEntry(
+                        severity=ErrorSeverity.INFO,
+                        category=ErrorCategory.DATA_INTEGRITY,
+                        error_code="semantics_parse_inconclusive",
+                        component="cli.position-note",
+                        message=(
+                            f"Threshold-style ticker"
+                            f" {resolved_ticker}: settlement rules"
+                            f" did not parse — semantics guard"
+                            f" inactive (#646)"
+                        ),
+                        context=_json.dumps({
+                            "ticker": resolved_ticker,
+                            "rules_primary": (rules_primary or "")[:500],
+                        }),
+                    ))
                 ok, errors, warnings = validate_observation(
                     ticker=resolved_ticker,
                     observation_body=body_val,

--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -356,6 +356,27 @@ def _parse_claim(clause: str) -> tuple[str, float] | None:
     return (direction, threshold)
 
 
+# #646: a ticker whose final segment is a threshold strike
+# (-T<number>, signs and decimals included) is exactly the shape the
+# semantics guard exists for — a parse miss there is a coverage gap,
+# not a non-threshold market.
+_THRESHOLD_TICKER_RE = re.compile(r"-T-?\d+(?:\.\d+)?$")
+
+
+def threshold_parse_inconclusive(
+    ticker: str, rules_primary: str | None,
+) -> bool:
+    """#646: True when the semantics guard is silently blind — the
+    ticker looks threshold-style but a NON-EMPTY settlement snapshot
+    failed to parse. Empty snapshots are the #647 backfill's job, and
+    a parse SUCCESS means the guard is active; both return False."""
+    if not rules_primary:
+        return False
+    if not _THRESHOLD_TICKER_RE.search(ticker):
+        return False
+    return parse_rules_threshold(rules_primary) is None
+
+
 _SEMANTICS_LINE_RE = re.compile(r"(?im)^Semantics:\s*(?P<rest>.+)$")
 _YES_CLAUSE_RE = re.compile(r"YES\s+wins\s+(?:when|if)\s+(?P<c>.*?)(?:;|$)", re.I)
 _NO_CLAUSE_RE = re.compile(r"NO\s+wins\s+(?:when|if)\s+(?P<c>.*)$", re.I)

--- a/tests/unit/test_cli_observation_validator.py
+++ b/tests/unit/test_cli_observation_validator.py
@@ -671,3 +671,75 @@ def test_forged_anchor_rejected_end_to_end(
     ])
     assert result.exit_code == 1
     assert "not yours to refresh" in result.output
+
+
+def test_inconclusive_parse_writes_info_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#646: a threshold-style ticker with an unparseable snapshot
+    writes the semantics_parse_inconclusive INFO row (with the rules
+    text) and the note still lands — telemetry, never a reject."""
+    import sqlite3 as _sqlite3
+
+    ticker = "KXCPI-26JUN-T0.2"
+    db_path = tmp_path / "test.db"
+    _seed_decision(db_path, ticker, CM_DECISION_SILENT_ON_SOURCES)
+    _seed_position_with_rules(
+        db_path, ticker,
+        "Settles per the committee's published judgment.",
+    )
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", ticker,
+        "--cycle", "1701",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", _obs_with_semantics("Price: steady."),
+    ])
+    assert result.exit_code == 0, result.output
+
+    conn = _sqlite3.connect(db_path)
+    conn.row_factory = _sqlite3.Row
+    rows = conn.execute(
+        "SELECT severity, context FROM error_log"
+        " WHERE error_code = 'semantics_parse_inconclusive'"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0]["severity"] == "info"
+    assert "committee" in rows[0]["context"]
+
+
+def test_conclusive_parse_writes_no_info_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "test.db"
+    ticker = "KXCPI-26JUN-T-0.1"
+    _seed_decision(db_path, ticker, CM_DECISION_SILENT_ON_SOURCES)
+    _seed_position_with_rules(db_path, ticker, INCIDENT_RULES)
+    _patch_config(monkeypatch, db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "position-note", ticker,
+        "--cycle", "1701",
+        "--agent", "monitor",
+        "--type", "observation",
+        "--body", _obs_with_semantics(
+            "Semantics: YES wins when CPI MoM > -0.1;"
+            " NO wins when CPI MoM <= -0.1"
+        ),
+    ])
+    assert result.exit_code == 0, result.output
+
+    import sqlite3 as _sqlite3
+
+    conn = _sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT 1 FROM error_log"
+        " WHERE error_code = 'semantics_parse_inconclusive'"
+    ).fetchall()
+    conn.close()
+    assert rows == []

--- a/tests/unit/test_observation_validator.py
+++ b/tests/unit/test_observation_validator.py
@@ -481,3 +481,57 @@ class TestSyncWith643Rules:
             rules_primary=rules,
         )
         assert errors == [] and warnings == []
+
+
+class TestThresholdParseInconclusive:
+    """#646: coverage telemetry for the semantics guard's silent
+    blind spot — threshold-style ticker, non-empty snapshot, parse
+    miss."""
+
+    def test_unparseable_rules_on_threshold_ticker(self) -> None:
+        from gimmes.store.observation_validator import (
+            threshold_parse_inconclusive,
+        )
+
+        assert threshold_parse_inconclusive(
+            "KXCPI-26APR-T0.5", "Settles per the committee's judgment.",
+        )
+
+    def test_parseable_rules_are_conclusive(self) -> None:
+        from gimmes.store.observation_validator import (
+            parse_rules_threshold,
+            threshold_parse_inconclusive,
+        )
+
+        rules = "Resolves YES if the value is above 0.5 percent."
+        assert parse_rules_threshold(rules) is not None
+        assert not threshold_parse_inconclusive(
+            "KXCPI-26APR-T0.5", rules,
+        )
+
+    def test_empty_snapshot_is_not_inconclusive(self) -> None:
+        """Empty snapshots are the #647 backfill's job."""
+        from gimmes.store.observation_validator import (
+            threshold_parse_inconclusive,
+        )
+
+        assert not threshold_parse_inconclusive("KXCPI-26APR-T0.5", "")
+        assert not threshold_parse_inconclusive("KXCPI-26APR-T0.5", None)
+
+    def test_non_threshold_ticker_ignored(self) -> None:
+        from gimmes.store.observation_validator import (
+            threshold_parse_inconclusive,
+        )
+
+        assert not threshold_parse_inconclusive(
+            "KXINX-26APR", "Settles per the committee's judgment.",
+        )
+
+    def test_negative_and_decimal_strikes_match(self) -> None:
+        from gimmes.store.observation_validator import (
+            threshold_parse_inconclusive,
+        )
+
+        for t in ("KXCPI-26JUN-T-0.1", "KXU3-26JUN-T4.3",
+                  "KXPAYROLLS-26MAY-T80000"):
+            assert threshold_parse_inconclusive(t, "opaque wording")


### PR DESCRIPTION
Closes #646.

## Blind spot
The #643 semantics guard deliberately goes silent when `parse_rules_threshold` returns None (never reject on parser uncertainty) — but a threshold-style ticker (`-T<strike>` suffix) with a non-empty, unparseable settlement snapshot gets zero enforcement AND zero visibility.

## Fix
- Pure helper `threshold_parse_inconclusive(ticker, rules_primary)`: fires only when the ticker's final segment is a `-T` strike (signs/decimals/integers — verified against every strike shape in the repo), the snapshot is NON-empty (empty is #647's backfill job), and the parse misses.
- `position-note` writes an INFO / DATA_INTEGRITY `semantics_parse_inconclusive` row carrying the rules text (truncated 500 chars) — so the comparator library can grow from observed misses before any warn→reject tightening.
- Telemetry only: validation outcomes unchanged; the row is written inside exactly the gate the validator itself runs under (observation type, not --force), so telemetry scope == guard scope. Groundskeeper suppresses info severity by design — no alert noise; the rows are for mining.

## Tests
Unit class (match/parse-success/empty/None/non-threshold/negative-and-integer strikes) + 2 end-to-end CLI tests (row written with rules text and note still lands; no row on a conclusive parse).

## Review
Correctness review APPROVE — regex checked against all repo ticker shapes (including KXBTCD's -T63599.99 and B-bracket non-matches), CLI gate placement matches the validator's own gate, INFO handling confirmed suppressed in groundskeeper.md. Frozen full-suite gate: **2566 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r