### PR TITLE
Footer on a non-playbook ticker warns (#648)

### DIFF
--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -639,6 +639,18 @@ def validate_playbook_footer(
     errors: list[str] = []
     warnings: list[str] = []
     if not ticker_in_economic_category(ticker):
+        # #648 item 2: monitor.md's Footer-omission rule says
+        # non-playbook tickers OMIT the footer entirely — a footer
+        # here means the agent misclassified the ticker (or copied a
+        # template), which pollutes the audit trail. Warn, never
+        # block: the note itself is fine.
+        if parse_playbook_footer(observation_body) is not None:
+            warnings.append(
+                f"Playbook footer present on NON-playbook ticker"
+                f" {ticker} (#648) — monitor.md's Footer-omission"
+                f" rule says equity-index and other non-economic"
+                f" tickers omit the footer entirely; drop it."
+            )
         return (errors, warnings)
 
     footer = parse_playbook_footer(observation_body)

--- a/src/gimmes/store/observation_validator.py
+++ b/src/gimmes/store/observation_validator.py
@@ -644,7 +644,7 @@ def validate_playbook_footer(
         # here means the agent misclassified the ticker (or copied a
         # template), which pollutes the audit trail. Warn, never
         # block: the note itself is fine.
-        if parse_playbook_footer(observation_body) is not None:
+        if _FOOTER_HEADER_RE.search(observation_body or ""):
             warnings.append(
                 f"Playbook footer present on NON-playbook ticker"
                 f" {ticker} (#648) — monitor.md's Footer-omission"

--- a/tests/unit/test_observation_validator.py
+++ b/tests/unit/test_observation_validator.py
@@ -535,3 +535,38 @@ class TestThresholdParseInconclusive:
         for t in ("KXCPI-26JUN-T-0.1", "KXU3-26JUN-T4.3",
                   "KXPAYROLLS-26MAY-T80000"):
             assert threshold_parse_inconclusive(t, "opaque wording")
+
+
+class TestFooterOnNonPlaybookTicker:
+    """#648 item 2: a footer on a non-playbook ticker violates the
+    Footer-omission rule — warn, never block."""
+
+    def test_footer_on_equity_ticker_warns(self) -> None:
+        from gimmes.store.observation_validator import (
+            PLAYBOOK_SOURCES,
+            validate_playbook_footer,
+        )
+
+        body = "Delta: none.\n\nPlaybook sources checked this cycle (#615):\n" + "\n".join(
+            f"- {s}: no result this cycle" for s in PLAYBOOK_SOURCES
+        )
+        errors, warnings = validate_playbook_footer(
+            ticker="KXINX-26APR-T5000",
+            observation_body=body,
+            prior_observation_body=None,
+        )
+        assert errors == []
+        assert len(warnings) == 1
+        assert "NON-playbook ticker" in warnings[0]
+
+    def test_no_footer_on_equity_ticker_silent(self) -> None:
+        from gimmes.store.observation_validator import (
+            validate_playbook_footer,
+        )
+
+        errors, warnings = validate_playbook_footer(
+            ticker="KXINX-26APR-T5000",
+            observation_body="Delta: none.",
+            prior_observation_body=None,
+        )
+        assert (errors, warnings) == ([], [])


### PR DESCRIPTION
Closes #648.

The issue deferred three strictness escalations from #643, each gated on observed evidence:

- **Item 1 (SUPERSEDED→no-result escalate to reject)**: NOT escalated. A 300-observation live-journal scan found **zero** SUPERSEDED→no-result transitions — the warn has been sufficient deterrent; escalation stays evidence-gated.
- **Item 2 (footer on non-playbook tickers)**: implemented. monitor.md's Footer-omission rule (line 184: non-playbook tickers OMIT the footer block entirely) was unvalidated — `validate_playbook_footer` now warns (never blocks) when a footer header appears on a non-economic ticker; the note itself still lands. Zero occurrences observed live, so this is cheap defense-in-depth against template-copying.
- **Item 3 (unknown sources escalate to reject)**: NOT escalated. The same scan found **zero** invented sources (an initial false alarm — Deutsche Bank/Reuters/Bloomberg — turned out to be real playbook members my scan set omitted).

## Tests
`TestFooterOnNonPlaybookTicker`: footer on KXINX warns exactly once with no errors; no footer stays fully silent.

## Review
Correctness review APPROVE — the footer header regex is line-anchored (prose mentions can't false-positive), the warn path is print-only end to end, and the cited monitor.md rule exists verbatim. Frozen full-suite gate: **2568 passed**.

https://claude.ai/code/session_01AhhAZzu5Cq13ob8LFXLX5r